### PR TITLE
TinyIOC generates an exception (probably while booting the app)

### DIFF
--- a/src/Nancy/Routing/RouteCache.cs
+++ b/src/Nancy/Routing/RouteCache.cs
@@ -12,8 +12,8 @@
         public RouteCache(INancyModuleCatalog moduleCatalog, IModuleKeyGenerator moduleKeyGenerator, INancyContextFactory contextFactory)
         {
             this.moduleKeyGenerator = moduleKeyGenerator;
-
-            this.BuildCache(moduleCatalog.GetAllModules(contextFactory.Create()));
+            // materialize the IEnumerable in order to avoid "Collection was modified"
+            this.BuildCache(moduleCatalog.GetAllModules(contextFactory.Create()).ToArray());
         }
 
         private void BuildCache(IEnumerable<NancyModule> modules)


### PR DESCRIPTION
Over at http://nerdbeers.apphb.com , I sometimes get the following exception (after it has been a while I visited):

<pre>
Server Error in '/' Application.
Collection was modified; enumeration operation may not execute.
Description: An unhandled exception occurred during the execution of the current web request. Please review the stack trace for more information about the error and where it originated in the code. 

Exception Details: System.InvalidOperationException: Collection was modified; enumeration operation may not execute.

Source Error: 

An unhandled exception was generated during the execution of the current web request. Information regarding the origin and location of the exception can be identified using the exception stack trace below.

Stack Trace: 

