### PR TITLE
View location convention improvements

### DIFF
--- a/src/Nancy.Tests/Unit/Conventions/DefaultViewLocationConventionsFixture.cs
+++ b/src/Nancy.Tests/Unit/Conventions/DefaultViewLocationConventionsFixture.cs
@@ -116,5 +116,73 @@ namespace Nancy.Tests.Unit.Conventions
             // Then
             this.conventions.ViewLocationConventions.Count.ShouldBeGreaterThan(0);
         }
+
+        [Fact]
+        public void Should_define_convention_that_returns_viewname()
+        {
+            // Given
+            this.viewLocationConventions.Initialise(this.conventions);
+            var convention = this.conventions.ViewLocationConventions[0];
+
+            // When
+            var result = convention.Invoke(
+                "viewname", 
+                null, 
+                new ViewLocationContext { ModulePath = string.Empty });
+
+            // Then
+            result.ShouldEqual("viewname");
+        }
+
+        [Fact]
+        public void Should_define_convention_that_returns_viewname_in_views_folder()
+        {
+            // Given
+            this.viewLocationConventions.Initialise(this.conventions);
+            var convention = this.conventions.ViewLocationConventions[1];
+
+            // When
+            var result = convention.Invoke(
+                "viewname",
+                null,
+                new ViewLocationContext { ModulePath = string.Empty });
+
+            // Then
+            result.ShouldEqual("views/viewname");
+        }
+
+        [Fact]
+        public void Should_define_convention_that_returns_viewname_in_modulepath_subfolder_of_views_folder()
+        {
+            // Given
+            this.viewLocationConventions.Initialise(this.conventions);
+            var convention = this.conventions.ViewLocationConventions[2];
+
+            // When
+            var result = convention.Invoke(
+                "viewname",
+                null,
+                new ViewLocationContext { ModulePath = "modulepath" });
+
+            // Then
+            result.ShouldEqual("views/modulepath/viewname");
+        }
+
+        [Fact]
+        public void Should_define_convention_that_returns_viewname_in_modulepath_folder()
+        {
+            // Given
+            this.viewLocationConventions.Initialise(this.conventions);
+            var convention = this.conventions.ViewLocationConventions[3];
+
+            // When
+            var result = convention.Invoke(
+                "viewname",
+                null,
+                new ViewLocationContext { ModulePath = "modulepath" });
+
+            // Then
+            result.ShouldEqual("modulepath/viewname");
+        }
     }
 }

--- a/src/Nancy/Conventions/DefaultViewLocationConventions.cs
+++ b/src/Nancy/Conventions/DefaultViewLocationConventions.cs
@@ -48,7 +48,11 @@
                 },
 
                 (viewName, model, viewLocationContext) => {
-                    return string.Concat("views", viewLocationContext.ModulePath, "/", viewName);
+                    return string.Concat("views/", viewLocationContext.ModulePath, "/", viewName);
+                },
+
+                (viewName, model, viewLocationContext) => {
+                    return string.Concat(viewLocationContext.ModulePath, "/", viewName);
                 }
             };
         }


### PR DESCRIPTION
Improved test coverage of the default view location conventions. Discovered a bug in one of them and fixed it. Also added a new convention that looks for the view in a folder with the same name as the module path
