### PR TITLE
Added Protocol member to IRequest

### DIFF
--- a/src/Nancy.Hosting.Wcf/NancyWcfGenericService.cs
+++ b/src/Nancy.Hosting.Wcf/NancyWcfGenericService.cs
@@ -51,7 +51,8 @@
                 webRequest.Method,
                 string.Concat("/", relativeUri),
                 webRequest.Headers.ToDictionary(),
-                requestBody);
+                requestBody,
+                webRequest.UriTemplateMatch.BaseUri.Scheme);
         }
 
         private static void SetNancyResponseToOutgoingWebResponse(OutgoingWebResponseContext webResponse, Response nancyResponse)

--- a/src/Nancy.Tests/Specifications/RequestSpec.cs
+++ b/src/Nancy.Tests/Specifications/RequestSpec.cs
@@ -15,27 +15,27 @@ namespace Nancy.Tests.Specifications
 
         protected static IRequest ManufactureGETRequestForRoute(string route)
         {
-            return new Request("GET", route);
+            return new Request("GET", route, "http");
         }
 
         protected static IRequest ManufacturePOSTRequestForRoute(string route)
         {
-            return new Request("POST", route);
+            return new Request("POST", route, "http");
         }
 
         protected static IRequest ManufactureDELETERequestForRoute(string route)
         {
-            return new Request("DELETE", route);
+            return new Request("DELETE", route, "http");
         }
 
         protected static IRequest ManufacturePUTRequestForRoute(string route)
         {
-            return new Request("PUT", route);
+            return new Request("PUT", route, "http");
         }
 
         protected static IRequest ManufactureHEADRequestForRoute(string route)
         {
-            return new Request("HEAD", route);
+            return new Request("HEAD", route, "http");
         }
     }
 }

