### PR TITLE
Non-generic JsonResponse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ build/
 [Oo]bj/
 [Rr]elease/
 _[Rr]e[Ss]harper.*/
+*.docstates

--- a/src/Nancy/Responses/JsonResponse.cs
+++ b/src/Nancy/Responses/JsonResponse.cs
@@ -28,4 +28,11 @@
             };
         }
     }
+
+    public class JsonResponse : JsonResponse<object>
+    {
+        public JsonResponse(object model) : base(model)
+        {
+        }
+    }
 }


### PR DESCRIPTION
All I've done here is add a class JsonResponse : JsonResponse&lt;object&gt; { ... }

The existing code will quite happily serialize from, e.g. IEnumerable&lt;IDictionary&lt;string, object&gt;&gt;, and personally I think it's neater than specifying "new JsonResponse&lt;object&gt;(x)" in app code.
