### PR TITLE
Fix parse form data content type detection

### DIFF
--- a/src/Nancy.Tests/Unit/RequestFixture.cs
+++ b/src/Nancy.Tests/Unit/RequestFixture.cs
@@ -148,7 +148,7 @@ namespace Nancy.Tests.Unit
             var headers = 
                 new Dictionary<string, IEnumerable<string>>
                 {
-                    { "content-type", new[] { "application/x-www-form-urlencoded" } }
+                    { "content-type", new[] { "application/x-www-form-urlencoded; charset=UTF-8" } }
                 };
 
             // When

--- a/src/Nancy/Request.cs
+++ b/src/Nancy/Request.cs
@@ -175,13 +175,14 @@ namespace Nancy
             }
 
             var contentType = this.Headers["content-type"].First();
-            if (contentType.Equals("application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase))
+            var mimeType = contentType.Split(';').First();
+            if (mimeType.Equals("application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase))
             {
                 var reader = new StreamReader(this.Body);
                 this.form = reader.ReadToEnd().AsQueryDictionary();
             }
 
-            if (!contentType.StartsWith("multipart/form-data", StringComparison.OrdinalIgnoreCase))
+            if (!mimeType.Equals("multipart/form-data", StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }


### PR DESCRIPTION
Fixes a problem with Nancy parsing x-www-form-urlencoded from Firefox which adds an extra semi-colon delimited parameter with the character set.
