### PR TITLE
URL encoding fix for Authentication demo

### DIFF
--- a/src/Nancy.Demo.Authentication/AuthenticationBootstrapper.cs
+++ b/src/Nancy.Demo.Authentication/AuthenticationBootstrapper.cs
@@ -34,7 +34,7 @@ namespace Nancy.Demo.Authentication
                 // forward the user to the login page
                 if (ctx.Response.StatusCode == HttpStatusCode.Unauthorized)
                 {
-                    ctx.Response = new RedirectResponse("/login?returnUrl=" + ctx.Request.Uri);
+                    ctx.Response = new RedirectResponse("/login?returnUrl=" + Uri.EscapeDataString(ctx.Request.Uri));
                 }
             };
         }


### PR DESCRIPTION
URL encoding returnUrl -  just in case anybody uses this demo as the start point for a real app.
