### PR TITLE
Fixed so that Nancy-Version header works

### DIFF
--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -4,4 +4,4 @@ using System.Reflection;
 [assembly: AssemblyCompany("Nancy")]
 [assembly: AssemblyProduct("Nancy")]
 [assembly: AssemblyCopyright("Copyright (C) Andreas Hakansson, Steven Robbins and contributors")]
-[assembly: AssemblyVersion("0.0.0")]
+[assembly: AssemblyVersion("0.7.1")]


### PR DESCRIPTION
Added the version number to SharedAssemblyInfo.cs because it is used by the Nancy-Version header at runtime
