### PR TITLE
Basic auth for api

### DIFF
--- a/src/Nancy.Authentication.Basic.Tests/BasicAuthenticationFixture.cs
+++ b/src/Nancy.Authentication.Basic.Tests/BasicAuthenticationFixture.cs
@@ -13,13 +13,13 @@
     public class BasicAuthenticationFixture
     {
         private readonly BasicAuthenticationConfiguration config;
-        private readonly BasicAuthenticationConfiguration noPromptConfig;
         private readonly IApplicationPipelines hooks;
+        const string ajaxRequestHeaderKey = "X-Requested-With";
+        const string ajaxRequestHeaderValue = "XMLHttpRequest";
 
         public BasicAuthenticationFixture()
         {
-            this.config = new BasicAuthenticationConfiguration(A.Fake<IUserValidator>(), "realm");
-            this.noPromptConfig = new BasicAuthenticationConfiguration(A.Fake<IUserValidator>(), "realm", false);
+            this.config = new BasicAuthenticationConfiguration(A.Fake<IUserValidator>(), "realm", UserPromptBehaviour.Always);
             this.hooks = new FakeApplicationPipelines();
             BasicAuthentication.Enable(this.hooks, this.config);
         }
@@ -41,21 +41,6 @@
         }
 
         [Fact]
-        public void Should_not_add_a_post_hook_in_application_when_promptuser_disabled() {
-            // Given
-            var pipelines = A.Fake<IApplicationPipelines>();
-
-            // When
-            BasicAuthentication.Enable(pipelines, this.noPromptConfig);
-
-            // Then
-            A.CallTo(() => pipelines.BeforeRequest.AddItemToStartOfPipeline(A<Func<NancyContext, Response>>.Ignored))
-                .MustHaveHappened(Repeated.Exactly.Once);
-            A.CallTo(() => pipelines.AfterRequest.AddItemToEndOfPipeline(A<Action<NancyContext>>.Ignored))
-                .MustNotHaveHappened();
-        }
-
-        [Fact]
         public void Should_add_both_basic_and_requires_auth_pre_and_post_hooks_in_module_when_enabled()
         {
             // Given
@@ -67,19 +52,6 @@
             // Then
             module.Before.PipelineDelegates.ShouldHaveCount(2);
             module.After.PipelineDelegates.ShouldHaveCount(1);
-        }
-
-        [Fact]
-        public void Should_not_add_auth_post_hooks_in_module_when_promptuser_disabled() {
-            // Given
-            var module = new FakeModule();
-
-            // When
-            BasicAuthentication.Enable(module, this.noPromptConfig);
-
-            // Then
-            module.Before.PipelineDelegates.ShouldHaveCount(2);
-            module.After.PipelineDelegates.ShouldHaveCount(0);
         }
 
         [Fact]
@@ -141,6 +113,75 @@
             context.Response.Headers["WWW-Authenticate"].ShouldContain("Basic");
             context.Response.Headers["WWW-Authenticate"].ShouldContain("realm=\"" + this.config.Realm + "\"");
         }
