### PR TITLE
XML content types

### DIFF
--- a/src/Nancy.Formatters/FormatterExtensions.cs
+++ b/src/Nancy.Formatters/FormatterExtensions.cs
@@ -11,7 +11,7 @@ namespace Nancy.Formatters
 
         public static Response AsXml<TModel>(this IResponseFormatter formatter, TModel model)
         {
-            return new XmlResponse<TModel>(model);
+            return new XmlResponse<TModel>(model, "application/xml");
         }
 
         public static Response Image(this IResponseFormatter formatter, string imagePath)

--- a/src/Nancy.Formatters/Responses/XmlResponse.cs
+++ b/src/Nancy.Formatters/Responses/XmlResponse.cs
@@ -1,17 +1,17 @@
 ﻿namespace Nancy.Formatters.Responses
 {
     using System;
-    using System.Net;
     using System.IO;
+    using System.Net;
     using System.Xml.Serialization;
 
     public class XmlResponse<TModel> : Response
     {
-        public XmlResponse(TModel model)
+        public XmlResponse(TModel model, string contentType)
         {
-            this.Contents = GetXmlContents(model);
-            this.ContentType = "text/xml";
-            this.StatusCode = HttpStatusCode.OK;
+            Contents = GetXmlContents(model);
+            ContentType = contentType;
+            StatusCode = HttpStatusCode.OK;
         }
 
         private static Action<Stream> GetXmlContents(TModel model)


### PR DESCRIPTION
Allowed response formatter extension methods to use whatever content type they like, and used `application/xml` for the basic `AsXml` extension method rather than `text/xml`. See [this post](http://www.grauw.nl/blog/entry/489) for why.
