### PR TITLE
DynamicDictionary naming conventions

### DIFF
--- a/src/Nancy.Tests/Unit/DynamicDictionaryFixture.cs
+++ b/src/Nancy.Tests/Unit/DynamicDictionaryFixture.cs
@@ -1,6 +1,7 @@
 namespace Nancy.Tests.Unit
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using Xunit;
 
@@ -13,6 +14,24 @@ namespace Nancy.Tests.Unit
             this.dictionary = new DynamicDictionary();
             this.dictionary["TestString"] = "Testing";
             this.dictionary["TestInt"] = 2;
+        }
+
+        [Fact]
+        public void Should_create_instance_from_dictionary()
+        {
+            // Given
+            var values = new Dictionary<string, object>
+            {
+                { "foo", 10 },
+                { "bar", "some value" },
+            };
+
+            // When
+            dynamic instance = DynamicDictionary.Create(values);
+
+            // Then
+            ((int)GetIntegerValue(instance.foo)).ShouldEqual(10);
+            ((string)GetStringValue(instance.bar)).ShouldEqual("some value");
         }
 
         [Fact]

--- a/src/Nancy/DynamicDictionary.cs
+++ b/src/Nancy/DynamicDictionary.cs
@@ -21,6 +21,23 @@
         }
 
         /// <summary>
+        /// Creates a dynamic dictionary from an <see cref="IDictionary{TKey,TValue}"/> instance.
+        /// </summary>
+        /// <param name="values">An <see cref="IDictionary{TKey,TValue}"/> instance, that the dynamic dictionary should be created from.</param>
+        /// <returns>An <see cref="DynamicDictionary"/> instance.</returns>
+        public static DynamicDictionary Create(IDictionary<string, object> values)
+        {
+            var instance = new DynamicDictionary();
+
+            foreach (var key in values.Keys)
+            {
+                instance[key] = values[key];
+            }
+
+            return instance;
+        }
+
+        /// <summary>
         /// Provides the implementation for operations that set member values. Classes derived from the <see cref="T:System.Dynamic.DynamicObject"/> class can override this method to specify dynamic behavior for operations such as setting a value for a property.
         /// </summary>
         /// <returns>true if the operation is successful; otherwise, false. If this method returns false, the run-time binder of the language determines the behavior. (In most cases, a language-specific run-time exception is thrown.)</returns>


### PR DESCRIPTION
It will now strip out a dash in the name, but still let you access it using both the dashed name and the stripped name. Can add more characters to strip if/when needed
