### PR TITLE
Made NancyContext available on IResponseFormatter

### DIFF
--- a/src/Nancy.Testing/ConfigurableBootstrapper.cs
+++ b/src/Nancy.Testing/ConfigurableBootstrapper.cs
@@ -627,26 +627,26 @@ namespace Nancy.Testing
             }
 
             /// <summary>
-            /// Configures the bootstrapper to use the provided instance of <see cref="IResponseFormatter"/>.
+            /// Configures the bootstrapper to use the provided instance of <see cref="IResponseFormatterFactory"/>.
             /// </summary>
-            /// <param name="responseFormatter">The <see cref="IResponseFormatter"/> instance that should be used by the bootstrapper.</param>
+            /// <param name="responseFormatterFactory">The <see cref="IResponseFormatterFactory"/> instance that should be used by the bootstrapper.</param>
             /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ResponseFormatter(IResponseFormatter responseFormatter)
+            public ConfigurableBoostrapperConfigurator ResponseFormatterFactory(IResponseFormatterFactory responseFormatterFactory)
             {
                 this.bootstrapper.registeredInstances.Add(
-                    new InstanceRegistration(typeof(IResponseFormatter), responseFormatter));
+                    new InstanceRegistration(typeof(IResponseFormatterFactory), responseFormatterFactory));
 
                 return this;
             }
 
             /// <summary>
-            /// Configures the bootstrapper to create an <see cref="IResponseFormatter"/> instance of the specified type.
+            /// Configures the bootstrapper to create an <see cref="IResponseFormatterFactory"/> instance of the specified type.
             /// </summary>
-            /// <typeparam name="T">The type of the <see cref="IResponseFormatter"/> that the bootstrapper should use.</typeparam>
+            /// <typeparam name="T">The type of the <see cref="IResponseFormatterFactory"/> that the bootstrapper should use.</typeparam>
             /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ResponseFormatter<T>() where T : IResponseFormatter
+            public ConfigurableBoostrapperConfigurator ResponseFormatterFactory<T>() where T : IResponseFormatterFactory
             {
-                this.bootstrapper.configuration.ResponseFormatter = typeof(T);
+                this.bootstrapper.configuration.ResponseFormatterFactory = typeof(T);
                 return this;
             }
 

--- a/src/Nancy.Tests/Nancy.Tests.csproj
+++ b/src/Nancy.Tests/Nancy.Tests.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Fakes\Person.cs" />
     <Compile Include="Fakes\ViewModel.cs" />
     <Compile Include="Unit\Conventions\DefaultStaticContentsConventionsFixture.cs" />
+    <Compile Include="Unit\DefaultResponseFormatterFactoryFixture.cs" />
     <Compile Include="Unit\ErrorHandling\DefaultErrorHandlerFixture.cs" />
     <Compile Include="Unit\MimeTypesFixture.cs" />
     <Compile Include="Unit\NamedPipelineBaseFixture.cs" />

--- a/src/Nancy.Tests/Unit/DefaultResponseFormatterFactoryFixture.cs
+++ b/src/Nancy.Tests/Unit/DefaultResponseFormatterFactoryFixture.cs
@@ -1,0 +1,42 @@
+﻿namespace Nancy.Tests.Unit
+{
+    using FakeItEasy;
+    using Xunit;
+
+    public class DefaultResponseFormatterFactoryFixture
+    {
+        private readonly IRootPathProvider rootPathProvider;
+        private readonly DefaultResponseFormatterFactory factory;
+
+        public DefaultResponseFormatterFactoryFixture()
+        {
+            this.rootPathProvider = A.Fake<IRootPathProvider>();
+            A.CallTo(() => this.rootPathProvider.GetRootPath()).Returns("RootPath");
+
+            this.factory = new DefaultResponseFormatterFactory(this.rootPathProvider);
+        }
+
+        [Fact]
+        public void Should_create_response_formatter_with_root_path_set()
+        {
+            // Given, When
+            var formatter = this.factory.Create(null);
+
+            // Then
+            formatter.RootPath.ShouldEqual("RootPath");
+        }
+
+        [Fact]
+        public void Should_create_response_formatter_with_context_set()
+        {
+            // Given
+            var context = new NancyContext();
+
+            // When
+            var formatter = this.factory.Create(context);
+
+            // Then
+            formatter.Context.ShouldBeSameAs(context);
+        }
+    }
+}

--- a/src/Nancy.Tests/Unit/DefaultResponseFormatterFixture.cs
+++ b/src/Nancy.Tests/Unit/DefaultResponseFormatterFixture.cs
@@ -11,13 +11,26 @@ namespace Nancy.Tests.Unit
             // Given
             var rootPathProvider = A.Fake<IRootPathProvider>();
             A.CallTo(() => rootPathProvider.GetRootPath()).Returns("foo");
-            var formatter = new DefaultResponseFormatter(rootPathProvider);
+            var formatter = new DefaultResponseFormatter(rootPathProvider, null);
 
             // When
             var result = formatter.RootPath;
 
             // Then
             result.ShouldEqual("foo");
