### PR TITLE
Moved path expansion to context extension and forms auth fixup.

### DIFF
--- a/src/Nancy.Authentication.Forms/FormsAuthentication.cs
+++ b/src/Nancy.Authentication.Forms/FormsAuthentication.cs
@@ -4,6 +4,9 @@ namespace Nancy.Authentication.Forms
     using Bootstrapper;
     using Cookies;
     using Cryptography;
+
+    using Nancy.Extensions;
+
     using Responses;
     using Security;
 
@@ -84,7 +87,7 @@ namespace Nancy.Authentication.Forms
                 redirectUrl = context.Request.Query[REDIRECT_QUERYSTRING_KEY];
             }
 
-            var response = new RedirectResponse(redirectUrl);
+            var response = context.GetRedirect(redirectUrl);
             var authenticationCookie = BuildCookie(userIdentifier, cookieExpiry, currentConfiguration);
             response.AddCookie(authenticationCookie);
 
@@ -99,7 +102,7 @@ namespace Nancy.Authentication.Forms
         /// <returns>Nancy response</returns>
         public static Response LogOutAndRedirectResponse(NancyContext context, string redirectUrl)
         {
-            var response = new RedirectResponse(redirectUrl);
+            var response = context.GetRedirect(redirectUrl);
             var authenticationCookie = BuildLogoutCookie(currentConfiguration);
             response.AddCookie(authenticationCookie);
 
@@ -146,7 +149,7 @@ namespace Nancy.Authentication.Forms
                 {
                     if (context.Response.StatusCode == HttpStatusCode.Unauthorized)
                     {
-                        context.Response = new RedirectResponse(string.Format("{0}?{1}={2}", configuration.RedirectUrl, REDIRECT_QUERYSTRING_KEY, context.Request.Path));
+                        context.Response = context.GetRedirect(string.Format("{0}?{1}={2}", configuration.RedirectUrl, REDIRECT_QUERYSTRING_KEY, context.ToFullPath("~" + context.Request.Path)));
                     }
                 };
         }

--- a/src/Nancy.Demo.Authentication.Forms/FormsAuthBootstrapper.cs
+++ b/src/Nancy.Demo.Authentication.Forms/FormsAuthBootstrapper.cs
@@ -12,7 +12,7 @@ namespace Nancy.Demo.Authentication.Forms
             var formsAuthConfiguration = 
                 new FormsAuthenticationConfiguration()
                 {
-                    RedirectUrl = "/login",
+                    RedirectUrl = "~/login",
                     UsernameMapper = container.Resolve<IUsernameMapper>(),
                 };
 

--- a/src/Nancy.Demo.Authentication.Forms/MainModule.cs
+++ b/src/Nancy.Demo.Authentication.Forms/MainModule.cs
@@ -4,6 +4,7 @@ namespace Nancy.Demo.Authentication.Forms
     using System.Dynamic;
     using Nancy;
     using Nancy.Authentication.Forms;
+    using Nancy.Extensions;
 
     public class MainModule : NancyModule
     {
@@ -26,7 +27,7 @@ namespace Nancy.Demo.Authentication.Forms
 
                 if (userGuid == null)
                 {
-                    return Response.AsRedirect("/login?error=true&username=" + (string)this.Request.Form.Username);
+                    return Context.GetRedirect("~/login?error=true&username=" + (string)this.Request.Form.Username);
                 }
 
                 DateTime? expiry = null;
@@ -39,7 +40,7 @@ namespace Nancy.Demo.Authentication.Forms
             };
 
             Get["/logout"] = x => {
-                return this.LogoutAndRedirect("/");
+                return this.LogoutAndRedirect("~/");
             };
         }
     }

--- a/src/Nancy.Demo.Authentication.Forms/Nancy.Demo.Authentication.Forms.csproj
+++ b/src/Nancy.Demo.Authentication.Forms/Nancy.Demo.Authentication.Forms.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -150,12 +150,12 @@
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" />
   <ProjectExtensions>
     <VisualStudio>
-      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+      <FlavorProperties GUID="{349C5851-65DF-11DA-9384-00065B846F21}">
         <WebProjectProperties>
           <UseIIS>False</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>2146</DevelopmentServerPort>
-          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <DevelopmentServerVPath>/forms</DevelopmentServerVPath>
           <IISUrl>
           </IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>

--- a/src/Nancy.Demo.Authentication.Forms/Views/index.cshtml
+++ b/src/Nancy.Demo.Authentication.Forms/Views/index.cshtml
@@ -4,6 +4,6 @@
     <title>Forms Authentication Demo</title>
 </head>
 <body>
-    <a href="/secure">Enter the "Secure Zone"!</a>
+    <a href="secure">Enter the "Secure Zone"!</a>
 </body>
 </html>