[InvalidOperationException: Collection was modified; enumeration operation may not execute.]
   System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource) +52
   System.Collections.Generic.Enumerator.MoveNext() +9644997
   System.Linq.WhereEnumerableIterator`1.MoveNext() +154
   System.Linq.<ConcatIterator>d__71`1.MoveNext() +207
   System.Linq.<ConcatIterator>d__71`1.MoveNext() +378
   System.Linq.WhereEnumerableIterator`1.MoveNext() +154
   TinyIoC.<ResolveAllInternal>d__3b.MoveNext() in C:\Projecten\Org.NerdBeers\Dependencies\Nancy\src\Nancy\TinyIoc\TinyIoC.cs:3097
   System.Linq.WhereSelectEnumerableIterator`2.MoveNext() +177
   TinyIoC.<ResolveAll>d__4`1.MoveNext() in C:\Projecten\Org.NerdBeers\Dependencies\Nancy\src\Nancy\TinyIoc\TinyIoC.cs:1861
   Nancy.Routing.RouteCache.BuildCache(IEnumerable`1 modules) in C:\Projecten\Org.NerdBeers\Dependencies\Nancy\src\Nancy\Routing\RouteCache.cs:21
   Nancy.Routing.RouteCache..ctor(INancyModuleCatalog moduleCatalog, IModuleKeyGenerator moduleKeyGenerator, INancyContextFactory contextFactory) in C:\Projecten\Org.NerdBeers\Dependencies\Nancy\src\Nancy\Routing\RouteCache.cs:16

[TargetInvocationException: Exception has been thrown by the target of an invocation.]
   System.RuntimeMethodHandle._InvokeConstructor(IRuntimeMethodInfo method, Object[] args, SignatureStruct& signature, RuntimeType declaringType) +0
   System.RuntimeMethodHandle.InvokeConstructor(IRuntimeMethodInfo method, Object[] args, SignatureStruct signature, RuntimeType declaringType) +15
   System.Reflection.RuntimeConstructorInfo.Invoke(BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture) +281
   System.Reflection.ConstructorInfo.Invoke(Object[] parameters) +17
   TinyIoC.TinyIoCContainer.ConstructType(Type type, ConstructorInfo constructor, NamedParameterOverloads parameters, ResolveOptions options) in C:\Projecten\Org.NerdBeers\Dependencies\Nancy\src\Nancy\TinyIoc\TinyIoC.cs:3050

[TinyIoCResolutionException: Unable to resolve type: Nancy.Routing.RouteCache]
   TinyIoC.TinyIoCContainer.ConstructType(Type type, ConstructorInfo constructor, NamedParameterOverloads parameters, ResolveOptions options) in C:\Projecten\Org.NerdBeers\Dependencies\Nancy\src\Nancy\TinyIoc\TinyIoC.cs:3054
   TinyIoC.TinyIoCContainer.ConstructType(Type type, ConstructorInfo constructor, ResolveOptions options) in C:\Projecten\Org.NerdBeers\Dependencies\Nancy\src\Nancy\TinyIoc\TinyIoC.cs:3022
   TinyIoC.SingletonFactory`2.GetObject(TinyIoCContainer container, NamedParameterOverloads parameters, ResolveOptions options) in C:\Projecten\Org.NerdBeers\Dependencies\Nancy\src\Nancy\TinyIoc\TinyIoC.cs:2345
   TinyIoC.TinyIoCContainer.ResolveInternal(TypeRegistration registration, NamedParameterOverloads parameters, ResolveOptions options) in C:\Projecten\Org.NerdBeers\Dependencies\Nancy\src\Nancy\TinyIoc\TinyIoC.cs:2822

[TinyIoCResolutionException: Unable to resolve type: Nancy.Routing.IRouteCache]
   TinyIoC.TinyIoCContainer.ResolveInternal(TypeRegistration registration, NamedParameterOverloads parameters, ResolveOptions options) in C:\Projecten\Org.NerdBeers\Dependencies\Nancy\src\Nancy\TinyIoc\TinyIoC.cs:2826
   TinyIoC.TinyIoCContainer.ConstructType(Type type, ConstructorInfo constructor, NamedParameterOverloads parameters, ResolveOptions options) in C:\Projecten\Org.NerdBeers\Dependencies\Nancy\src\Nancy\TinyIoc\TinyIoC.cs:3045
   TinyIoC.TinyIoCContainer.ConstructType(Type type, ConstructorInfo constructor, ResolveOptions options) in C:\Projecten\Org.NerdBeers\Dependencies\Nancy\src\Nancy\TinyIoc\TinyIoC.cs:3022
   TinyIoC.SingletonFactory`2.GetObject(TinyIoCContainer container, NamedParameterOverloads parameters, ResolveOptions options) in C:\Projecten\Org.NerdBeers\Dependencies\Nancy\src\Nancy\TinyIoc\TinyIoC.cs:2345
   TinyIoC.TinyIoCContainer.ResolveInternal(TypeRegistration registration, NamedParameterOverloads parameters, ResolveOptions options) in C:\Projecten\Org.NerdBeers\Dependencies\Nancy\src\Nancy\TinyIoc\TinyIoC.cs:2822

[TinyIoCResolutionException: Unable to resolve type: Nancy.INancyEngine]
   TinyIoC.TinyIoCContainer.ResolveInternal(TypeRegistration registration, NamedParameterOverloads parameters, ResolveOptions options) in C:\Projecten\Org.NerdBeers\Dependencies\Nancy\src\Nancy\TinyIoc\TinyIoC.cs:2826
   TinyIoC.TinyIoCContainer.Resolve(Type resolveType) in C:\Projecten\Org.NerdBeers\Dependencies\Nancy\src\Nancy\TinyIoc\TinyIoC.cs:991
   TinyIoC.TinyIoCContainer.Resolve() in C:\Projecten\Org.NerdBeers\Dependencies\Nancy\src\Nancy\TinyIoc\TinyIoC.cs:1110
   Nancy.DefaultNancyBootstrapper.GetEngineInternal() in C:\Projecten\Org.NerdBeers\Dependencies\Nancy\src\Nancy\DefaultNancyBootstrapper.cs:31
   Nancy.Bootstrapper.NancyBootstrapperBase`1.GetEngine() in C:\Projecten\Org.NerdBeers\Dependencies\Nancy\src\Nancy\Bootstrapper\NancyBootstrapperBase.cs:164
   Nancy.Hosting.Aspnet.NancyHttpRequestHandler..ctor() in C:\Projecten\Org.NerdBeers\Dependencies\Nancy\src\Nancy.Hosting.Aspnet\NancyHttpRequestHandler.cs:24

[TargetInvocationException: Exception has been thrown by the target of an invocation.]
   System.RuntimeTypeHandle.CreateInstance(RuntimeType type, Boolean publicOnly, Boolean noCheck, Boolean& canBeCached, RuntimeMethodHandleInternal& ctor, Boolean& bNeedSecurityCheck) +0
   System.RuntimeType.CreateInstanceSlow(Boolean publicOnly, Boolean skipCheckThis, Boolean fillCache) +98
   System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean skipVisibilityChecks, Boolean skipCheckThis, Boolean fillCache) +241
   System.Activator.CreateInstance(Type type, Boolean nonPublic) +69
   System.RuntimeType.CreateInstanceImpl(BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture, Object[] activationAttributes) +1136
   System.Activator.CreateInstance(Type type, BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture, Object[] activationAttributes) +111
   System.Activator.CreateInstance(Type type, BindingFlags bindingAttr, Binder binder, Object[] args, CultureInfo culture) +23
   System.Web.HttpRuntime.CreateNonPublicInstance(Type type, Object[] args) +60
   System.Web.Configuration.HandlerFactoryCache..ctor(String type) +46
   System.Web.HttpApplication.GetFactory(String type) +81
   System.Web.MaterializeHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute() +223
   System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& 
</pre>

I think it might be a problem with the initialisation of the container (I am using the default container, and my modules do not have any dependencies; code over at http://github.com/tojans/nerdbeers )
