### PR TITLE
Dynamic dictionary value type bug

### DIFF
--- a/src/Nancy.Tests/Unit/DynamicDictionaryValueFixture.cs
+++ b/src/Nancy.Tests/Unit/DynamicDictionaryValueFixture.cs
@@ -159,5 +159,17 @@
             // Then
             result.ShouldBeTrue();
         }
+
+        [Fact]
+        public void Should_be_able_to_implictly_cast_long_to_other_value_types()
+        {
+            // Given 
+            dynamic valueLong = new DynamicDictionaryValue((long)10);
+
+            // Then
+            Assert.Equal(10, valueLong);
+            Assert.Equal(10.0, valueLong);
+            Assert.Equal(10M, valueLong);
+        }
     }
 }

--- a/src/Nancy/DynamicDictionaryValue.cs
+++ b/src/Nancy/DynamicDictionaryValue.cs
@@ -192,7 +192,7 @@
         {
             if (dynamicValue.value.GetType().IsValueType)
             {
-                return (int)dynamicValue.value;
+                return Convert.ToInt32(dynamicValue.value);
             }
 
             return int.Parse(dynamicValue.ToString());
@@ -232,7 +232,7 @@
         {
             if (dynamicValue.value.GetType().IsValueType)
             {
-                return (long)dynamicValue.value;
+                return Convert.ToInt64(dynamicValue.value);
             }
 
             return long.Parse(dynamicValue.ToString());
@@ -242,7 +242,7 @@
         {
             if (dynamicValue.value.GetType().IsValueType)
             {
-                return (float)dynamicValue.value;
+                return Convert.ToSingle(dynamicValue.value);
             }
 
             return float.Parse(dynamicValue.ToString());
@@ -252,7 +252,7 @@
         {
             if (dynamicValue.value.GetType().IsValueType)
             {
-                return (decimal)dynamicValue.value;
+                return Convert.ToDecimal(dynamicValue.value);
             }
 
             return decimal.Parse(dynamicValue.ToString());
@@ -262,7 +262,7 @@
         {
             if (dynamicValue.value.GetType().IsValueType)
             {
-                return (double)dynamicValue.value;
+                return Convert.ToDouble(dynamicValue.value);
             }
 
             return double.Parse(dynamicValue.ToString());


### PR DESCRIPTION
So for some reason you can't use (int) to cast from even a long in this situation (see included test).  It's weird but probably has something to do with casting inside an implicit call.  The Convert method is the safest approach given the situation.
