### PR TITLE
Can access resolved parameters in Nancy Context

### DIFF
--- a/src/Nancy.Tests/Unit/NancyEngineFixture.cs
+++ b/src/Nancy.Tests/Unit/NancyEngineFixture.cs
@@ -344,5 +344,17 @@ namespace Nancy.Tests.Unit
             executionOrder.Count().ShouldEqual(3);
             executionOrder.SequenceEqual(new[] { "Routeprehook", "Routeposthook", "Posthook" }).ShouldBeTrue();
         }
+
+        [Fact]
+        public void Should_set_the_route_parameters_to_the_nancy_context_before_calling_the_module_before()
+        {
+            dynamic parameters = new DynamicDictionary();
+            parameters.Foo = "Bar";
+            Func<NancyContext, Response> moduleBefore = (ctx) =>  { Assert.Equal(this.context.Parameters, parameters); return null; };
+            A.CallTo(() => resolver.Resolve(A<NancyContext>.Ignored, A<IRouteCache>.Ignored)).Returns(new ResolveResult(route, parameters, moduleBefore, null));
+            var request = new Request("GET", "/", "http");
+            engine.HandleRequest(request);
+            Assert.Equal(this.context.Parameters, parameters);
+        }
     }
 }

--- a/src/Nancy/NancyContext.cs
+++ b/src/Nancy/NancyContext.cs
@@ -23,6 +23,11 @@ namespace Nancy
         public IDictionary<string, object> Items { get; private set; }
 
         /// <summary>
+        /// Gets or sets the parameters for the resolved route 
+        /// </summary>
+        public dynamic Parameters { get; set; }
+
+        /// <summary>
         /// Gets or sets the incoming request
         /// </summary>
         public Request Request { get; set; }

--- a/src/Nancy/NancyEngine.cs
+++ b/src/Nancy/NancyEngine.cs
@@ -151,9 +151,10 @@
         private void ResolveAndInvokeRoute(NancyContext context)
         {
             var resolveResult = this.resolver.Resolve(context, this.routeCache);
+
+            context.Parameters = resolveResult.Item2; 
             var resolveResultPreReq = resolveResult.Item3;
             var resolveResultPostReq = resolveResult.Item4;
-
             this.ExecuteRoutePreReq(context, resolveResultPreReq);
 
             if (context.Response == null)


### PR DESCRIPTION
I thought this would be useful.  I'm not totally sure that NancyEngine was the right place for this, but after some thought I decided the DefaultRouteResolver was \* definitely\* not the right place for it since changing the context would have been an ugly side effect.

In the end this seemed like the best choice.  It saves me having to parse values that Nancy already knows from the Request uri value.