--- a/src/Nancy.Tests/Unit/NancyEngineFixture.cs
+++ b/src/Nancy.Tests/Unit/NancyEngineFixture.cs
@@ -64,7 +64,7 @@ namespace Nancy.Tests.Unit
         public void Should_retrieve_modules_from_locator_when_handling_request()
         {
             // Given
-            var request = new Request("GET", "/");
+            var request = new Request("GET", "/", "http");
 
             // When
             this.engine.HandleRequest(request);
@@ -77,7 +77,7 @@ namespace Nancy.Tests.Unit
         public void Should_return_not_found_response_when_no_nancy_modules_could_be_found()
         {
             // Given
-            var request = new Request("GET", "/");
+            var request = new Request("GET", "/", "http");
 
             A.CallTo(() => this.locator.GetModules()).Returns(new Dictionary<string, IEnumerable<ModuleMeta>>());
 
@@ -92,7 +92,7 @@ namespace Nancy.Tests.Unit
         public void Should_pass_all_registered_route_handlers_for_get_request_to_route_resolver()
         {
             // Given
-            var request = new Request("GET", "/");
+            var request = new Request("GET", "/", "http");
             
 
             A.CallTo(() => this.locator.GetModules()).Returns(modules);
@@ -118,7 +118,7 @@ namespace Nancy.Tests.Unit
         public void Should_ignore_case_of_request_verb_when_resolving_route_handlers(string verb)
         {
             // Given
-            var request = new Request(verb, "/");
+            var request = new Request(verb, "/", "http");
             
             A.CallTo(() => this.locator.GetModules()).Returns(this.modules);
 
@@ -134,7 +134,7 @@ namespace Nancy.Tests.Unit
         public void Should_treat_a_HEAD_request_like_a_GET_when_getting_a_request_to_route_resolver()
         {
             // Given
-            var request = new Request("HEAD", "/");
+            var request = new Request("HEAD", "/", "http");
 
 
             A.CallTo(() => this.locator.GetModules()).Returns(modules);
@@ -151,7 +151,7 @@ namespace Nancy.Tests.Unit
         public void Should_pass_all_registered_route_handlers_for_delete_request_to_route_resolver()
         {
             // Given
-            var request = new Request("DELETE", "/");
+            var request = new Request("DELETE", "/", "http");
             
             A.CallTo(() => this.locator.GetModules()).Returns(this.modules);
 
@@ -166,7 +166,7 @@ namespace Nancy.Tests.Unit
         public void Should_call_route_resolver_with_all_route_handlers()
         {
             // Given
-            var request = new Request("PUT", "/");
+            var request = new Request("PUT", "/", "http");
             
             A.CallTo(() => this.locator.GetModules()).Returns(this.modules);
 
@@ -181,7 +181,7 @@ namespace Nancy.Tests.Unit
         public void Should_call_route_resolver_with_request()
         {
             // Given
-            var request = new Request("GET", "/");
+            var request = new Request("GET", "/", "http");
 
             A.CallTo(() => this.locator.GetModules()).Returns(this.modules);
 
@@ -197,7 +197,7 @@ namespace Nancy.Tests.Unit
         public void Should_return_not_found_response_when_no_route_could_be_matched_for_the_request_verb()
         {
             // Given
-            var request = new Request("NOTVALID", "/");
+            var request = new Request("NOTVALID", "/", "http");
 
             A.CallTo(() => this.locator.GetModules()).Returns(this.modules);
 
@@ -224,7 +224,7 @@ namespace Nancy.Tests.Unit
         {
             // Given
             var route = A.Fake<IRoute>();
-            var request = new Request("GET", "/");            
+            var request = new Request("GET", "/", "http");            
 
             A.CallTo(() => this.locator.GetModules()).Returns(this.modules);
             A.CallTo(() => this.resolver.GetRoute(request, A<IEnumerable<ModuleMeta>>.Ignored.Argument, A<INancyApplication>.Ignored.Argument)).Returns(route);
@@ -242,7 +242,7 @@ namespace Nancy.Tests.Unit
             // Given
             var expectedResponse = new Response();
             var route = A.Fake<IRoute>();
-            var request = new Request("GET", "/");
+            var request = new Request("GET", "/", "http");
             var descriptions = GetRouteDescriptions(request, this.modules);
 
             A.CallTo(() => route.Invoke()).Returns(expectedResponse);
@@ -260,7 +260,7 @@ namespace Nancy.Tests.Unit
         public void Should_set_base_route_on_descriptions_that_are_passed_to_resolver()
         {
             // Given
-            var request = new Request("POST", "/fake/");
+            var request = new Request("POST", "/fake/", "http");
 
             var r = new FakeRouteResolver();
             var e = new NancyEngine(this.locator, r, this.application);
@@ -278,7 +278,7 @@ namespace Nancy.Tests.Unit
         public void Should_set_path_on_descriptions_that_are_passed_to_resolver()
         {
             // Given
-            var request = new Request("POST", "/");
+            var request = new Request("POST", "/", "http");
 
             var r = new FakeRouteResolver();
             var e = new NancyEngine(this.locator, r, this.application);

--- a/src/Nancy.Tests/Unit/RequestFixture.cs
+++ b/src/Nancy.Tests/Unit/RequestFixture.cs
@@ -11,8 +11,8 @@ namespace Nancy.Tests.Unit
         public void Should_throw_argumentnullexception_when_initialized_with_null_method()
         {
             // Given, When
-            var exception = 
-                Record.Exception(() => new Request(null, "/"));
+            var exception =
+                Record.Exception(() => new Request(null, "/", "http"));
 
             // Then
             exception.ShouldBeOfType<ArgumentNullException>();
@@ -23,7 +23,7 @@ namespace Nancy.Tests.Unit
         {
             // Given, When
             var exception =
-                Record.Exception(() => new Request(string.Empty, "/"));
+                Record.Exception(() => new Request(string.Empty, "/", "http"));
 
             // Then
             exception.ShouldBeOfType<ArgumentOutOfRangeException>();
@@ -34,7 +34,7 @@ namespace Nancy.Tests.Unit
         {
             // Given, When
             var exception =
-                Record.Exception(() => new Request("GET", null));
+                Record.Exception(() => new Request("GET", null, "http"));
 
             // Then
             exception.ShouldBeOfType<ArgumentNullException>();
@@ -45,7 +45,7 @@ namespace Nancy.Tests.Unit
         {
             // Given, When
             var exception =
-                Record.Exception(() => new Request("GET", string.Empty));
+                Record.Exception(() => new Request("GET", string.Empty, "http"));
 
             // Then
             exception.ShouldBeOfType<ArgumentOutOfRangeException>();
@@ -56,7 +56,7 @@ namespace Nancy.Tests.Unit
         {
             // Given, When
             var exception =
-                Record.Exception(() => new Request("GET", "/", null, new MemoryStream()));
+                Record.Exception(() => new Request("GET", "/", null, new MemoryStream(), "http"));
 
             // Then
             exception.ShouldBeOfType<ArgumentNullException>();
@@ -67,7 +67,7 @@ namespace Nancy.Tests.Unit
         {
             // Given, When
             var exception =
-                Record.Exception(() => new Request("GET", "/", new Dictionary<string, IEnumerable<string>>(), null));
+                Record.Exception(() => new Request("GET", "/", new Dictionary<string, IEnumerable<string>>(), null, "http"));
 
             // Then
             exception.ShouldBeOfType<ArgumentNullException>();
@@ -80,7 +80,7 @@ namespace Nancy.Tests.Unit
             const string method = "GET";
 
             // When
-            var request = new Request(method, "/");
+            var request = new Request(method, "/", "http");
 
             // Then
             request.Method.ShouldEqual(method);
@@ -93,7 +93,7 @@ namespace Nancy.Tests.Unit
             const string uri = "/";
             
             // When
-            var request = new Request("GET", uri);
+            var request = new Request("GET", uri, "http");
 
             // Then
             request.Uri.ShouldEqual(uri);
@@ -109,7 +109,7 @@ namespace Nancy.Tests.Unit
                 };
 
             // When
-            var request = new Request("GET", "/", headers, new MemoryStream());
+            var request = new Request("GET", "/", headers, new MemoryStream(), "http");
 
             // Then
             request.Headers.Keys.Contains("content-type").ShouldBeTrue();
@@ -122,7 +122,7 @@ namespace Nancy.Tests.Unit
             var body = new MemoryStream();
 
             // When
-            var request = new Request("GET", "/", new Dictionary<string, IEnumerable<string>>(), body);
+            var request = new Request("GET", "/", new Dictionary<string, IEnumerable<string>>(), body, "http");
 
             // Then
             request.Body.ShouldBeSameAs(body);
@@ -146,7 +146,7 @@ namespace Nancy.Tests.Unit
                 };
 
             // When
-            var request = new Request("POST", "/", headers, memory);
+            var request = new Request("POST", "/", headers, memory, "http");
 
             // Then
             ((string)request.Form.name).ShouldEqual("John Doe");
@@ -169,10 +169,45 @@ namespace Nancy.Tests.Unit
                 };
 
 			// When
-			var request = new Request("POST", "/", headers, memory);
+            var request = new Request("POST", "/", headers, memory, "http");
 			request.Form.ToString();
 			// Then
 			((string)request.Form.name).ShouldEqual("John Doe");
 		}
+
+        [Fact]
+        public void Should_throw_argumentnullexception_when_initialized_with_null_protocol()
+        {
+            // Given, When
+            var exception =
+                Record.Exception(() => new Request("GET", "/", null));
+
+            // Then
+            exception.ShouldBeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Should_throw_argumentoutofrangeexception_when_initialized_with_an_empty_protocol()
+        {
+            // Given, When
+            var exception =
+                Record.Exception(() => new Request("GET", "/", string.Empty));
+
+            // Then
+            exception.ShouldBeOfType<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void Should_set_protocol_parameter_value_to_protocol_property_when_initialized()
+        {
+            // Given
+            const string protocol = "http";
+
+            // When
+            var request = new Request("GET", "/", protocol);
+
+            // Then
+            request.Protocol.ShouldEqual(protocol);
+        }
     }
 }

--- a/src/Nancy.Tests/Unit/Routing/RouteResolverFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/RouteResolverFixture.cs
@@ -24,7 +24,7 @@
         public void Should_return_no_matching_route_found_route_when_no_match_could_be_found()
         {
             // Given
-            var request = new Request("GET", "/invalid", new Dictionary<string, IEnumerable<string>>(), new MemoryStream());
+            var request = new Request("GET", "/invalid", new Dictionary<string, IEnumerable<string>>(), new MemoryStream(), "http");
 
             var metas = new[] { new ModuleMeta(typeof(FakeNancyModuleWithBasePath), new FakeNancyModuleWithBasePath().GetRouteDescription("GET")) };
             
@@ -39,7 +39,7 @@
         public void Should_match_on_combination_of_module_base_path_and_action_path_when_module_defines_base_path()
         {
             // Given
-            var request = new Request("GET", "/fake/route/with/some/parts", new Dictionary<string, IEnumerable<string>>(), new MemoryStream());
+            var request = new Request("GET", "/fake/route/with/some/parts", new Dictionary<string, IEnumerable<string>>(), new MemoryStream(), "http");
 
             var metas = new[] { new ModuleMeta(typeof(FakeNancyModuleWithBasePath), new FakeNancyModuleWithBasePath().GetRouteDescription("GET")) };
 
@@ -56,7 +56,7 @@
         public void Should_be_case_insensitive_when_matching(string path)
         {
             // Given
-            var request = new Request("GET", path, new Dictionary<string, IEnumerable<string>>(), new MemoryStream());
+            var request = new Request("GET", path, new Dictionary<string, IEnumerable<string>>(), new MemoryStream(), "http");
 
             var metas = new[] { new ModuleMeta(typeof(FakeNancyModuleWithBasePath), new FakeNancyModuleWithBasePath().GetRouteDescription("GET")) };
 
@@ -71,7 +71,7 @@
         public void Should_not_match_on_combination_of_module_base_path_and_action_path_when_module_defines_base_path()
         {
             // Given
-            var request = new Request("GET", "/route/with/some/parts", new Dictionary<string, IEnumerable<string>>(), new MemoryStream());
+            var request = new Request("GET", "/route/with/some/parts", new Dictionary<string, IEnumerable<string>>(), new MemoryStream(), "http");
 
             var metas = new[] { new ModuleMeta(typeof(FakeNancyModuleWithBasePath), new FakeNancyModuleWithBasePath().GetRouteDescription("GET")) };
 
@@ -86,7 +86,7 @@
         public void Should_set_combination_of_module_base_path_and_action_path_on_no_matching_route_found_route_when_no_match_could_be_found()
         {
             // Given
-            var request = new Request("GET", "/fake/route/with/some/parts", new Dictionary<string, IEnumerable<string>>(), new MemoryStream());
+            var request = new Request("GET", "/fake/route/with/some/parts", new Dictionary<string, IEnumerable<string>>(), new MemoryStream(), "http");
             var metas = new[] { new ModuleMeta(typeof(FakeNancyModuleWithBasePath), new FakeNancyModuleWithBasePath().GetRouteDescription("GET")) };
 
             // When
@@ -100,7 +100,7 @@
         public void Should_set_action_on_route_when_match_was_found()
         {
             // Given
-            var request = new Request("GET", "/fake/route/with/some/parts", new Dictionary<string, IEnumerable<string>>(), new MemoryStream());
+            var request = new Request("GET", "/fake/route/with/some/parts", new Dictionary<string, IEnumerable<string>>(), new MemoryStream(), "http");
             var metas = new[] { new ModuleMeta(typeof(FakeNancyModuleWithBasePath), new FakeNancyModuleWithBasePath().GetRouteDescription("GET")) };
 
             // When
@@ -116,7 +116,7 @@
         public void Should_return_first_matched_route_when_conflicting_routs_are_available()
         {
             // Given
-            var request = new Request("GET", "/fake/should/have/conflicting/route/defined", new Dictionary<string, IEnumerable<string>>(), new MemoryStream());
+            var request = new Request("GET", "/fake/should/have/conflicting/route/defined", new Dictionary<string, IEnumerable<string>>(), new MemoryStream(), "http");
             var metas = new[] { new ModuleMeta(typeof(FakeNancyModuleWithBasePath), new FakeNancyModuleWithBasePath().GetRouteDescription("GET")) };
             var route = this.resolver.GetRoute(request, metas, new NancyApplication());
             var response = route.Invoke();
@@ -132,7 +132,7 @@
         public void Should_match_parameterized_action_path_with_request_path()
         {
             // Given
-            var request = new Request("GET", "/fake/child/route", new Dictionary<string, IEnumerable<string>>(), new MemoryStream());
+            var request = new Request("GET", "/fake/child/route", new Dictionary<string, IEnumerable<string>>(), new MemoryStream(), "http");
             var metas = new[] { new ModuleMeta(typeof(FakeNancyModuleWithBasePath), new FakeNancyModuleWithBasePath().GetRouteDescription("GET")) };
 
             // When
@@ -146,7 +146,7 @@
         public void Should_treat_action_route_parameters_as_greedy()
         {
             // Given
-            var request = new Request("GET", "/fake/foo/some/stuff/not/in/route/bar/more/stuff/not/in/route", new Dictionary<string, IEnumerable<string>>(), new MemoryStream());
+            var request = new Request("GET", "/fake/foo/some/stuff/not/in/route/bar/more/stuff/not/in/route", new Dictionary<string, IEnumerable<string>>(), new MemoryStream(), "http");
             var metas = new[] { new ModuleMeta(typeof(FakeNancyModuleWithBasePath), new FakeNancyModuleWithBasePath().GetRouteDescription("GET")) };
 
             // When
@@ -160,7 +160,7 @@
         public void Should_return_the_route_with_most_static_matches_when_multiple_matches_are_found()
         {
             // Given
-            var request = new Request("GET", "/fake/child/route/foo", new Dictionary<string, IEnumerable<string>>(), new MemoryStream());
+            var request = new Request("GET", "/fake/child/route/foo", new Dictionary<string, IEnumerable<string>>(), new MemoryStream(), "http");
             var metas = new[] { new ModuleMeta(typeof(FakeNancyModuleWithBasePath), new FakeNancyModuleWithBasePath().GetRouteDescription("GET")) };
             var route = this.resolver.GetRoute(request, metas, new NancyApplication());
             var response = route.Invoke();
@@ -176,7 +176,7 @@
         public void Should_set_parameters_on_route_when_match_was_made_for_parameterized_action_route()
         {
             // Given
-            var request = new Request("GET", "/fake/foo/some/stuff/not/in/route/bar/more/stuff/not/in/route", new Dictionary<string, IEnumerable<string>>(), new MemoryStream());
+            var request = new Request("GET", "/fake/foo/some/stuff/not/in/route/bar/more/stuff/not/in/route", new Dictionary<string, IEnumerable<string>>(), new MemoryStream(), "http");
             var metas = new[] { new ModuleMeta(typeof(FakeNancyModuleWithBasePath), new FakeNancyModuleWithBasePath().GetRouteDescription("GET")) };
             dynamic result;
 
@@ -192,7 +192,7 @@
         public void Should_pass_a_new_instance_of_the_module()
         {
             // Given
-            var request = new Request("GET", "/fake/foo/some/stuff/not/in/route/bar/more/stuff/not/in/route", new Dictionary<string, IEnumerable<string>>(), new MemoryStream());
+            var request = new Request("GET", "/fake/foo/some/stuff/not/in/route/bar/more/stuff/not/in/route", new Dictionary<string, IEnumerable<string>>(), new MemoryStream(), "http");
             var metas = new[] { new ModuleMeta(typeof(FakeNancyModuleWithBasePath), new FakeNancyModuleWithBasePath().GetRouteDescription("GET")) };            
 
             // When
@@ -209,7 +209,7 @@
         public void Should_pass_the_application_to_the_module()
         {
             // Given
-            var request = new Request("GET", "/fake/foo/some/stuff/not/in/route/bar/more/stuff/not/in/route", new Dictionary<string, IEnumerable<string>>(), new MemoryStream());
+            var request = new Request("GET", "/fake/foo/some/stuff/not/in/route/bar/more/stuff/not/in/route", new Dictionary<string, IEnumerable<string>>(), new MemoryStream(), "http");
             var metas = new[] { new ModuleMeta(typeof(FakeNancyModuleWithBasePath), new FakeNancyModuleWithBasePath().GetRouteDescription("GET")) };
             var application = new NancyApplication();            
 
@@ -224,7 +224,7 @@
         public void Should_pass_the_request_to_the_module()
         {
             // Given
-            var request = new Request("GET", "/fake/foo/some/stuff/not/in/route/bar/more/stuff/not/in/route", new Dictionary<string, IEnumerable<string>>(), new MemoryStream());
+            var request = new Request("GET", "/fake/foo/some/stuff/not/in/route/bar/more/stuff/not/in/route", new Dictionary<string, IEnumerable<string>>(), new MemoryStream(), "http");
             var metas = new[] { new ModuleMeta(typeof(FakeNancyModuleWithBasePath), new FakeNancyModuleWithBasePath().GetRouteDescription("GET")) };                        
 
             // When

--- a/src/Nancy/Hosting/NancyHandler.cs
+++ b/src/Nancy/Hosting/NancyHandler.cs
@@ -36,7 +36,8 @@
                 context.Request.HttpMethod,
                 context.Request.Url.AbsolutePath,
                 context.Request.Headers.ToDictionary(),
-                context.Request.InputStream);
+                context.Request.InputStream,
+                context.Request.Url.Scheme);
         }
 
         private static void SetNancyResponseToHttpResponse(HttpContextBase context, Response response)

--- a/src/Nancy/IRequest.cs
+++ b/src/Nancy/IRequest.cs
@@ -19,18 +19,20 @@ namespace Nancy
         Stream Body { get; }
 
         dynamic Form { get; }
+
+        string Protocol { get; }
     }
 
     public class Request : IRequest
     {
         private dynamic form;
 
-        public Request(string method, string uri)
-            : this(method, uri, new Dictionary<string, IEnumerable<string>>(), new MemoryStream())
+        public Request(string method, string uri, string protocol)
+            : this(method, uri, new Dictionary<string, IEnumerable<string>>(), new MemoryStream(), protocol)
         {
         }
 
-        public Request(string method, string uri, IDictionary<string, IEnumerable<string>> headers, Stream body)
+        public Request(string method, string uri, IDictionary<string, IEnumerable<string>> headers, Stream body, string protocol)
         {
             if (method == null)
                 throw new ArgumentNullException("method", "The value of the method parameter cannot be null.");
@@ -50,10 +52,17 @@ namespace Nancy
             if (body == null)
                 throw new ArgumentNullException("body", "The value of the body parameter cannot be null.");
 
+            if (protocol == null)
+                throw new ArgumentNullException("protocol", "The value of the protocol parameter cannot be null.");
+
+            if (protocol.Length == 0)
+                throw new ArgumentOutOfRangeException("protocol", protocol, "The value of the protocol parameter cannot be empty.");
+
             this.Body = body;
             this.Headers = new Dictionary<string, IEnumerable<string>>(headers, StringComparer.OrdinalIgnoreCase);
             this.Method = method;
             this.Uri = uri;
+            this.Protocol = protocol;
         }
 
         public Stream Body { get; set; }
@@ -92,5 +101,7 @@ namespace Nancy
         public string Method { get; private set; }
 
         public string Uri { get; private set; }
+
+        public string Protocol { get; private set; }
     }
 }


### PR DESCRIPTION
Updated the unit tests, IRequest, and Request constructors to allow for a Url's Scheme (protocol) to be exposed. Use case for this addition would be to allow a user to verify https vs http.
