### PR TITLE
Fix project reference

### DIFF
--- a/src/Nancy.BootStrappers.Ninject/Nancy.BootStrappers.Ninject.csproj
+++ b/src/Nancy.BootStrappers.Ninject/Nancy.BootStrappers.Ninject.csproj
@@ -31,9 +31,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Nancy">
-      <HintPath>..\Nancy\bin\Debug\Nancy.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\Nancy\Nancy.csproj">
+      <Project>{34576216-0DCA-4B0F-A0DC-9075E75A676F}</Project>
+      <Name>Nancy</Name>
+    </ProjectReference>
     <Reference Include="Ninject, Version=2.1.0.91, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL" />
     <Reference Include="Ninject.Extensions.ChildKernel, Version=2.1.0.16, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL" />
     <Reference Include="System" />


### PR DESCRIPTION
If you download the source and try building it in release mode, the build will fail as the Ninject project referenced the Nancy assemby in the `bin\Debug` directory rather than the project. This branch fixes this.