+
+        [Fact]
+        public void Post_request_hook_should_not_return_a_challenge_when_set_to_never()
+        {
+            // Given
+            var config = new BasicAuthenticationConfiguration(A.Fake<IUserValidator>(), "realm", UserPromptBehaviour.Never);
+            var hooks = new FakeApplicationPipelines();
+            BasicAuthentication.Enable(hooks, config);
+
+            var context = new NancyContext()
+            {
+                Request = new FakeRequest("GET", "/")
+            };
+
+            context.Response = new Response { StatusCode = HttpStatusCode.Unauthorized };
+
+            // When
+            hooks.AfterRequest.Invoke(context);
+
+            // Then
+            context.Response.Headers.ContainsKey("WWW-Authenticate").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Post_request_hook_should_not_return_a_challenge_on_an_ajax_request_when_set_to_nonajax()
+        {
+            // Given
+            var config = new BasicAuthenticationConfiguration(A.Fake<IUserValidator>(), "realm", UserPromptBehaviour.NonAjax);
+            var hooks = new FakeApplicationPipelines();
+            BasicAuthentication.Enable(hooks, config);
+            var headers = new Dictionary<string,IEnumerable<string>>();
+            headers.Add(ajaxRequestHeaderKey, new [] { ajaxRequestHeaderValue });
+
+            var context = new NancyContext()
+            {
+                Request = new FakeRequest("GET", "/", headers)
+            };
+
+            context.Response = new Response { StatusCode = HttpStatusCode.Unauthorized };
+
+            // When
+            hooks.AfterRequest.Invoke(context);
+
+            // Then
+            context.Response.Headers.ContainsKey("WWW-Authenticate").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Post_request_hook_should_return_a_challenge_on_a_nonajax_request_when_set_to_nonajax()
+        {
+            // Given
+            var config = new BasicAuthenticationConfiguration(A.Fake<IUserValidator>(), "realm", UserPromptBehaviour.NonAjax);
+            var hooks = new FakeApplicationPipelines();
+            BasicAuthentication.Enable(hooks, config);
+
+            var context = new NancyContext()
+            {
+                Request = new FakeRequest("GET", "/")
+            };
+
+            context.Response = new Response { StatusCode = HttpStatusCode.Unauthorized };
+
+            // When
+            hooks.AfterRequest.Invoke(context);
+
+            // Then
+            context.Response.Headers.ContainsKey("WWW-Authenticate").ShouldBeTrue();
+        }
+
 
         [Fact]
         public void Pre_request_hook_should_not_set_auth_details_when_invalid_scheme_in_auth_header()

--- a/src/Nancy.Authentication.Basic/BasicAuthenticationConfiguration.cs
+++ b/src/Nancy.Authentication.Basic/BasicAuthenticationConfiguration.cs
@@ -15,8 +15,8 @@ namespace Nancy.Authentication.Basic
         /// </summary>
         /// <param name="userValidator">A valid instance of <see cref="IUserValidator"/> class</param>
         /// <param name="realm">Basic authentication realm</param>
-        /// <param name="promptUser">Tell the browser to prompt the user for credentials</param>
-        public BasicAuthenticationConfiguration(IUserValidator userValidator, string realm, bool promptUser = true)
+        /// <param name="userPromptBehaviour">Control when the browser should be instructed to prompt for credentials</param>
+        public BasicAuthenticationConfiguration(IUserValidator userValidator, string realm, UserPromptBehaviour userPromptBehaviour = Basic.UserPromptBehaviour.NonAjax)
         {
             if (userValidator == null)
                 throw new ArgumentNullException("userValidator");
@@ -26,7 +26,7 @@ namespace Nancy.Authentication.Basic
 
             this.UserValidator = userValidator;
             this.Realm = realm;
-            this.PromptUser = promptUser;
+            this.UserPromptBehaviour = userPromptBehaviour;
         }
 
         /// <summary>
@@ -48,12 +48,33 @@ namespace Nancy.Authentication.Basic
         }
 
         /// <summary>
-        /// Determines whether the browser should prompt for credentials
+        /// Determines when the browser should prompt the user for credentials
         /// </summary>
-        public bool PromptUser
+        public UserPromptBehaviour UserPromptBehaviour
         {
             get;
             private set;
         }
+    }
+
+    /// <summary>
+    /// Options to control when the browser prompts the user for credentials
+    /// </summary>
+    public enum UserPromptBehaviour
+    {
+        /// <summary>
+        /// Never present user with login prompt
+        /// </summary>
+        Never,
+        
+        /// <summary>
+        /// Always present user with login prompt
+        /// </summary>
+        Always,
+
+        /// <summary>
+        /// Only prompt the user for credentials on non-ajax requests
+        /// </summary>
+        NonAjax
     }
 }


### PR DESCRIPTION
Added an option to the Basic Authentication plugin to stop it sending back the WWW-Authenticate header which prompts the browser to pop up a login dialog.

This popup is no good for ajax requests to a REST API.

Second commit reformats the class as it was indented with tabs instead of the spaces I saw through the rest of the project. I have done this as a seperate commit to help isolate the real changes to the file in the first commit. Hope that helps.