+        }
+
+        [Fact]
+        public void Should_return_context_that_was_used_when_creating_instance()
+        {
+            // Given
+            var context = new NancyContext();
+
+            // When
+            var formatter = new DefaultResponseFormatter(null, context);
+
+            // Then
+            formatter.Context.ShouldBeSameAs(context);
         }
     }
 }

--- a/src/Nancy.Tests/Unit/XmlFormatterExtensionsFixtures.cs
+++ b/src/Nancy.Tests/Unit/XmlFormatterExtensionsFixtures.cs
@@ -17,7 +17,10 @@ namespace Nancy.Tests.Unit
         public XmlFormatterExtensionsFixtures()
         {
             this.rootPathProvider = A.Fake<IRootPathProvider>();
-            this.responseFormatter = new DefaultResponseFormatter(this.rootPathProvider);
+            
+            this.responseFormatter = 
+                new DefaultResponseFormatter(this.rootPathProvider, new NancyContext());
+
             this.model = new Person { FirstName = "Andy", LastName = "Pike" };
             this.response = this.responseFormatter.AsXml(model);
         }

--- a/src/Nancy/Bootstrapper/NancyInternalConfiguration.cs
+++ b/src/Nancy/Bootstrapper/NancyInternalConfiguration.cs
@@ -37,7 +37,7 @@ namespace Nancy.Bootstrapper
                         ViewLocator = typeof(DefaultViewLocator),
                         ViewFactory = typeof(DefaultViewFactory),
                         NancyModuleBuilder = typeof(DefaultNancyModuleBuilder),
-                        ResponseFormatter = typeof(DefaultResponseFormatter),
+                        ResponseFormatterFactory = typeof(DefaultResponseFormatterFactory),
                         ModelBinderLocator = typeof(DefaultModelBinderLocator),
                         Binder = typeof(DefaultBinder),
                         BindingDefaults = typeof(BindingDefaults),
@@ -75,7 +75,7 @@ namespace Nancy.Bootstrapper
 
         public Type NancyModuleBuilder { get; set; }
 
-        public Type ResponseFormatter { get; set; }
+        public Type ResponseFormatterFactory { get; set; }
 
         public Type ModelBinderLocator { get; set; }
 
@@ -153,7 +153,7 @@ namespace Nancy.Bootstrapper
                 new TypeRegistration(typeof(IViewFactory), this.ViewFactory),
                 new TypeRegistration(typeof(INancyContextFactory), this.ContextFactory),
                 new TypeRegistration(typeof(INancyModuleBuilder), this.NancyModuleBuilder),
-                new TypeRegistration(typeof(IResponseFormatter), this.ResponseFormatter),
+                new TypeRegistration(typeof(IResponseFormatterFactory), this.ResponseFormatterFactory),
                 new TypeRegistration(typeof(IModelBinderLocator), this.ModelBinderLocator), 
                 new TypeRegistration(typeof(IBinder), this.Binder), 
                 new TypeRegistration(typeof(BindingDefaults), this.BindingDefaults), 

