### PR TITLE
Fixes a potential encoding problem with the rakefile

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 require 'rubygems'
 require 'albacore'
 require 'rake/clean'


### PR DESCRIPTION
This is supposed to hep with the encoding issue.  Also some users may need to change the codepage of their console environment in Windows to utf-8 with `chcp 65001` (I know cryptic isn't it).  I've updated the wiki with a page with tips for rake problems which includes this.  

All this effort just for your name ;P.

http://bitprison.net/invalid_multibyte_char_US-ASCII
