### PR TITLE
Implemented possibility to specify routes using regex

### DIFF
--- a/src/Nancy.Tests/Unit/Routing/DefaultRoutePatternMatcherFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/DefaultRoutePatternMatcherFixture.cs
@@ -92,5 +92,27 @@ namespace Nancy.Tests.Unit.Routing
             // Then
             ((string)results.Parameters["bar"]).ShouldEqual("bar/baz");
         }
+
+        [Fact]
+        public void Should_allow_regex_in_route_definition_and_capture_specified_parameters()
+        {
+            // Given, When
+            var results = this.matcher.Match("/foo/1234", @"/(?<foo>foo)/(?<bar>\d{4})/");
+
+            // Then
+            results.IsMatch.ShouldBeTrue();
+            ((string)results.Parameters["foo"]).ShouldEqual("foo");
+            ((string)results.Parameters["bar"]).ShouldEqual("1234");
+        }
+
+        [Fact]
+        public void Should_allow_regex_in_route_definition_and_return_negative_result_when_it_does_not_match()
+        {
+            // Given, When
+            var results = this.matcher.Match("/foo/bar", @"/foo/(?<bar>[0-9]*)");
+
+            // Then
+            results.IsMatch.ShouldBeFalse();
+        }
     }
 }

--- a/src/Nancy/Extensions/StringExtensions.cs
+++ b/src/Nancy/Extensions/StringExtensions.cs
@@ -15,7 +15,7 @@ namespace Nancy.Extensions
         /// <value>A <see cref="Regex"/> object.</value>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private static readonly Regex ParameterExpression =
-            new Regex(@"\{(?<name>[A-Z0-9]*)\}", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            new Regex(@"^\{(?<name>[A-Z0-9]*)\}", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Extracts the name of a parameter from a segment.

--- a/src/Nancy/Routing/DefaultRoutePatternMatcher.cs
+++ b/src/Nancy/Routing/DefaultRoutePatternMatcher.cs
@@ -2,9 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
     using System.Globalization;
-    using System.Linq;
     using System.Text.RegularExpressions;
     using Nancy.Extensions;
 
@@ -22,7 +20,7 @@
 
             return new RoutePatternMatchResult(
                 match.Success,
-                GetParameters(routePath, match.Groups));
+                GetParameters(routePathPattern, match.Groups));
         }
 
         private static string TrimTrailingSlashFromRequestedPath(string requestedPath)
@@ -49,24 +47,13 @@
             return new Regex(pattern, RegexOptions.IgnoreCase);
         }
 
-        private static DynamicDictionary GetParameters(string path, GroupCollection groups)
+        private static DynamicDictionary GetParameters(Regex regex, GroupCollection groups)
         {
-            var segments =
-                new ReadOnlyCollection<string>(
-                    path.Split(new[] { "/" },
-                        StringSplitOptions.RemoveEmptyEntries).ToList());
+            dynamic data = new DynamicDictionary();
 
-            var parameters =
-                from segment in segments
-                where segment.IsParameterized()
-                select segment.GetParameterName();
-
-            dynamic data =
-                new DynamicDictionary();
-
-            foreach (var parameter in parameters)
+            for (int i = 1; i <= groups.Count; i++)
             {
-                data[parameter] = groups[parameter].Value;
+                data[regex.GroupNameFromNumber(i)] = groups[i].Value;
             }
 
             return data;


### PR DESCRIPTION
Sometimes you need to use regex when specifying routes. This can now be done inline instead of using a condition:

```
Get[@"/(?<foo>\d{4})/{bar}"] = x => GetFoo(x.foo, x.bar); 
```
