### PR TITLE
Added /routes to demo to show a dynamic list of registered routes for the demo

### DIFF
--- a/src/Nancy.Demo/MainModule.cs
+++ b/src/Nancy.Demo/MainModule.cs
@@ -13,11 +13,16 @@ namespace Nancy.Demo
         public Module()
         {
             Get["/"] = x => {
-                return "This is the root. Visit /static, /razor, /nhaml or /ndjango or /spark!";
+                return "This is the root! Visit <a href='/routes'>/routes</a> to see all registered routes!";
             };
             
             Get["/test"] = x => {
                 return "Test";
+            };
+
+            Get["/routes"] = x => {
+                var routes = GetRoutes("GET");
+                return View.Razor("~/views/routes.cshtml", routes);
             };
 
             Get["/static"] = x => {
@@ -44,12 +49,12 @@ namespace Nancy.Demo
 			};
 
             Get["/json"] = x => {
-                var model = new RatPack { FirstName = "Frank" };
+                var model = new RatPack { FirstName = "Andy" };
                 return Response.AsJson(model);
             };
 
             Get["/xml"] = x => {
-                var model = new RatPack { FirstName = "Frank" };
+                var model = new RatPack { FirstName = "Andy" };
                 return Response.AsXml(model);
             };
         }

--- a/src/Nancy.Demo/Nancy.Demo.csproj
+++ b/src/Nancy.Demo/Nancy.Demo.csproj
@@ -98,6 +98,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="Views\routes.cshtml" />
     <None Include="Views\spark.spark" />
     <None Include="Views\ndjango.django" />
     <None Include="Views\nhaml.haml" />

--- a/src/Nancy.Demo/Views/routes.cshtml
+++ b/src/Nancy.Demo/Views/routes.cshtml
@@ -1,0 +1,17 @@
+﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <title>Routes</title>
+</head>
+<body>
+
+	<h1>Routes</h1>
+	<p>Below is a list of all of the currently registered routes in this application</p>
+	<ul>
+		@foreach (var route in @Model) {
+			<li><a href="@route.Key">@route.Key</a></li>
+		}
+	</ul>
+
+</body>
+</html>


### PR DESCRIPTION
As the list of sample routes increase (and I had a few minutes) I've added a /routes route to the demo with links so people trying out the demo can easily see all routes without us keeping the root up-to-date.

Hoping this will be useful.
