### PR TITLE
Browser uses FormValues if present

### DIFF
--- a/src/Nancy.Demo.Authentication.Forms.TestingDemo/LoginFixture.cs
+++ b/src/Nancy.Demo.Authentication.Forms.TestingDemo/LoginFixture.cs
@@ -28,7 +28,7 @@ namespace Nancy.Demo.Authentication.Forms.TestingDemo
                 with.FormValue("Password", "wrongpassword");
             });
 
-            response.ShouldHaveRedirectedTo("/login?error=true");
+            response.ShouldHaveRedirectedTo("/login?error=true&username=username");
         }
 
         [Fact]

--- a/src/Nancy.Demo.Authentication.Forms/MainModule.cs
+++ b/src/Nancy.Demo.Authentication.Forms/MainModule.cs
@@ -26,7 +26,7 @@ namespace Nancy.Demo.Authentication.Forms
 
                 if (userGuid == null)
                 {
-                    return Response.AsRedirect("/login?error=true");
+                    return Response.AsRedirect("/login?error=true&username=" + (string)this.Request.Form.Username);
                 }
 
                 DateTime? expiry = null;

--- a/src/Nancy.Testing/Browser.cs
+++ b/src/Nancy.Testing/Browser.cs
@@ -84,7 +84,7 @@ namespace Nancy.Testing
                 return;
             }
 
-            var useFormValues = !String.IsNullOrEmpty(contextValues.BodyString);
+            var useFormValues = !String.IsNullOrEmpty(contextValues.FormValues);
             var bodyContents = useFormValues ? contextValues.FormValues : contextValues.BodyString;
             var bodyBytes = bodyContents != null ? Encoding.UTF8.GetBytes(bodyContents) : new byte[] { };
 


### PR DESCRIPTION
I've fixed the issue with the Browser class not using the FormValues when making a Post request, and updated the existing test that was passing but not for the right reason.
- From initial issue raised
  The Browser doesn't use the FormValues as the bodycontents in the generated request

var response = browser.Post("/login/", (with) =>
            {
                with.HttpRequest();
                with.FormValue("Username", "username");
                with.FormValue("Password", "wrongpassword");
            });
The existing LoginFixture.Should_redirect_to_login_with_error_querystring_if_username_or_password_incorrect test is passing, but the form values defined in the setup aren't what are being Validated.
