### PR TITLE
Changed the behavior of the StreamResponse

### DIFF
--- a/src/Nancy.Tests/Unit/Responses/StreamResponseFixture.cs
+++ b/src/Nancy.Tests/Unit/Responses/StreamResponseFixture.cs
@@ -1,6 +1,8 @@
 ﻿namespace Nancy.Tests.Unit.Responses
 {
+    using System;
     using System.IO;
+    using FakeItEasy;
     using Nancy.Responses;
     using Xunit;
 
@@ -9,14 +11,69 @@
         [Fact]
         public void Should_copy_stream_to_output_when_body_invoked()
         {
-            var inputStream = new MemoryStream();
-            inputStream.Write(new byte[] { 1, 2, 3, 4, 5 }, 0, 5);
-            var response = new StreamResponse(() => inputStream, "test");
+            // Given
+            var streamContent =
+                new byte[] { 1, 2, 3, 4, 5 };
+
+            var inputStream =
+                new MemoryStream(streamContent);
+            
+            var response = 
+                new StreamResponse(() => inputStream, "test");
+            
             var outputStream = new MemoryStream();
 
+            // When
             response.Contents.Invoke(outputStream);
 
-            outputStream.ToArray().ShouldEqualSequence(new byte[] { 1, 2, 3, 4, 5 });
-        } 
+            // Then
+            outputStream.ToArray().ShouldEqualSequence(streamContent);
+        }
+
+        [Fact]
+        public void Should_return_content_of_stream_from_current_location_of_stream()
+        {
+            // Given
+            var streamContent =
+                new byte[] { 1, 2, 3, 4, 5 };
+
+            var inputStream =
+                new MemoryStream(streamContent) { Position = 2 };
+
+            var response =
+                new StreamResponse(() => inputStream, "test");
+
+            var outputStream = new MemoryStream();
+
+            var expectedContent =
+                new byte[] { 3, 4, 5 };
+
+            // When
+            response.Contents.Invoke(outputStream);
+
+            // Then
+            outputStream.ToArray().ShouldEqualSequence(expectedContent);
+        }
+
+        [Fact]
+        public void Should_throw_exception_when_stream_is_non_readable()
+        {
+            // Given
+            var inputStream =
+                A.Fake<Stream>();
+
+            A.CallTo(() => inputStream.CanRead).Returns(false);
+
+            var response =
+                new StreamResponse(() => inputStream, "test");
+
+            var outputStream = new MemoryStream();
+
+            // When
+            var exception = Record.Exception(() => response.Contents.Invoke(outputStream));
+
+            // Then
+            exception.ShouldNotBeNull();
+        }
     }
 }

--- a/src/Nancy/Responses/StreamResponse.cs
+++ b/src/Nancy/Responses/StreamResponse.cs
@@ -3,8 +3,17 @@
     using System;
     using System.IO;
 
+    /// <summary>
+    /// Response that returns the contents of a stream of a given content-type.
+    /// </summary>
     public class StreamResponse : Response
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StreamResponse"/> class with the
+        /// provided stream provider and content-type.
+        /// </summary>
+        /// <param name="source">The value producer for the response.</param>
+        /// <param name="contentType">The content-type of the stream contents.</param>
         public StreamResponse(Func<Stream> source, string contentType)
         {
             this.Contents = GetResponseBodyDelegate(source);
@@ -15,20 +24,12 @@
         private static Action<Stream> GetResponseBodyDelegate(Func<Stream> sourceDelegate)
         {
             return stream =>
+            {
+                using (var source = sourceDelegate.Invoke())
                 {
-                    using (var source = sourceDelegate.Invoke())
-                    {
-                        if (source.CanSeek)
-                        {
-                            source.Position = 0;
-                        }
-
-                        if (source.CanRead)
-                        {
-                            source.CopyTo(stream);
-                        }
-                    }
-                };
+                    source.CopyTo(stream);
+                }
+            };
         }
     }
 }


### PR DESCRIPTION
The StreamResponse will now throw an exception if the value stream can
not be read. It no longer repositions the stream at the beginning
before returning the contents, making it possible to return from the
current position of the value stream

Fixes issue #377
