### PR TITLE
Changed so that the Razor view engine uses the escaped code base of assem

### DIFF
--- a/src/Nancy.ViewEngines.Razor/RazorViewEngine.cs
+++ b/src/Nancy.ViewEngines.Razor/RazorViewEngine.cs
@@ -157,7 +157,7 @@
         }
 
         private static string GetAssemblyPath(Assembly assembly) {
-            return new Uri(assembly.CodeBase).LocalPath;
+            return new Uri(assembly.EscapedCodeBase).LocalPath;
         }
 
         private NancyRazorViewBase GetOrCompileView(ViewLocationResult viewLocationResult, IRenderContext renderContext, Assembly referencingAssembly)


### PR DESCRIPTION
Changed so that the Razor view engine uses the escaped code base of assemblies
Fixes issue #169
