### PR TITLE
Allow choice of redirect http status code

### DIFF
--- a/src/Nancy.Tests/Nancy.Tests.csproj
+++ b/src/Nancy.Tests/Nancy.Tests.csproj
@@ -168,6 +168,7 @@
     <Compile Include="Unit\DefaultResponseFormatterFixture.cs" />
     <Compile Include="Unit\RequestHeadersFixture.cs" />
     <Compile Include="Unit\ResponseExtensionsFixture.cs" />
+    <Compile Include="Unit\Responses\RedirectResponseFixture.cs" />
     <Compile Include="Unit\Responses\StreamResponseFixture.cs" />
     <Compile Include="Unit\Routing\DefaultNancyModuleBuilderFixture.cs" />
     <Compile Include="Unit\Routing\DefaultRouteCacheProviderFixture.cs" />

--- a/src/Nancy.Tests/Unit/Responses/RedirectResponseFixture.cs
+++ b/src/Nancy.Tests/Unit/Responses/RedirectResponseFixture.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+using Nancy.Responses;
+
+namespace Nancy.Tests.Unit.Responses
+{
+    public class RedirectResponseFixture
+    {
+        [Fact]
+        public void Permanent_redirect_should_return_status_code_301()
+        {
+            var response = new RedirectResponse("/", RedirectResponse.RedirectType.Permanent);
+            response.StatusCode.ShouldEqual(HttpStatusCode.MovedPermanently);
+        }
+
+        [Fact]
+        public void Temporary_redirect_should_return_status_code_307()
+        {
+            var response = new RedirectResponse("/", RedirectResponse.RedirectType.Temporary);
+            response.StatusCode.ShouldEqual(HttpStatusCode.TemporaryRedirect);
+        }
+
+        [Fact]
+        public void SeeOther_redirect_should_return_status_code_303()
+        {
+            var response = new RedirectResponse("/", RedirectResponse.RedirectType.SeeOther);
+            response.StatusCode.ShouldEqual(HttpStatusCode.SeeOther);
+        }
+
+        [Fact]
+        public void Default_redirect_should_return_status_code_303()
+        {
+            var response = new RedirectResponse("/");
+            response.StatusCode.ShouldEqual(HttpStatusCode.SeeOther);
+        }
+    }
+}

--- a/src/Nancy/FormatterExtensions.cs
+++ b/src/Nancy/FormatterExtensions.cs
@@ -45,9 +45,9 @@ namespace Nancy
             return new JsonResponse<TModel>(model, serializer);
         }
 
-        public static Response AsRedirect(this IResponseFormatter formatter, string location)
+        public static Response AsRedirect(this IResponseFormatter formatter, string location, Nancy.Responses.RedirectResponse.RedirectType type = RedirectResponse.RedirectType.SeeOther)
         {
-            return new RedirectResponse(formatter.Context.ToFullPath(location));
+            return new RedirectResponse(formatter.Context.ToFullPath(location), type);
         }
 
         public static Response AsXml<TModel>(this IResponseFormatter formatter, TModel model)

--- a/src/Nancy/Responses/RedirectResponse.cs
+++ b/src/Nancy/Responses/RedirectResponse.cs
@@ -1,7 +1,7 @@
 namespace Nancy.Responses
 {
     /// <summary>
-    /// A response representing a raw 303 redirect
+    /// A response representing an HTTP redirect
     /// <seealso cref="Nancy.Extensions.ContextExtensions.ToFullPath"/>
     /// <seealso cref="Nancy.Extensions.ContextExtensions.GetRedirect"/>
     /// </summary>
@@ -10,15 +10,44 @@ namespace Nancy.Responses
         /// <summary>
         /// Initializes a new instance of the <see cref="RedirectResponse"/> class. 
         /// </summary>
-        /// <param name="location">
-        /// Location to redirect to
-        /// </param>
-        public RedirectResponse(string location)
+        /// <param name="location">Location to redirect to</param>
+        /// <param name="type">Type of redirection to perform</param>
+        public RedirectResponse(string location, RedirectType type = RedirectType.SeeOther)
         {
             this.Headers.Add("Location", location);
             this.Contents = GetStringContents(string.Empty);
             this.ContentType = "text/html";
-            this.StatusCode = HttpStatusCode.SeeOther;
+            switch (type)
+            {
+                case RedirectType.Permanent:
+                    this.StatusCode = HttpStatusCode.MovedPermanently;
+                    break;
+                case RedirectType.Temporary:
+                    this.StatusCode = HttpStatusCode.TemporaryRedirect;
+                    break;
+                default:
+                    this.StatusCode = HttpStatusCode.SeeOther;
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Which type of redirect
+        /// </summary>
+        public enum RedirectType
+        {
+            /// <summary>
+            /// HTTP 301 - All future requests should be to this URL
+            /// </summary>
+            Permanent,
+            /// <summary>
+            /// HTTP 307 - Redirect this request but allow future requests to the original URL
+            /// </summary>
+            Temporary,
+            /// <summary>
+            /// HTTP 303 - Redirect this request using an HTTP GET
+            /// </summary>
+            SeeOther
         }
     }
 }


### PR DESCRIPTION
Added support to choose which type of http redirect is returned from a Response.AsRedirect()

My personal feel is that making this a parameter is simpler than creating multiple RedirectResponse classes.

I am not so happy with the name "SeeOther" but it is consistent with the HTTP spec and the /// comments hopefully help explain.

Default remains unchanged.
