### PR TITLE
Added IConvertible to DynamicDictionaryValue

### DIFF
--- a/src/Nancy.Tests/Unit/DynamicDictionaryValueFixture.cs
+++ b/src/Nancy.Tests/Unit/DynamicDictionaryValueFixture.cs
@@ -1,5 +1,6 @@
 ﻿namespace Nancy.Tests.Unit
 {
+    using System;
     using Xunit;
 
     public class DynamicDictionaryValueFixture
@@ -231,5 +232,150 @@
             Assert.Equal(10.0, valueLong);
             Assert.Equal(10M, valueLong);
         }
+
+        [Fact]
+        public void Should_be_able_to_call_ConvertToBoolean()
+        {
+            const bool expected = true;
+            object value = new DynamicDictionaryValue(expected);
+            var actual = Convert.ToBoolean(value);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Should_be_able_to_call_ConvertToChar()
+        {
+            const char expected = 'a';
+            object value = new DynamicDictionaryValue(expected);
+            var actual = Convert.ToChar(value);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Should_be_able_to_call_ConvertToSByte()
+        {
+            const sbyte expected = 42;
+            object value = new DynamicDictionaryValue(expected);
+            var actual = Convert.ToSByte(value);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Should_be_able_to_call_ConvertToByte()
+        {
+            const byte expected = 42;
+            object value = new DynamicDictionaryValue(expected);
+            var actual = Convert.ToByte(value);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Should_be_able_to_call_ConvertToInt16()
+        {
+            const short expected = 42;
+            object value = new DynamicDictionaryValue(expected);
+            var actual = Convert.ToInt16(value);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Should_be_able_to_call_ConvertToUInt16()
+        {
+            const ushort expected = 42;
+            object value = new DynamicDictionaryValue(expected);
+            var actual = Convert.ToUInt16(value);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Should_be_able_to_call_ConvertToInt32()
+        {
+            const int expected = 42;
+            object value = new DynamicDictionaryValue(expected);
+            var actual = Convert.ToInt32(value);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Should_be_able_to_call_ConvertToUInt32()
+        {
+            const uint expected = 42;
+            object value = new DynamicDictionaryValue(expected);
+            var actual = Convert.ToUInt32(value);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Should_be_able_to_call_ConvertToInt64()
+        {
+            const long expected = 42;
+            object value = new DynamicDictionaryValue(expected);
+            var actual = Convert.ToInt64(value);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Should_be_able_to_call_ConvertToUInt64()
+        {
+            const ulong expected = 42;
+            object value = new DynamicDictionaryValue(expected);
+            var actual = Convert.ToUInt64(value);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Should_be_able_to_call_ConvertToSingle()
+        {
+            const float expected = 42;
+            object value = new DynamicDictionaryValue(expected);
+            var actual = Convert.ToSingle(value);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Should_be_able_to_call_ConvertToDouble()
+        {
+            const double expected = 42;
+            object value = new DynamicDictionaryValue(expected);
+            var actual = Convert.ToDouble(value);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Should_be_able_to_call_ConvertToDecimal()
+        {
+            const decimal expected = 42;
+            object value = new DynamicDictionaryValue(expected);
+            var actual = Convert.ToDecimal(value);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Should_be_able_to_call_ConvertToDateTime()
+        {
+            DateTime expected = new DateTime(1952, 3, 11);
+            object value = new DynamicDictionaryValue(expected);
+            var actual = Convert.ToDateTime(value);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Should_be_able_to_call_ConvertToString()
+        {
+            const string expected = "Forty two";
+            object value = new DynamicDictionaryValue(expected);
+            var actual = Convert.ToString(value);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Should_be_able_to_call_ConvertChangeType()
+        {
+            const int expected = 42;
+            object value = new DynamicDictionaryValue(expected);
+            var actual = Convert.ChangeType(value, typeof(int));
+            Assert.Equal(expected, actual);
+        }
+
     }
 }

--- a/src/Nancy/DynamicDictionaryValue.cs
+++ b/src/Nancy/DynamicDictionaryValue.cs
@@ -5,7 +5,7 @@
     using System.Linq.Expressions;
     using Microsoft.CSharp.RuntimeBinder;
 
-    public class DynamicDictionaryValue : DynamicObject, IEquatable<DynamicDictionaryValue>, IHideObjectMembers
+    public class DynamicDictionaryValue : DynamicObject, IEquatable<DynamicDictionaryValue>, IHideObjectMembers, IConvertible
     {
         private readonly object value;
 
@@ -296,5 +296,214 @@
 
             return double.Parse(dynamicValue.ToString());
         }
+
+        #region Implementation of IConvertible
+
+        /// <summary>
+        /// Returns the <see cref="T:System.TypeCode"/> for this instance.
+        /// </summary>
+        /// <returns>
+        /// The enumerated constant that is the <see cref="T:System.TypeCode"/> of the class or value type that implements this interface.
+        /// </returns>
+        /// <filterpriority>2</filterpriority>
+        public TypeCode GetTypeCode()
+        {
+            if (value == null) return TypeCode.Empty;
+            return Type.GetTypeCode(value.GetType());
+        }
+
+        /// <summary>
+        /// Converts the value of this instance to an equivalent Boolean value using the specified culture-specific formatting information.
+        /// </summary>
+        /// <returns>
+        /// A Boolean value equivalent to the value of this instance.
+        /// </returns>
+        /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
+        public bool ToBoolean(IFormatProvider provider)
+        {
+            return Convert.ToBoolean(value, provider);
+        }
+
+        /// <summary>
+        /// Converts the value of this instance to an equivalent Unicode character using the specified culture-specific formatting information.
+        /// </summary>
+        /// <returns>
+        /// A Unicode character equivalent to the value of this instance.
+        /// </returns>
+        /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
+        public char ToChar(IFormatProvider provider)
+        {
+            return Convert.ToChar(value, provider);
+        }
+
+        /// <summary>
+        /// Converts the value of this instance to an equivalent 8-bit signed integer using the specified culture-specific formatting information.
+        /// </summary>
+        /// <returns>
+        /// An 8-bit signed integer equivalent to the value of this instance.
+        /// </returns>
+        /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
+        public sbyte ToSByte(IFormatProvider provider)
+        {
+            return Convert.ToSByte(value, provider);
+        }
+
+        /// <summary>
+        /// Converts the value of this instance to an equivalent 8-bit unsigned integer using the specified culture-specific formatting information.
+        /// </summary>
+        /// <returns>
+        /// An 8-bit unsigned integer equivalent to the value of this instance.
+        /// </returns>
+        /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
+        public byte ToByte(IFormatProvider provider)
+        {
+            return Convert.ToByte(value, provider);
+        }
+
+        /// <summary>
+        /// Converts the value of this instance to an equivalent 16-bit signed integer using the specified culture-specific formatting information.
+        /// </summary>
+        /// <returns>
+        /// An 16-bit signed integer equivalent to the value of this instance.
+        /// </returns>
+        /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
+        public short ToInt16(IFormatProvider provider)
+        {
+            return Convert.ToInt16(value, provider);
+        }
+
+        /// <summary>
+        /// Converts the value of this instance to an equivalent 16-bit unsigned integer using the specified culture-specific formatting information.
+        /// </summary>
+        /// <returns>
+        /// An 16-bit unsigned integer equivalent to the value of this instance.
+        /// </returns>
+        /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
+        public ushort ToUInt16(IFormatProvider provider)
+        {
+            return Convert.ToUInt16(value, provider);
+        }
+
+        /// <summary>
+        /// Converts the value of this instance to an equivalent 32-bit signed integer using the specified culture-specific formatting information.
+        /// </summary>
+        /// <returns>
+        /// An 32-bit signed integer equivalent to the value of this instance.
+        /// </returns>
+        /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
+        public int ToInt32(IFormatProvider provider)
+        {
+            return Convert.ToInt32(value, provider);
+        }
+
+        /// <summary>
+        /// Converts the value of this instance to an equivalent 32-bit unsigned integer using the specified culture-specific formatting information.
+        /// </summary>
+        /// <returns>
+        /// An 32-bit unsigned integer equivalent to the value of this instance.
+        /// </returns>
+        /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
+        public uint ToUInt32(IFormatProvider provider)
+        {
+            return Convert.ToUInt32(value, provider);
+        }
+
+        /// <summary>
+        /// Converts the value of this instance to an equivalent 64-bit signed integer using the specified culture-specific formatting information.
+        /// </summary>
+        /// <returns>
+        /// An 64-bit signed integer equivalent to the value of this instance.
+        /// </returns>
+        /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
+        public long ToInt64(IFormatProvider provider)
+        {
+            return Convert.ToInt64(value, provider);
+        }
+
+        /// <summary>
+        /// Converts the value of this instance to an equivalent 64-bit unsigned integer using the specified culture-specific formatting information.
+        /// </summary>
+        /// <returns>
+        /// An 64-bit unsigned integer equivalent to the value of this instance.
+        /// </returns>
+        /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
+        public ulong ToUInt64(IFormatProvider provider)
+        {
+            return Convert.ToUInt64(value, provider);
+        }
+
+        /// <summary>
+        /// Converts the value of this instance to an equivalent single-precision floating-point number using the specified culture-specific formatting information.
+        /// </summary>
+        /// <returns>
+        /// A single-precision floating-point number equivalent to the value of this instance.
+        /// </returns>
+        /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
+        public float ToSingle(IFormatProvider provider)
+        {
+            return Convert.ToSingle(value, provider);
+        }
+
+        /// <summary>
+        /// Converts the value of this instance to an equivalent double-precision floating-point number using the specified culture-specific formatting information.
+        /// </summary>
+        /// <returns>
+        /// A double-precision floating-point number equivalent to the value of this instance.
+        /// </returns>
+        /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
+        public double ToDouble(IFormatProvider provider)
+        {
+            return Convert.ToDouble(value, provider);
+        }
+
+        /// <summary>
+        /// Converts the value of this instance to an equivalent <see cref="T:System.Decimal"/> number using the specified culture-specific formatting information.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="T:System.Decimal"/> number equivalent to the value of this instance.
+        /// </returns>
+        /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
+        public decimal ToDecimal(IFormatProvider provider)
+        {
+            return Convert.ToDecimal(value, provider);
+        }
+
+        /// <summary>
+        /// Converts the value of this instance to an equivalent <see cref="T:System.DateTime"/> using the specified culture-specific formatting information.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="T:System.DateTime"/> instance equivalent to the value of this instance.
+        /// </returns>
+        /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
+        public DateTime ToDateTime(IFormatProvider provider)
+        {
+            return Convert.ToDateTime(value, provider);
+        }
+
+        /// <summary>
+        /// Converts the value of this instance to an equivalent <see cref="T:System.String"/> using the specified culture-specific formatting information.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="T:System.String"/> instance equivalent to the value of this instance.
+        /// </returns>
+        /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
+        public string ToString(IFormatProvider provider)
+        {
+            return Convert.ToString(value, provider);
+        }
+
+        /// <summary>
+        /// Converts the value of this instance to an <see cref="T:System.Object"/> of the specified <see cref="T:System.Type"/> that has an equivalent value, using the specified culture-specific formatting information.
+        /// </summary>
+        /// <returns>
+        /// An <see cref="T:System.Object"/> instance of type <paramref name="conversionType"/> whose value is equivalent to the value of this instance.
+        /// </returns>
+        /// <param name="conversionType">The <see cref="T:System.Type"/> to which the value of this instance is converted. </param><param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
+        public object ToType(Type conversionType, IFormatProvider provider)
+        {
+            return Convert.ChangeType(value, conversionType, provider);
+        }
+
+        #endregion
     }
 }

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -7,4 +7,3 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Nancy")]
 [assembly: AssemblyCopyright("Copyright (C) Andreas Hakansson, Steven Robbins and contributors")]
 [assembly: AssemblyVersion("0.6.0")]
-


### PR DESCRIPTION
ADO.NET requires objects passed in parameters to implement IConvertible. Adding this interface to DynamicDictionaryValue means it can be used directly in calls like _db.Users.FindById(req.uid).

Full test coverage included :)
