### PR TITLE
Introduce IModuleActivator to support dependency injection via an external container

### DIFF
--- a/src/Nancy.Hosting.Wcf/NancyWcfGenericService.cs
+++ b/src/Nancy.Hosting.Wcf/NancyWcfGenericService.cs
@@ -19,7 +19,7 @@
         /// </summary>
         public NancyWcfGenericService()
         {
-            engine = new NancyEngine(new AppDomainModuleLocator(), new RouteResolver());
+            engine = new NancyEngine(new AppDomainModuleLocator(new DefaultModuleActivator()), new RouteResolver());
         }
 
         [WebInvoke(UriTemplate = "*")]

--- a/src/Nancy.Tests/Nancy.Tests.csproj
+++ b/src/Nancy.Tests/Nancy.Tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Specifications\Handling a POST request.cs" />
     <Compile Include="Specifications\Handling a PUT request.cs" />
     <Compile Include="Specifications\RequestSpec.cs" />
+    <Compile Include="Unit\DefaultModuleActivatorFixture.cs" />
     <Compile Include="Unit\HeadResponseFixture.cs" />
     <Compile Include="Unit\Hosting\HancyHandlerFixture.cs" />
     <Compile Include="Unit\NancyEngineFixture.cs" />

--- a/src/Nancy.Tests/Specifications/RequestSpec.cs
+++ b/src/Nancy.Tests/Specifications/RequestSpec.cs
@@ -12,7 +12,7 @@
 
         protected RequestSpec()
         {
-            engine = new NancyEngine(new AppDomainModuleLocator(), new RouteResolver());
+            engine = new NancyEngine(new AppDomainModuleLocator(new DefaultModuleActivator()), new RouteResolver());
         }
 
         protected static IRequest ManufactureGETRequestForRoute(string route)

--- a/src/Nancy.Tests/Unit/DefaultModuleActivatorFixture.cs
+++ b/src/Nancy.Tests/Unit/DefaultModuleActivatorFixture.cs
@@ -1,0 +1,63 @@
+namespace Nancy.Tests.Unit
+{
+    using System;
+    using Xunit;
+
+    public class DefaultModuleActivatorFixture
+    {
+        DefaultModuleActivator activator;
+
+        public DefaultModuleActivatorFixture()
+        {
+            this.activator = new DefaultModuleActivator();
+        }
+
+        [Fact]
+        public void CanCreateInstance_should_return_true_for_module()
+        {
+            activator.CanCreateInstance(typeof(TestModule)).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void CanCreateInstance_should_return_false_for_incorrect_baseclass()
+        {
+            activator.CanCreateInstance(typeof(TestModuleWithoutBaseclass)).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void CanCreateInstance_should_return_false_when_no_default_constructor()
+        {
+            activator.CanCreateInstance(typeof(TestModuleWrongCtor)).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void CreateInstance_creates_instance()
+        {
+            var instance = activator.CreateInstance(typeof(TestModule)) as TestModule;
+            instance.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void CreateInstance_throws_for_incorrect_base_class()
+        {
+            typeof(InvalidOperationException).ShouldBeThrownBy(() => activator.CreateInstance(typeof(TestModuleWithoutBaseclass)));
+        }
+
+        private class TestModule : NancyModule
+        {
+            
+        }
+
+        private class TestModuleWithoutBaseclass
+        {
+            
+        }
+
+        private class TestModuleWrongCtor : NancyModule
+        {
+            public TestModuleWrongCtor(int x)
+            {
+            }
+        }
+    }
+}

--- a/src/Nancy/DefaultModuleActivator.cs
+++ b/src/Nancy/DefaultModuleActivator.cs
@@ -1,0 +1,28 @@
+namespace Nancy
+{
+    using System;
+
+    public class DefaultModuleActivator : IModuleActivator
+    {
+        public virtual NancyModule CreateInstance(Type moduleType)
+        {
+            if(! CanCreateInstance(moduleType))
+            {
+                throw new InvalidOperationException("Cannot create an instance of type {0} as it does not inherit from NancyModule or it does not have a public parameterless constructor.");
+            }
+
+            return (NancyModule) Activator.CreateInstance(moduleType);
+        }
+
+        public virtual bool CanCreateInstance(Type moduleType)
+        {
+            bool hasDefaultConstructor = moduleType.GetConstructor(Type.EmptyTypes) != null;
+            return IsModuleType(moduleType) && hasDefaultConstructor;
+        }
+
+        protected bool IsModuleType(Type type)
+        {
+            return type.IsSubclassOf(typeof(NancyModule));
+        }
+    }
+}

--- a/src/Nancy/Hosting/NancyHttpRequestHandler.cs
+++ b/src/Nancy/Hosting/NancyHttpRequestHandler.cs
@@ -13,12 +13,17 @@ namespace Nancy.Hosting
         public void ProcessRequest(HttpContext context)
         {
             var engine = new NancyEngine(
-                new AppDomainModuleLocator(),
+                CreateModuleLocator(),
                 new RouteResolver());
 
             var wrappedContext = new HttpContextWrapper(context);
             var handler = new NancyHandler(engine);
             handler.ProcessRequest(wrappedContext);
+        }
+
+        protected virtual INancyModuleLocator CreateModuleLocator()
+        {
+            return new AppDomainModuleLocator(new DefaultModuleActivator());
         }
     }
 }

--- a/src/Nancy/IModuleActivator.cs
+++ b/src/Nancy/IModuleActivator.cs
@@ -1,0 +1,24 @@
+namespace Nancy
+{
+    using System;
+
+    /// <summary>
+    /// Used to create an instance of a module.
+    /// </summary>
+    public interface IModuleActivator
+    {
+        /// <summary>
+        /// Creates an instance of the module with the specified type.
+        /// </summary>
+        /// <param name="moduleType">The type of the module to activate</param>
+        /// <returns>The instantiated module</returns>
+        NancyModule CreateInstance(Type moduleType);
+
+        /// <summary>
+        /// Checks whether the activator can create an instance of the specified type. 
+        /// </summary>
+        /// <param name="moduleType">The type of the module to check</param>
+        /// <returns>True if this activator can create an instance of the specified module type, otherwise false.</returns>
+        bool CanCreateInstance(Type moduleType);
+    }
+}

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -42,6 +42,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="AppDomainModuleLocator.cs" />
+    <Compile Include="DefaultModuleActivator.cs" />
     <Compile Include="Extensions\NancyExtensions.cs" />
     <Compile Include="Extensions\RouteDescriptionExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
@@ -49,6 +50,7 @@
     <Compile Include="Hosting\NancyHandler.cs" />
     <Compile Include="HeadResponse.cs" />
     <Compile Include="Hosting\NancyHttpRequestHandler.cs" />
+    <Compile Include="IModuleActivator.cs" />
     <Compile Include="IResponseFormatter.cs" />
     <Compile Include="IViewEngine.cs" />
     <Compile Include="NancyModule.cs" />


### PR DESCRIPTION
Extracted the instantiation logic from AppDomainModuleLocator to ModuleActivator. This could be swapped out with a different implementation that creates modules using a container. 

Also introduced a CreateModuleLocator virtual method in NancyHttpRequestHandler to easily allow a custom INancyModuleLocator to be used.
