### PR TITLE
Asp net boot strapper override

### DIFF
--- a/src/Nancy.Demo/Web.config
+++ b/src/Nancy.Demo/Web.config
@@ -6,6 +6,17 @@
   -->
 
 <configuration>
+  
+  <!-- 
+  We can override the bootstrapper inside the config if we don't want to rely on the bootstrapper locator.
+  -->
+  <configSections>
+    <section name="nancyFx" type="Nancy.Hosting.NancyFxSection" />
+  </configSections>
+  <nancyFx>
+    <bootstrapper assembly="Nancy.Demo" type="Nancy.Demo.DemoBootStrapper"/>
+  </nancyFx>
+  
   <system.web>
     <compilation debug="true" targetFramework="4.0" />
     <httpHandlers>

--- a/src/Nancy/Hosting/BootStrapperEntry.cs
+++ b/src/Nancy/Hosting/BootStrapperEntry.cs
@@ -1,0 +1,20 @@
+namespace Nancy.Hosting
+{
+    using System.Web;
+    using Routing;
+    using System;
+    using Nancy.BootStrapper;
+    using System.Configuration;
+
+    public sealed class BootStrapperEntry
+    {
+        public string Assembly { get; private set; }
+        public string Name { get; private set; }
+
+        public BootStrapperEntry(string assembly, string name)
+        {
+            Assembly = assembly;
+            Name = name;
+        }
+    }
+}

--- a/src/Nancy/Hosting/NancyFxSection.cs
+++ b/src/Nancy/Hosting/NancyFxSection.cs
@@ -1,0 +1,54 @@
+namespace Nancy.Hosting
+{
+    using System.Web;
+    using Routing;
+    using System;
+    using Nancy.BootStrapper;
+    using System.Configuration;
+
+    public class NancyFxSection : ConfigurationSection
+    {
+        // Create a "font" element.
+        [ConfigurationProperty("bootstrapper")]
+        public BootStrapperElement BootStrapper
+        {
+            get
+            {
+                return (BootStrapperElement)this["bootstrapper"];
+            }
+            set
+            {
+                this["bootstrapper"] = value;
+            }
+        }
+
+        public class BootStrapperElement : ConfigurationElement
+        {
+            [ConfigurationProperty("type", DefaultValue = "", IsRequired = true)]
+            public String Type
+            {
+                get
+                {
+                    return (String)this["type"];
+                }
+                set
+                {
+                    this["type"] = value;
+                }
+            }
+
+            [ConfigurationProperty("assembly", DefaultValue = "", IsRequired = true)]
+            public String Assembly
+            {
+                get
+                {
+                    return (String)this["assembly"];
+                }
+                set
+                {
+                    this["assembly"] = value;
+                }
+            }
+        }
+    }
+}

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -34,6 +34,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
   </ItemGroup>
@@ -56,6 +57,8 @@
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="HeadResponse.cs" />
     <Compile Include="Extensions\CollectionExtensions.cs" />
+    <Compile Include="Hosting\BootStrapperEntry.cs" />
+    <Compile Include="Hosting\NancyFxSection.cs" />
     <Compile Include="Hosting\NancyHandler.cs" />
     <Compile Include="Hosting\NancyHttpRequestHandler.cs" />
     <Compile Include="BootStrapper\INancyBootStrapperPerRequestRegistration.cs" />


### PR DESCRIPTION
Overridable asp.net bootstrapper support - can override the bootstrapper in the web.config and bypass the locator completely.