--- a/src/Nancy/DefaultResponseFormatter.cs
+++ b/src/Nancy/DefaultResponseFormatter.cs
@@ -1,23 +1,37 @@
 ﻿namespace Nancy
 {
+    using System;
+
     /// <summary>
     /// The default implementation of the <see cref="IResponseFormatter"/> interface.
     /// </summary>
     public class DefaultResponseFormatter : IResponseFormatter
     {
         private readonly IRootPathProvider rootPathProvider;
+        private readonly NancyContext context;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultResponseFormatter"/> class.
         /// </summary>
         /// <param name="rootPathProvider">The <see cref="IRootPathProvider"/> that should be used by the instance.</param>
-        public DefaultResponseFormatter(IRootPathProvider rootPathProvider)
+        /// <param name="context">The <see cref="NancyContext"/> that should be used by the instance.</param>
+        public DefaultResponseFormatter(IRootPathProvider rootPathProvider, NancyContext context)
         {
             this.rootPathProvider = rootPathProvider;
+            this.context = context;
         }
 
         /// <summary>
-        /// Gets root path of the Nancy application.
+        /// Gets the context for which the response is being formatted.
+        /// </summary>
+        /// <value>A <see cref="NancyContext"/> intance.</value>
+        public NancyContext Context
+        {
+            get { return this.context; }
+        }
+
+        /// <summary>
+        /// Gets the root path of the application.
         /// </summary>
         /// <value>A <see cref="string"/> containing the root path.</value>
         public string RootPath

--- a/src/Nancy/DefaultResponseFormatterFactory.cs
+++ b/src/Nancy/DefaultResponseFormatterFactory.cs
@@ -1,0 +1,30 @@
+﻿namespace Nancy
+{
+    /// <summary>
+    /// The default implementation of the <see cref="IResponseFormatterFactory"/> interface.
+    /// </summary>
+    public class DefaultResponseFormatterFactory : IResponseFormatterFactory
+    {
+        private readonly IRootPathProvider rootPathProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultResponseFormatter"/> class, with the
+        /// provided <see cref="IRootPathProvider"/>.
+        /// </summary>
+        /// <param name="rootPathProvider"></param>
+        public DefaultResponseFormatterFactory(IRootPathProvider rootPathProvider)
+        {
+            this.rootPathProvider = rootPathProvider;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="IResponseFormatter"/> instance.
+        /// </summary>
+        /// <param name="context">The <see cref="NancyContext"/> instance that should be used by the response formatter.</param>
+        /// <returns>An <see cref="IResponseFormatter"/> instance.</returns>
+        public IResponseFormatter Create(NancyContext context)
+        {
+            return new DefaultResponseFormatter(this.rootPathProvider, context);
+        }
+    }
+}

--- a/src/Nancy/IResponseFormatter.cs
+++ b/src/Nancy/IResponseFormatter.cs
@@ -6,6 +6,16 @@
     /// <remarks>Extension methods to this interface should always return <see cref="Response"/> or one of the types that can implicitly be types into a <see cref="Response"/>.</remarks>
     public interface IResponseFormatter : IHideObjectMembers
     {
+        /// <summary>
+        /// Gets the context for which the response is being formatted.
+        /// </summary>
+        /// <value>A <see cref="NancyContext"/> intance.</value>
+        NancyContext Context { get; }
+
+        /// <summary>
+        /// Gets the root path of the application.
+        /// </summary>
+        /// <value>A <see cref="string"/> containing the root path.</value>
         string RootPath { get; }
     }
 }

--- a/src/Nancy/IResponseFormatterFactory.cs
+++ b/src/Nancy/IResponseFormatterFactory.cs
@@ -1,0 +1,15 @@
+﻿namespace Nancy
+{
+    /// <summary>
+    /// Defines the functionality of a <see cref="IResponseFormatter"/> factory.
+    /// </summary>
+    public interface IResponseFormatterFactory
+    {
+        /// <summary>
+        /// Creates a new <see cref="IResponseFormatter"/> instance.
+        /// </summary>
+        /// <param name="context">The <see cref="NancyContext"/> instance that should be used by the response formatter.</param>
+        /// <returns>An <see cref="IResponseFormatter"/> instance.</returns>
+        IResponseFormatter Create(NancyContext context);
+    }
+}

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -98,6 +98,8 @@
     <Compile Include="Conventions\IConvention.cs" />
     <Compile Include="Conventions\NancyConventions.cs" />
     <Compile Include="Conventions\StaticContentConventionBuilder.cs" />
+    <Compile Include="DefaultResponseFormatterFactory.cs" />
+    <Compile Include="IResponseFormatterFactory.cs" />
     <Compile Include="Responses\StreamResponse.cs" />
     <Compile Include="IO\UnclosableStreamWrapper.cs" />
     <Compile Include="ISerializer.cs" />

--- a/src/Nancy/Routing/DefaultNancyModuleBuilder.cs
+++ b/src/Nancy/Routing/DefaultNancyModuleBuilder.cs
@@ -9,19 +9,19 @@
     public class DefaultNancyModuleBuilder : INancyModuleBuilder
     {
         private readonly IViewFactory viewFactory;
-        private readonly IResponseFormatter responseFormatter;
+        private readonly IResponseFormatterFactory responseFormatterFactory;
         private readonly IModelBinderLocator modelBinderLocator;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultNancyModuleBuilder"/> class.
         /// </summary>
         /// <param name="viewFactory">The <see cref="IViewFactory"/> instance that should be assigned to the module.</param>
-        /// <param name="responseFormatter">An <see cref="DefaultResponseFormatter"/> instance that should be assigned to the module.</param>
+        /// <param name="responseFormatterFactory">An <see cref="IResponseFormatterFactory"/> instance that should be used to create a response formatter for the module.</param>
         /// <param name="modelBinderLocator">A <see cref="IModelBinderLocator"/> instance that should be assigned to the module.</param>
-        public DefaultNancyModuleBuilder(IViewFactory viewFactory, IResponseFormatter responseFormatter, IModelBinderLocator modelBinderLocator)
+        public DefaultNancyModuleBuilder(IViewFactory viewFactory, IResponseFormatterFactory responseFormatterFactory, IModelBinderLocator modelBinderLocator)
         {
             this.viewFactory = viewFactory;
-            this.responseFormatter = responseFormatter;
+            this.responseFormatterFactory = responseFormatterFactory;
             this.modelBinderLocator = modelBinderLocator;
         }
 
@@ -34,7 +34,7 @@
         public NancyModule BuildModule(NancyModule module, NancyContext context)
         {
             module.Context = context;
-            module.Response = this.responseFormatter;
+            module.Response = this.responseFormatterFactory.Create(context);
             module.ViewFactory = this.viewFactory;
             module.ModelBinderLocator = this.modelBinderLocator;
 


### PR DESCRIPTION
The current context is now available to response formatters. The new
IResponseFormatterFactory is exposed on the ConfigurableBootstrapper
and the IResponseFormatter configuration on the
NancyInternalConfiguration was replaced in favor of the factory.

Resolves issue #341
