### PR TITLE
Cache disabling in debug mode

### DIFF
--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Extensions\ContextExtensions.cs" />
     <Compile Include="Extensions\RequestExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
+    <Compile Include="StaticConfiguration.cs" />
     <Compile Include="ViewEngines\DefaultRenderContext.cs" />
     <Compile Include="ViewEngines\DefaultRenderContextFactory.cs" />
     <Compile Include="ViewEngines\DefaultViewCache.cs" />

--- a/src/Nancy/StaticConfiguration.cs
+++ b/src/Nancy/StaticConfiguration.cs
@@ -1,0 +1,20 @@
+namespace Nancy
+{
+    public static class StaticConfiguration
+    {
+#if DEBUG
+        private static bool disableCaches = true;
+#else
+        private static bool disableCaches = false;
+#endif   
+
+        /// <summary>
+        /// Gets or sets a value indicating whether Nancy should disable caching
+        /// </summary>
+        public static bool DisableCaches
+        {
+            get { return disableCaches; }
+            set { disableCaches = value; }
+        }
+    }
+}

--- a/src/Nancy/ViewEngines/DefaultViewCache.cs
+++ b/src/Nancy/ViewEngines/DefaultViewCache.cs
@@ -27,6 +27,11 @@
         /// <returns>An instance of the type specified by the <typeparamref name="TCompiledView"/> type.</returns>
         public TCompiledView GetOrAdd<TCompiledView>(ViewLocationResult viewLocationResult, Func<ViewLocationResult, TCompiledView> valueFactory)
         {
+            if (StaticConfiguration.DisableCaches)
+            {
+                return valueFactory(viewLocationResult);
+            }
+
             return (TCompiledView)this.cache.GetOrAdd(viewLocationResult, (x) => valueFactory(x));
         }
     }


### PR DESCRIPTION
Actually sets a static property that can be switched back on again in debug mode for debugging if any cache related bugs rear their heads.

Related to #161
