### PR TITLE
Updated IStartup to resolve issue #237

### DIFF
--- a/src/Nancy.Tests/Unit/Bootstrapper/NancyBootstrapperBaseFixture.cs
+++ b/src/Nancy.Tests/Unit/Bootstrapper/NancyBootstrapperBaseFixture.cs
@@ -19,6 +19,8 @@
         public object AppContainer { get; set; }
         public IModuleKeyGenerator Generator { get; set; }
         public IEnumerable<TypeRegistration> TypeRegistrations { get; set; }
+        public IEnumerable<CollectionTypeRegistration> CollectionTypeRegistrations { get; set; }
+        public IEnumerable<InstanceRegistration> InstanceRegistrations { get; set; }
         public List<ModuleRegistration> PassedModules { get; set; }
         public IStartup[] OverriddenStartupTasks { get; set; }
 
@@ -106,8 +108,9 @@
             this.TypeRegistrations = typeRegistrations;
         }
 
-        protected override void RegisterCollectionTypes(object container, IEnumerable<CollectionTypeRegistration> collectionTypeRegistrationsn)
+        protected override void RegisterCollectionTypes(object container, IEnumerable<CollectionTypeRegistration> collectionTypeRegistrations)
         {
+            this.CollectionTypeRegistrations = collectionTypeRegistrations;
         }
 
         protected override void RegisterModules(object container, IEnumerable<ModuleRegistration> moduleRegistrationTypes)
@@ -117,6 +120,7 @@
 
         protected override void RegisterInstances(object container, IEnumerable<InstanceRegistration> instanceRegistrations)
         {
+            this.InstanceRegistrations = instanceRegistrations;
         }
 
         protected override byte[] DefaultFavIcon
@@ -329,8 +333,47 @@
 
             _Bootstrapper.Initialise();
 
-            A.CallTo(() => startupMock.Initialize()).MustHaveHappened(Repeated.Exactly.Once);
-            A.CallTo(() => startupMock2.Initialize()).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => startupMock.Initialize(_Bootstrapper)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => startupMock2.Initialize(_Bootstrapper)).MustHaveHappened(Repeated.Exactly.Once);
+        }
+
+        [Fact]
+        public void Should_register_startup_task_type_registrations_into_container()
+        {
+            var typeRegistrations = new TypeRegistration[] { };
+            var startupStub = A.Fake<IStartup>();
+            A.CallTo(() => startupStub.TypeRegistrations).Returns(typeRegistrations);
+            _Bootstrapper.OverriddenStartupTasks = new[] { startupStub };
+
+            _Bootstrapper.Initialise();
+
+            _Bootstrapper.TypeRegistrations.ShouldBeSameAs(typeRegistrations);
+        }
+
+        [Fact]
+        public void Should_register_startup_task_collection_registrations_into_container()
+        {
+            var collectionTypeRegistrations = new CollectionTypeRegistration[] { };
+            var startupStub = A.Fake<IStartup>();
+            A.CallTo(() => startupStub.CollectionTypeRegistrations).Returns(collectionTypeRegistrations);
+            _Bootstrapper.OverriddenStartupTasks = new[] { startupStub };
+
+            _Bootstrapper.Initialise();
+
+            _Bootstrapper.CollectionTypeRegistrations.ShouldBeSameAs(collectionTypeRegistrations);
+        }
+
+        [Fact]
+        public void Should_register_startup_task_instance_registrations_into_container()
+        {
+            var instanceRegistrations = new InstanceRegistration[] { };
+            var startupStub = A.Fake<IStartup>();
+            A.CallTo(() => startupStub.InstanceRegistrations).Returns(instanceRegistrations);
+            _Bootstrapper.OverriddenStartupTasks = new[] { startupStub };
+
+            _Bootstrapper.Initialise();
+
+            _Bootstrapper.InstanceRegistrations.ShouldBeSameAs(instanceRegistrations);
         }
 
         [Fact]

--- a/src/Nancy.Tests/Unit/ViewEngines/ViewEngineStartupFixture.cs
+++ b/src/Nancy.Tests/Unit/ViewEngines/ViewEngineStartupFixture.cs
@@ -28,7 +28,7 @@ namespace Nancy.Tests.Unit.ViewEngines
             var startup = new ViewEngineStartup(engines, this.viewLocationCache, this.viewCache);
 
             // When
-            startup.Initialize();
+            startup.Initialize(null);
 
             // Then
             A.CallTo(() => engines[0].Initialize(A<ViewEngineStartupContext>.Ignored)).MustHaveHappened();
