### PR TITLE
Fixed a couple issues in DefaultDescriptorBuilder.

### DIFF
--- a/src/Nancy.ViewEngines.Spark/Descriptors/DefaultDescriptorBuilder.cs
+++ b/src/Nancy.ViewEngines.Spark/Descriptors/DefaultDescriptorBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System;
+using System.Text.RegularExpressions;
 
 namespace Nancy.ViewEngines.Spark.Descriptors
 {
@@ -54,8 +55,8 @@ namespace Nancy.ViewEngines.Spark.Descriptors
         {
             // Is there any other characters that are allowed in the path which 
             // are not allowed in a c# class name / namespace?
-            Regex illegalNamespaceChars = new Regex("\\/"); 
-            string namespage = illegalNamespaceChars.Replace(buildDescriptorParams.ViewPath, "");
+            Regex illegalNamespaceChars = new Regex(@"[\\/]+"); 
+            string namespage = illegalNamespaceChars.Replace(buildDescriptorParams.ViewPath, String.Empty);
             var descriptor = new SparkViewDescriptor { TargetNamespace = namespage };
 
             if (!LocatePotentialTemplate(


### PR DESCRIPTION
Fixed a couple issues in DefaultDescriptorBuilder.  Found whilst testing Spark View Engine
- The namespace of the view was being set to the view path.  The view path could have '\' characters which are invalid for namespaces.
- Master pages (layouts) were hardcoded to 2 locations /Layouts, /Shared.  This is now more flexible looking for the layouts in /Layouts, /Shared, viewPath/Layouts and viewPath/Shared
