### PR TITLE
Able to not scan certain assemblies for embedded views

### DIFF
--- a/src/Nancy.Tests/Unit/ViewEngines/ResourceViewLocationProviderFixture.cs
+++ b/src/Nancy.Tests/Unit/ViewEngines/ResourceViewLocationProviderFixture.cs
@@ -171,5 +171,47 @@ namespace Nancy.Tests.Unit.ViewEngines
             // Then
             result.First().Location.ShouldEqual("Path/With/Sub/Folder");
         }
+
+        [Fact]
+        public void Should_scan_assemblies_returned_by_assembly_provider()
+        {
+            // Given
+            A.CallTo(() => this.assemblyProvider.GetAssembliesToScan()).Returns(new[]
+            {
+                typeof(NancyEngine).Assembly,
+                this.GetType().Assembly
+            });
+
+            var extensions = new[] { "html" };
+
+            // When
+            this.viewProvider.GetLocatedViews(extensions).ToList();
+
+            // Then
+            A.CallTo(() => this.reader.GetResourceStreamMatches(this.GetType().Assembly, A<IEnumerable<string>>._)).MustHaveHappened();
+            A.CallTo(() => this.reader.GetResourceStreamMatches(typeof(NancyEngine).Assembly, A<IEnumerable<string>>._)).MustHaveHappened();
+        }
+
+        [Fact]
+        public void Should_not_scan_ignored_assemblies()
+        {
+            // Given
+            A.CallTo(() => this.assemblyProvider.GetAssembliesToScan()).Returns(new[]
+            {
+                typeof(NancyEngine).Assembly,
+                this.GetType().Assembly
+            });
+
+            ResourceViewLocationProvider.Ignore.Add(this.GetType().Assembly);
+
+            var extensions = new[] { "html" };
+
+            // When
+            this.viewProvider.GetLocatedViews(extensions).ToList();
+
+            // Then
+            A.CallTo(() => this.reader.GetResourceStreamMatches(this.GetType().Assembly, A<IEnumerable<string>>._)).MustNotHaveHappened();
+            A.CallTo(() => this.reader.GetResourceStreamMatches(typeof(NancyEngine).Assembly, A<IEnumerable<string>>._)).MustHaveHappened();
+        }
     }
 }

--- a/src/Nancy/ViewEngines/ResourceViewLocationProvider.cs
+++ b/src/Nancy/ViewEngines/ResourceViewLocationProvider.cs
@@ -13,7 +13,16 @@
     {
         private readonly IResourceReader resourceReader;
         private readonly IResourceAssemblyProvider resourceAssemblyProvider;
+        
+        /// <summary>
+        /// User-configured root namespaces for assemblies.
+        /// </summary>
         public static IDictionary<Assembly, string> RootNamespaces = new Dictionary<Assembly, string>();
+        
+        /// <summary>
+        /// A list of assemblies to ignore when scanning for embedded views.
+        /// </summary>
+        public static IList<Assembly> Ignore = new List<Assembly>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ResourceViewLocationProvider"/> class.
@@ -49,6 +58,7 @@
 
             return this.resourceAssemblyProvider
                 .GetAssembliesToScan()
+                .Where(x => !Ignore.Contains(x))
                 .SelectMany(x => GetViewLocations(x, supportedViewExtensions));
         }
 


### PR DESCRIPTION
The ResourceViewLocationProvider now supports an Ignore list which will
precent the provider from scanning the assemblies in the list.

Fixes issue #375