@@ -43,7 +43,7 @@ namespace Nancy.Tests.Unit.ViewEngines
             var startup = new ViewEngineStartup(engines, this.viewLocationCache, this.viewCache);
 
             // When
-            startup.Initialize();
+            startup.Initialize(null);
 
             // Then
             A.CallTo(() => engines[0].Initialize(A<ViewEngineStartupContext>.That.Matches(x => x.ViewCache.Equals(this.viewCache)))).MustHaveHappened();
@@ -65,7 +65,7 @@ namespace Nancy.Tests.Unit.ViewEngines
             var startup = new ViewEngineStartup(engines, this.viewLocationCache, this.viewCache);
 
             // When
-            startup.Initialize();
+            startup.Initialize(null);
 
             // Then
             A.CallTo(() => engines[0].Initialize(A<ViewEngineStartupContext>.That.Matches(x => x.ViewLocationResults.Count().Equals(2)))).MustHaveHappened();

--- a/src/Nancy/Bootstrapper/IStartup.cs
+++ b/src/Nancy/Bootstrapper/IStartup.cs
@@ -1,13 +1,30 @@
 namespace Nancy.Bootstrapper
 {
+    using System.Collections.Generic;
+
     /// <summary>
-    /// Provides a hook to execute code during initialisation
+    /// Provides a hook to execute code and register types during initialisation
     /// </summary>
     public interface IStartup
     {
         /// <summary>
+        /// Gets the type registrations to register for this startup task`
+        /// </summary>
+        IEnumerable<TypeRegistration> TypeRegistrations{ get; }
+
+        /// <summary>
+        /// Gets the collection registrations to register for this startup task
+        /// </summary>
+        IEnumerable<CollectionTypeRegistration> CollectionTypeRegistrations { get; }
+
+        /// <summary>
+        /// Gets the instance registrations to register for this startup task
+        /// </summary>
+        IEnumerable<InstanceRegistration> InstanceRegistrations { get; }
+
+        /// <summary>
         /// Perform any initialisation tasks
         /// </summary>
-        void Initialize();
+        void Initialize(IApplicationPipelines pipelines);
     }
 }

--- a/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
+++ b/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
@@ -235,13 +235,28 @@
             this.RegisterCollectionTypes(this.ApplicationContainer, this.GetApplicationCollections());
             this.RegisterModules(this.ApplicationContainer, this.Modules);
             this.RegisterInstances(this.ApplicationContainer, this.Conventions.GetInstanceRegistrations());
-            
-            this.InitialiseInternal(this.ApplicationContainer);
 
             foreach (var startupTask in this.GetStartupTasks())
             {
-                startupTask.Initialize();
+                startupTask.Initialize(this);
+
+                if (startupTask.TypeRegistrations != null)
+                {
+                    this.RegisterTypes(this.ApplicationContainer, startupTask.TypeRegistrations);
+                }
+
+                if (startupTask.CollectionTypeRegistrations != null)
+                {
+                    this.RegisterCollectionTypes(this.ApplicationContainer, startupTask.CollectionTypeRegistrations);
+                }
+
+                if (startupTask.InstanceRegistrations != null)
+                {
+                    this.RegisterInstances(this.ApplicationContainer, startupTask.InstanceRegistrations);
+                }
             }
+
+            this.InitialiseInternal(this.ApplicationContainer);
 
             if (this.DefaultFavIcon != null)
             {

--- a/src/Nancy/ViewEngines/ViewEngineStartup.cs
+++ b/src/Nancy/ViewEngines/ViewEngineStartup.cs
@@ -17,7 +17,31 @@ namespace Nancy.ViewEngines
             this.viewCache = viewCache;
         }
 
-        public void Initialize()
+        /// <summary>
+        /// Gets the type registrations to register for this startup task`
+        /// </summary>
+        public IEnumerable<TypeRegistration> TypeRegistrations
+        {
+            get { return null; }
+        }
+
+        /// <summary>
+        /// Gets the collection registrations to register for this startup task
+        /// </summary>
+        public IEnumerable<CollectionTypeRegistration> CollectionTypeRegistrations
+        {
+            get { return null; }
+        }
+
+        /// <summary>
+        /// Gets the instance registrations to register for this startup task
+        /// </summary>
+        public IEnumerable<InstanceRegistration> InstanceRegistrations
+        {
+            get { return null; }
+        }
+
+        public void Initialize(IApplicationPipelines pipelines)
         {
             foreach (var viewEngine in viewEngines)
             {


### PR DESCRIPTION
Now IStartup is passed in the application pipelines so they can be modified, and can also set 3 properties to get types, collections and instances registered into the container.
