### PR TITLE
Added a dispose for context when building route cache

### DIFF
--- a/src/Nancy/Routing/RouteCache.cs
+++ b/src/Nancy/Routing/RouteCache.cs
@@ -13,7 +13,10 @@
         {
             this.moduleKeyGenerator = moduleKeyGenerator;
 
-            this.BuildCache(moduleCatalog.GetAllModules(contextFactory.Create()));
+            using (var context = contextFactory.Create())
+            {
+                this.BuildCache(moduleCatalog.GetAllModules(context));
+            }
         }
 
         private void BuildCache(IEnumerable<NancyModule> modules)


### PR DESCRIPTION
I noticed when working on a project that the first time the server starts up my services get created but never disposed. Each subsequent request gets created and disposed however. This was causing problems since I'm managing sessions through the IoC container (due to a middle container that has to stay compatible with MVC.)

The problem comes from RouteCache which creates a context but doesn't dispose of it. I put a using around it which seems to solve the problem just fine for me.
