### PR TITLE
Dynamic dictionary boolean

### DIFF
--- a/src/Nancy.Tests/Unit/DynamicDictionaryValueFixture.cs
+++ b/src/Nancy.Tests/Unit/DynamicDictionaryValueFixture.cs
@@ -163,18 +163,22 @@
         [Fact]
         public void Should_return_false_when_value_is_null_and_implicitly_cast_to_bool()
         {
+            // Given, When
             dynamic value = new DynamicDictionaryValue(null);
 
+            // Then
             Assert.False(value);
         }
 
         [Fact]
         public void Should_return_false_when_value_is_0_and_implicitly_cast_to_bool()
         {
+            // Given, When
             dynamic valueInt = new DynamicDictionaryValue(0);
             dynamic valueFloat = new DynamicDictionaryValue(0.0);
             dynamic valueDec = new DynamicDictionaryValue(0.0M);
 
+            // Then
             Assert.False(valueInt);
             Assert.False(valueFloat);
             Assert.False(valueDec);
@@ -183,10 +187,12 @@
         [Fact]
         public void Should_return_true_when_value_is_non_zero_and_implicitly_cast_to_bool()
         {
+            // Given, When
             dynamic valueInt = new DynamicDictionaryValue(8);
             dynamic valueFloat = new DynamicDictionaryValue(0.1);
             dynamic valueDec = new DynamicDictionaryValue(0.1M);
 
+            // Then
             Assert.True(valueInt);
             Assert.True(valueFloat);
             Assert.True(valueDec);
@@ -195,9 +201,23 @@
         [Fact]
         public void Should_return_true_when_value_is_a_not_null_reference_type()
         {
+            // Given, When
             dynamic value = new DynamicDictionaryValue(new object());
 
+            // Then
             Assert.True(value);
+        }
+
+        [Fact]
+        public void Should_return_true_and_false_for_true_false_strings()
+        {
+            // Given, When
+            dynamic valueTrue = new DynamicDictionaryValue("true");
+            dynamic valueFalse = new DynamicDictionaryValue("false");
+
+            // Then
+            Assert.True(valueTrue);
+            Assert.False(valueFalse);
         }
     }
 }

--- a/src/Nancy/DynamicDictionaryValue.cs
+++ b/src/Nancy/DynamicDictionaryValue.cs
@@ -186,14 +186,20 @@
         public static implicit operator bool(DynamicDictionaryValue dynamicValue)
         {
             if (!dynamicValue.HasValue)
+            {
                 return false;
+            }
 
             if (dynamicValue.value.GetType().IsValueType)
+            {
                 return (Convert.ToBoolean(dynamicValue.value));
+            }
 
             bool result;
             if (bool.TryParse(dynamicValue.ToString(), out result))
+            {
                 return result;
+            }
 
             return true;
         }


### PR DESCRIPTION
I'm very curious to see what people think about this.  I noticed that implicit casting for boolean types was missing and I thought we might add some very dynamic feeling functionality.  So some of the following test cases are implemented:

null == false
"True" == true
0 == false
0.0 == false
1 == true
2 = =true
new object() == true

This is designed to be similar to the way other dynamic languages interpret true and false on dynamic types. 

So, am I crazy... or crazy awesome! 
