### PR TITLE
Using partial method in Razor template causes RuntimeBinderException exception

### DIFF
--- a/src/Nancy.ViewEngines.Razor.Tests/RazorViewCompilerFixture.cs
+++ b/src/Nancy.ViewEngines.Razor.Tests/RazorViewCompilerFixture.cs
@@ -49,5 +49,35 @@
             // Then
             stream.ShouldEqual("<h1>Hello Mr. test</h1>");
         }
+
+        [Fact]
+        public void Should_be_able_to_render_view_with_partial_to_stream()
+        {
+            // Given
+            var location = new ViewLocationResult(
+                string.Empty,
+                string.Empty,
+                "cshtml",
+                () => new StringReader(@"@{var x = ""test"";}<h1>Hello Mr. @x</h1> @Html.Partial(""partial.cshtml"")")
+            );
+
+            var partialLocation = new ViewLocationResult(
+                string.Empty,
+                "partial.cshtml",
+                "cshtml",
+                () => new StringReader(@"this is partial")
+            );
+
+            A.CallTo(() => this.renderContext.LocateView("partial.cshtml",null)).Returns(partialLocation);
+
+            var stream = new MemoryStream();
+
+            // When
+            var response = this.engine.RenderView(location, null,this.renderContext);
+            response.Contents.Invoke(stream);
+
+            // Then
+            stream.ShouldEqual("<h1>Hello Mr. test</h1> this is partial");
+        }
     }
 }

--- a/src/Nancy.ViewEngines.Razor/HtmlHelpers.cs
+++ b/src/Nancy.ViewEngines.Razor/HtmlHelpers.cs
@@ -29,7 +29,8 @@
         {
             ViewLocationResult view = this.renderContext.LocateView(viewName, model);
 
-            Action<Stream> action = this.engine.RenderView(view, model, this.renderContext);
+            Response response = this.engine.RenderView(view, model, this.renderContext);
+            Action<Stream> action = response.Contents;
             var mem = new MemoryStream();
 
             action.Invoke(mem);


### PR DESCRIPTION
When you try to use partial view in Razor template (by @Html.Partial statement) the Microsoft.CSharp.RuntimeBinder.RuntimeBinderException is thrown in Partial method in HtmlHelpers class.

Exception details:
Microsoft.CSharp.RuntimeBinder.RuntimeBinderException was unhandled by user code
  Message=Cannot implicitly convert type 'Nancy.Responses.HtmlResponse' to 'System.Action<System.IO.Stream>'
  Source=Anonymously Hosted DynamicMethods Assembly
