### PR TITLE
Enumerable Dynamic Dictionary

### DIFF
--- a/src/Nancy.Tests/Unit/DynamicDictionaryFixture.cs
+++ b/src/Nancy.Tests/Unit/DynamicDictionaryFixture.cs
@@ -645,126 +645,126 @@ namespace Nancy.Tests.Unit
             value.ShouldEqual(10);
         }
 
-		[Fact]
-		public void Should_support_dynamic_casting_of_properties_to_ints()
-		{
-			//Given
-			dynamic parameters = new DynamicDictionary();
-			parameters.test = "10";
+        [Fact]
+        public void Should_support_dynamic_casting_of_properties_to_ints()
+        {
+            //Given
+            dynamic parameters = new DynamicDictionary();
+            parameters.test = "10";
 
-			// When
-			var value = (int)parameters.test;
+            // When
+            var value = (int)parameters.test;
 
-			// Then
-			value.ShouldEqual(10);
-		}
+            // Then
+            value.ShouldEqual(10);
+        }
 
-		[Fact]
-		public void Should_support_dynamic_casting_of_properties_to_guids()
-		{
-			//Given
-			dynamic parameters = new DynamicDictionary();
-			var guid = Guid.NewGuid();
-			parameters.test = guid.ToString();
+        [Fact]
+        public void Should_support_dynamic_casting_of_properties_to_guids()
+        {
+            //Given
+            dynamic parameters = new DynamicDictionary();
+            var guid = Guid.NewGuid();
+            parameters.test = guid.ToString();
 
-			// When
-			var value = (Guid)parameters.test;
+            // When
+            var value = (Guid)parameters.test;
 
-			// Then
-			value.ShouldEqual(guid);
-		}
-
-
-		[Fact]
-		public void Should_support_dynamic_casting_of_properties_to_timespans()
-		{
-			//Given
-			dynamic parameters = new DynamicDictionary();
-			parameters.test = new TimeSpan(1, 2, 3, 4).ToString();
-
-			// When
-			var value = (TimeSpan)parameters.test;
-
-			// Then
-			value.ShouldEqual(new TimeSpan(1, 2, 3, 4));
-		}
-
-		[Fact]
-		public void Should_support_dynamic_casting_of_properties_to_datetimes()
-		{
-			//Given
-			dynamic parameters = new DynamicDictionary();
-
-			parameters.test = new DateTime(2001, 3, 4);
-
-			// When
-			var value = (DateTime)parameters.test;
-
-			// Then
-			value.ShouldEqual(new DateTime(2001, 3, 4));
-		}
+            // Then
+            value.ShouldEqual(guid);
+        }
 
 
-		[Fact]
-		public void Should_support_dynamic_casting_of_nullable_properties()
-		{
-			//Given
-			dynamic parameters = new DynamicDictionary();
-			var guid = Guid.NewGuid();
-			parameters.test = guid.ToString();
+        [Fact]
+        public void Should_support_dynamic_casting_of_properties_to_timespans()
+        {
+            //Given
+            dynamic parameters = new DynamicDictionary();
+            parameters.test = new TimeSpan(1, 2, 3, 4).ToString();
 
-			// When
-			var value = (Guid?)parameters.test;
+            // When
+            var value = (TimeSpan)parameters.test;
 
-			// Then
-			value.ShouldEqual(guid);
-		}
+            // Then
+            value.ShouldEqual(new TimeSpan(1, 2, 3, 4));
+        }
 
-		[Fact]
-		public void Should_support_implicit_casting()
-		{
-			// Given
-			dynamic parameters = new DynamicDictionary();
+        [Fact]
+        public void Should_support_dynamic_casting_of_properties_to_datetimes()
+        {
+            //Given
+            dynamic parameters = new DynamicDictionary();
 
-			parameters.test = "10";
+            parameters.test = new DateTime(2001, 3, 4);
 
-			// When
-			int value = parameters.test;
+            // When
+            var value = (DateTime)parameters.test;
 
-			// Then
-			value.ShouldEqual(10);
-		}
+            // Then
+            value.ShouldEqual(new DateTime(2001, 3, 4));
+        }
 
-		[Fact]
-		public void Should_support_casting_when_using_indexer_to_set_values()
-		{
-			// Given
-			dynamic parameters = new DynamicDictionary();
 
-			parameters["test"] = "10";
+        [Fact]
+        public void Should_support_dynamic_casting_of_nullable_properties()
+        {
+            //Given
+            dynamic parameters = new DynamicDictionary();
+            var guid = Guid.NewGuid();
+            parameters.test = guid.ToString();
 
-			// When
-			int value = parameters.test;
+            // When
+            var value = (Guid?)parameters.test;
 
-			// Then
-			value.ShouldEqual(10);
-		}
+            // Then
+            value.ShouldEqual(guid);
+        }
 
-		[Fact]
-		public void Should_support_GetDynamicMemberNames()
-		{
-			// Given
-			dynamic parameters = new DynamicDictionary();
+        [Fact]
+        public void Should_support_implicit_casting()
+        {
+            // Given
+            dynamic parameters = new DynamicDictionary();
 
-			parameters["test"] = "10";
-			parameters["rest"] = "20";
+            parameters.test = "10";
 
-			// When
-			var names = ((DynamicDictionary) parameters).GetDynamicMemberNames();
+            // When
+            int value = parameters.test;
 
-			// Then
-			Assert.True(names.SequenceEqual(new[] {"test", "rest"}));
-		}
+            // Then
+            value.ShouldEqual(10);
+        }
+
+        [Fact]
+        public void Should_support_casting_when_using_indexer_to_set_values()
+        {
+            // Given
+            dynamic parameters = new DynamicDictionary();
+
+            parameters["test"] = "10";
+
+            // When
+            int value = parameters.test;
+
+            // Then
+            value.ShouldEqual(10);
+        }
+
+        [Fact]
+        public void Should_support_GetDynamicMemberNames()
+        {
+            // Given
+            dynamic parameters = new DynamicDictionary();
+
+            parameters["test"] = "10";
+            parameters["rest"] = "20";
+
+            // When
+            var names = ((DynamicDictionary)parameters).GetDynamicMemberNames();
+
+            // Then
+            Assert.True(names.SequenceEqual(new[] { "test", "rest" }));
+        }
 
         [Fact]
         public void Should_be_able_to_enumerate_keys()

--- a/src/Nancy/DynamicDictionary.cs
+++ b/src/Nancy/DynamicDictionary.cs
@@ -70,9 +70,9 @@
         /// </summary>
         /// <returns>A <see cref="IEnumerable{T}"/> that contains dynamic member names.</returns>
         public override IEnumerable<string> GetDynamicMemberNames()
-		{
-			return dictionary.Keys;
-		}
+        {
+            return dictionary.Keys;
+        }
 
         /// <summary>
         /// Returns the enumeration of all dynamic member names.


### PR DESCRIPTION
This change was prompted from my answer to this SO question
http://stackoverflow.com/questions/7919835/capture-all-url-segments-after-the-initial-match-with-nancy

I don't really like the GetDynamicMemberNames() call in that answer.

This commit allows you to simply foreach() the DynamicDictionary to get the names out.

```
foreach(var name in parameters) {
     parameters[name];
}
```

What do you think?

(Once again I have split commits between the actual changes, and then some formatting changes where I notice inconsistencies)
