### PR TITLE
Fixed exception calling IStartup.InstanceRegistrations

### DIFF
--- a/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
+++ b/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
@@ -216,7 +216,7 @@
             this.RegisterModules(this.ApplicationContainer, this.Modules);
             this.RegisterInstances(this.ApplicationContainer, instanceRegistrations);
 
-            foreach (var startupTask in this.GetStartupTasks())
+            foreach (var startupTask in this.GetStartupTasks().ToList())
             {
                 startupTask.Initialize(this.ApplicationPipelines);
 


### PR DESCRIPTION
I'm writing an IStartup class and implementing IStartup.InstanceRegistrations.  However, returning anything but null from this property throws an InvalidOperationException because the TinyIoC was modified while it was being enumerated (via GetStartupTasks()).

I simply added a .ToList() to GetStartupTasks() and all is well.
