### PR TITLE
Removed url decoding in route matcher

### DIFF
--- a/src/Nancy.Tests/Unit/Routing/DefaultRoutePatternMatcherFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/DefaultRoutePatternMatcherFixture.cs
@@ -118,14 +118,13 @@ namespace Nancy.Tests.Unit.Routing
         }
 
         [Fact]
-        public void Should_properly_handle_uri_escaped_route_parameters_that_were_matched()
+        public void Should_not_url_decode_captured_parameters()
         {
             // Given
-            const string parameter = "baa ram ewe{}";
-            var escapedParameter = Uri.EscapeUriString(parameter);
+            var parameter = Uri.EscapeUriString("baa ram ewe{}");
             
             // When
-            var results = this.matcher.Match("/foo/" + escapedParameter, "/foo/{bar}");
+            var results = this.matcher.Match("/foo/" + parameter, "/foo/{bar}");
 
             //Then
             ((string)results.Parameters["bar"]).ShouldEqual(parameter);

--- a/src/Nancy/Routing/DefaultRoutePatternMatcher.cs
+++ b/src/Nancy/Routing/DefaultRoutePatternMatcher.cs
@@ -6,7 +6,6 @@
     using System.Globalization;
     using System.Text.RegularExpressions;
     using Nancy.Extensions;
-    using Nancy.Helpers;
 
     /// <summary>
     /// Default implementation of a route pattern matcher.
@@ -17,10 +16,14 @@
 
         public IRoutePatternMatchResult Match(string requestedPath, string routePath)
         {
-            var routePathPattern = this.matcherCache.GetOrAdd(routePath, (s) => BuildRegexMatcher(routePath));
+            var routePathPattern = 
+                this.matcherCache.GetOrAdd(routePath, s => BuildRegexMatcher(routePath));
 
-            requestedPath = TrimTrailingSlashFromRequestedPath(requestedPath);
-            var match = routePathPattern.Match(HttpUtility.UrlDecode(requestedPath));
+            requestedPath = 
+                TrimTrailingSlashFromRequestedPath(requestedPath);
+
+            var match = 
+                routePathPattern.Match(requestedPath);
 
             return new RoutePatternMatchResult(
                 match.Success,
@@ -55,9 +58,9 @@
         {
             dynamic data = new DynamicDictionary();
 
-            for (int i = 1; i <= groups.Count; i++)
+            for (var i = 1; i <= groups.Count; i++)
             {
-                data[regex.GroupNameFromNumber(i)] = Uri.UnescapeDataString(groups[i].Value);
+                data[regex.GroupNameFromNumber(i)] = groups[i].Value;
             }
 
             return data;


### PR DESCRIPTION
The responsibility for making sure that the route is URL decoded is
now moved to the individual hosts. We are going to assume that a
host creates the Nancy Request with a URL decoded.

Resolves issue #351
