### PR TITLE
Request.Url.HostName is was set to the hostname of the client, rather tha

### DIFF
--- a/src/Nancy.Hosting.Aspnet/NancyHandler.cs
+++ b/src/Nancy.Hosting.Aspnet/NancyHandler.cs
@@ -34,7 +34,7 @@ namespace Nancy.Hosting.Aspnet
             var nancyUrl = new Url
                                {
                                    Scheme = context.Request.Url.Scheme,
-                                   HostName = context.Request.UserHostName,
+                                   HostName = context.Url.Host,
                                    Port = context.Request.Url.Port,
                                    BasePath = context.Request.ApplicationPath.TrimEnd('/'),
                                    Path = context.Request.AppRelativeCurrentExecutionFilePath.Replace("~", string.Empty),


### PR DESCRIPTION
Request.Url.HostName is was set to the hostname of the client, rather than the hostname in the request url as expected.
Should address issue #354