--- a/src/Nancy.Tests/Unit/Extensions/ContextExtensionsFixture.cs
+++ b/src/Nancy.Tests/Unit/Extensions/ContextExtensionsFixture.cs
@@ -1,10 +1,12 @@
-﻿using System.Collections.Generic;
-using Nancy.Extensions;
-using Nancy.Tests.Fakes;
-using Xunit;
-
-namespace Nancy.Tests.Unit.Extensions
+﻿namespace Nancy.Tests.Unit.Extensions
 {
+    using System.Collections.Generic;
+
+    using Nancy.Extensions;
+    using Nancy.Tests.Fakes;
+
+    using Xunit;
+
     public class ContextExtensionsFixture
     {
         [Fact]
@@ -49,5 +51,57 @@ namespace Nancy.Tests.Unit.Extensions
             // Then
             Assert.False(context.IsAjaxRequest());
         }
+
+        [Fact]
+        public void Should_return_same_path_when_parsing_path_if_path_doesnt_contain_tilde()
+        {
+            const string input = "/scripts/test.js";
+            var url = new Url
+            {
+                BasePath = "/base/path",
+                Path = "/"
+            };
+            var request = new Request("GET", url);
+            var nancyContext = new NancyContext { Request = request };
+
+            var result = nancyContext.ToFullPath(input);
+
+            result.ShouldEqual(input);
+        }
+
+        [Fact]
+        public void Should_replace_tilde_with_base_path_when_parsing_path_if_one_present()
+        {
+            const string input = "~/scripts/test.js";
+            var url = new Url
+            {
+                BasePath = "/base/path/",
+                Path = "/"
+            };
+            var request = new Request("GET", url);
+            var nancyContext = new NancyContext { Request = request };
+
+            var result = nancyContext.ToFullPath(input);
+
+            result.ShouldEqual("/base/path/scripts/test.js");
+        }
+
+        [Fact]
+        public void Should_replace_tilde_with_nothing_when_parsing_path_if_one_present_and_base_path_is_null()
+        {
+            const string input = "~/scripts/test.js";
+            var url = new Url
+            {
+                BasePath = null,
+                Path = "/"
+            };
+            var request = new Request("GET", url);
+            var nancyContext = new NancyContext { Request = request };
+
+            var result = nancyContext.ToFullPath(input);
+
+            result.ShouldEqual("/scripts/test.js");
+        }
+
     }
 }

--- a/src/Nancy/Extensions/ContextExtensions.cs
+++ b/src/Nancy/Extensions/ContextExtensions.cs
@@ -1,18 +1,63 @@
 namespace Nancy.Extensions
 {
+    using Nancy.Responses;
+
     /// <summary>
     /// Containing extensions for the NancyContext object
     /// </summary>
     public static class ContextExtensions
     {
         /// <summary>
-        /// An extension method making it easy to check if the reqeuest was done using ajax
+        /// Ascertains if a request originated from an Ajax request or not.
         /// </summary>
         /// <param name="context">The current nancy context</param>
-        /// <returns>True if the request was done using ajax</returns>
+        /// <returns>True if the request was done using ajax, false otherwise</returns>
         public static bool IsAjaxRequest(this NancyContext context)
         {
             return context.Request != null && context.Request.IsAjaxRequest();
+        }
+
+        /// <summary>
+        /// Expands a path to take into account a base path (if any)
+        /// </summary>
+        /// <param name="context">Nancy context</param>
+        /// <param name="path">Path to expand</param>
+        /// <returns>Expanded path</returns>
+        public static string ToFullPath(this NancyContext context, string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
+
+            if (context.Request == null)
+            {
+                return path.TrimStart('~');
+            }
+            
+            if (string.IsNullOrEmpty(context.Request.Url.BasePath))
+            {
+                return path.TrimStart('~');
+            }
+
+            if (!path.StartsWith("~/"))
+            {
+                return path;
+            }
+
+            return string.Format("{0}{1}", context.Request.Url.BasePath, path.TrimStart('~'));
+        }
+
+        /// <summary>
+        /// Returns a redirect response with the redirect path expanded to take into
+        /// account a base path (if any)
+        /// </summary>
+        /// <param name="context">Nancy context</param>
+        /// <param name="path">Path to redirect to</param>
+        /// <returns>Redirect response</returns>
+        public static RedirectResponse GetRedirect(this NancyContext context, string path)
+        {
+            return new RedirectResponse(context.ToFullPath(path));
         }
     }
 }

--- a/src/Nancy/Responses/RedirectResponse.cs
+++ b/src/Nancy/Responses/RedirectResponse.cs
@@ -1,13 +1,24 @@
 namespace Nancy.Responses
 {
+    /// <summary>
+    /// A response representing a raw 303 redirect
+    /// <seealso cref="Nancy.Extensions.ContextExtensions.ToFullPath"/>
+    /// <seealso cref="Nancy.Extensions.ContextExtensions.GetRedirect"/>
+    /// </summary>
     public class RedirectResponse : Response
-	{
-		public RedirectResponse (string location) 
-		{
-			this.Headers.Add("Location",location);
-			this.Contents = GetStringContents(string.Empty);
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RedirectResponse"/> class. 
+        /// </summary>
+        /// <param name="location">
+        /// Location to redirect to
+        /// </param>
+        public RedirectResponse(string location)
+        {
+            this.Headers.Add("Location", location);
+            this.Contents = GetStringContents(string.Empty);
             this.ContentType = "text/html";
             this.StatusCode = HttpStatusCode.SeeOther;
-		}
-	}
+        }
+    }
 }

--- a/src/Nancy/ViewEngines/DefaultRenderContext.cs
+++ b/src/Nancy/ViewEngines/DefaultRenderContext.cs
@@ -1,5 +1,7 @@
 ﻿namespace Nancy.ViewEngines
 {
+    using Nancy.Extensions;
+
     /// <summary>
     /// Default render context implementation.
     /// </summary>
@@ -30,20 +32,7 @@
         /// <returns>Parsed absolut url path</returns>
         public string ParsePath(string input)
         {
-            if (string.IsNullOrEmpty(input))
-            {
-                return string.Empty;
-            }
-
-            if (!input.StartsWith("~/"))
-            {
-                return input;
-            }
-
-            return string.Format(
-                "{0}{1}", 
-                this.viewLocationContext.Context.Request.Url.BasePath ?? string.Empty,
-                input.TrimStart('~'));
+            return this.viewLocationContext.Context.ToFullPath(input);
         }
 
         /// <summary>


### PR DESCRIPTION
Path expansion is now in an extension method on context and is
used by the render context. It is also used by another new extension
method on context for creating redirects with "expanded" urls. Altered
forms authentication to take advantage of the new path expansion.
