### PR TITLE
Route matching places highest priority on exact path matches

### DIFF
--- a/src/Nancy/Routing/DefaultRouteResolver.cs
+++ b/src/Nancy/Routing/DefaultRouteResolver.cs
@@ -108,9 +108,8 @@
             // Order is by number of path segment matches first number of parameter matches second.  
             // If two candidates have the same number of path segments the tie breaker is the parameter count.
             foreach (var tuple in routesWithCorrectRequestMethod
-                .OrderByDescending(x => x.Item4.Parameters.GetDynamicMemberNames().Count())
-                .OrderByDescending(x => x.Item3.Path.Count(c => c.Equals('/')))
-                )
+                .OrderBy(x => x.Item4.Parameters.GetDynamicMemberNames().Count())
+                .OrderByDescending(x => x.Item3.Path.Count(c => c.Equals('/'))))
             {
                 var segments = tuple.Item3.Path.Count(c => c == '/');
                 var parameters = tuple.Item4.Parameters.GetDynamicMemberNames().Count();


### PR DESCRIPTION
An exact path match is one which matches with no parameter captures.
When there is no exact match with continue to match to the result with
the highest number of captures.

Priority order for matching is then:
1st: The first exact match found with no parameter captures (there should really only ever be one exact match)
2nd: The match with the highest number of parameters captures
