### PR TITLE
Tweaked request container logic.

### DIFF
--- a/src/Nancy.Demo.Authentication.Forms/FormsAuthBootstrapper.cs
+++ b/src/Nancy.Demo.Authentication.Forms/FormsAuthBootstrapper.cs
@@ -2,6 +2,9 @@ namespace Nancy.Demo.Authentication.Forms
 {
     using Nancy;
     using Nancy.Authentication.Forms;
+    using Nancy.Bootstrapper;
+
+    using TinyIoC;
 
     public class FormsAuthBootstrapper : DefaultNancyBootstrapper
     {
@@ -11,9 +14,9 @@ namespace Nancy.Demo.Authentication.Forms
             // types/dependencies
         }
 
-        protected override void ConfigureRequestContainer(TinyIoC.TinyIoCContainer container)
+        protected override void ConfigureRequestContainer(TinyIoCContainer container, NancyContext context)
         {
-            base.ConfigureRequestContainer(container);
+            base.ConfigureRequestContainer(container, context);
 
             // Here we register our user mapper as a per-request singleton.
             // As this is now per-request we could inject a request scoped
@@ -21,7 +24,7 @@ namespace Nancy.Demo.Authentication.Forms
             container.Register<IUserMapper, UserDatabase>();
         }
 
-        protected override void RequestStartup(TinyIoC.TinyIoCContainer requestContainer, Bootstrapper.IPipelines pipelines)
+        protected override void RequestStartup(TinyIoCContainer requestContainer, IPipelines pipelines, NancyContext context)
         {
             // At request startup we modify the request pipelines to
             // include forms authentication - passing in our now request

--- a/src/Nancy.Demo.Hosting.Aspnet/DemoBootstrapper.cs
+++ b/src/Nancy.Demo.Hosting.Aspnet/DemoBootstrapper.cs
@@ -6,6 +6,8 @@
     using Nancy.Session;
     using Nancy.ViewEngines.Razor;
 
+    using TinyIoC;
+
     public class DemoBootstrapper : DefaultNancyBootstrapper
     {
         // Overriding this just to show how it works, not actually necessary as autoregister
@@ -18,9 +20,9 @@
             existingContainer.Register<IRazorConfiguration, MyRazorConfiguration>().AsSingleton();
         }
 
-        protected override void ConfigureRequestContainer(TinyIoC.TinyIoCContainer existingContainer)
+        protected override void ConfigureRequestContainer(TinyIoCContainer existingContainer, NancyContext context)
         {
-            base.ConfigureRequestContainer(existingContainer);
+            base.ConfigureRequestContainer(existingContainer, context);
 
             existingContainer.Register<IRequestDependency, RequestDependencyClass>().AsSingleton();
         }

--- a/src/Nancy.Tests/Fakes/FakeDefaultNancyBootstrapper.cs
+++ b/src/Nancy.Tests/Fakes/FakeDefaultNancyBootstrapper.cs
@@ -1,14 +1,33 @@
 ﻿namespace Nancy.Tests.Fakes
 {
+    using System.Collections.Generic;
+
     using Bootstrapper;
+
+    using TinyIoC;
 
     public class FakeDefaultNancyBootstrapper : DefaultNancyBootstrapper
     {
         private NancyInternalConfiguration configuration;
 
+        protected override System.Collections.Generic.IEnumerable<ModuleRegistration> Modules
+        {
+            get
+            {
+                return new[] { new ModuleRegistration(typeof(FakeNancyModuleWithoutBasePath), "Module") };
+            }
+        }
+        public FakeDefaultNancyBootstrapper()
+            : this(NancyInternalConfiguration.Default)
+        {
+            
+        }
+
         public FakeDefaultNancyBootstrapper(NancyInternalConfiguration configuration)
         {
             this.configuration = configuration;
+
+            this.RequestContainerInitialisations = new Dictionary<NancyContext, int>();
         }
 
         protected override NancyInternalConfiguration InternalConfiguration
@@ -16,20 +35,44 @@
             get { return configuration; }
         }
 
-        public bool RequestContainerConfigured { get; set; }
+        public IDictionary<NancyContext, int> RequestContainerInitialisations { get; private set; }
 
         public bool ApplicationContainerConfigured { get; set; }
 
         public TinyIoC.TinyIoCContainer Container { get { return this.ApplicationContainer; } }
 
-        protected override void ConfigureRequestContainer(TinyIoC.TinyIoCContainer existingContainer)
-        {
-            base.ConfigureRequestContainer(existingContainer);
+        public Request ConfigureRequestContainerLastRequest { get; set; }
 
-            RequestContainerConfigured = true;
+        public Request RequestStartupLastRequest { get; set; }
+
+        protected override void RequestStartup(TinyIoCContainer container, IPipelines pipelines, NancyContext context)
+        {
+            base.RequestStartup(container, pipelines, context);
+
+            this.RequestStartupLastRequest = context.Request;
+        }
+
+        protected override void ConfigureRequestContainer(TinyIoCContainer existingContainer, NancyContext context)
+        {
+            base.ConfigureRequestContainer(existingContainer, context);
+
+            this.ConfigureRequestContainerLastRequest = context.Request;
+
+            this.AddRequestContainerInitialisation(context);
 
             existingContainer.Register<IFoo, Foo>().AsSingleton();
             existingContainer.Register<IDependency, Dependency>().AsSingleton();
+        }
+
+        private void AddRequestContainerInitialisation(NancyContext context)
+        {
+            if (!this.RequestContainerInitialisations.ContainsKey(context))
+            {
+                this.RequestContainerInitialisations.Add(context, 1);
+                return;
+            }
+
+            this.RequestContainerInitialisations[context] = this.RequestContainerInitialisations[context] + 1;
         }
 
         protected override void ConfigureApplicationContainer(TinyIoC.TinyIoCContainer existingContainer)

--- a/src/Nancy.Tests/Nancy.Tests.csproj
+++ b/src/Nancy.Tests/Nancy.Tests.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Fakes\ViewModel.cs" />
     <Compile Include="Unit\Bootstrapper\PipelinesFixture.cs" />
     <Compile Include="Unit\Conventions\DefaultStaticContentsConventionsFixture.cs" />
+    <Compile Include="Unit\DefaultNancyBootstrapperFixture.cs" />
     <Compile Include="Unit\DefaultResponseFormatterFactoryFixture.cs" />
     <Compile Include="Unit\ErrorHandling\DefaultErrorHandlerFixture.cs" />
     <Compile Include="Unit\FormatterExtensionsFixture.cs" />

--- a/src/Nancy.Tests/Unit/DefaultNancyBootstrapperFixture.cs
+++ b/src/Nancy.Tests/Unit/DefaultNancyBootstrapperFixture.cs
@@ -1,0 +1,58 @@
+﻿namespace Nancy.Tests.Unit
+{
+    using System.Linq;
+
+    using Nancy.Tests.Fakes;
+
+    using Xunit;
+
+    public class DefaultNancyBootstrapperFixture
+    {
+        private readonly FakeDefaultNancyBootstrapper bootstrapper;
+
+        public DefaultNancyBootstrapperFixture()
+        {
+            this.bootstrapper = new FakeDefaultNancyBootstrapper();
+        }
+
+        [Fact]
+        public void Should_only_initialise_request_container_once_per_request()
+        {
+            this.bootstrapper.Initialise();
+            var engine = this.bootstrapper.GetEngine();
+            var request = new FakeRequest("GET", "/");
+            var request2 = new FakeRequest("GET", "/");
+
+            engine.HandleRequest(request);
+            engine.HandleRequest(request2);
+
+            bootstrapper.RequestContainerInitialisations.Any(kvp => kvp.Value > 1).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Request_should_be_available_to_configure_request_container()
+        {
+            this.bootstrapper.Initialise();
+            var engine = this.bootstrapper.GetEngine();
+            var request = new FakeRequest("GET", "/");
+
+            engine.HandleRequest(request);
+
+            this.bootstrapper.ConfigureRequestContainerLastRequest.ShouldNotBeNull();
+            this.bootstrapper.ConfigureRequestContainerLastRequest.ShouldBeSameAs(request);
+        }
+
+        [Fact]
+        public void Request_should_be_available_to_request_startup()
+        {
+            this.bootstrapper.Initialise();
+            var engine = this.bootstrapper.GetEngine();
+            var request = new FakeRequest("GET", "/");
+
+            engine.HandleRequest(request);
+
+            this.bootstrapper.RequestStartupLastRequest.ShouldNotBeNull();
+            this.bootstrapper.RequestStartupLastRequest.ShouldBeSameAs(request);
+        }
+    }
+}

--- a/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
+++ b/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
@@ -336,7 +336,7 @@
             var requestPipelines =
                 new Pipelines(this.ApplicationPipelines);
 
-            this.RequestStartup(this.ApplicationContainer, requestPipelines);
+            this.RequestStartup(this.ApplicationContainer, requestPipelines, context);
 
             return requestPipelines;
         }
@@ -361,11 +361,14 @@
         }
 
         /// <summary>
-        /// 
+        /// Initialise the request - can be used for adding pre/post hooks and
+        /// any other per-request initialisation tasks that aren't specifically container setup
+        /// related
         /// </summary>
-        /// <param name="container"></param>
-        /// <param name="pipelines"></param>
-        protected virtual void RequestStartup(TContainer container, IPipelines pipelines)
+        /// <param name="container">Container</param>
+        /// <param name="pipelines">Current pipelines</param>
+        /// <param name="context">Current context</param>
+        protected virtual void RequestStartup(TContainer container, IPipelines pipelines, NancyContext context)
         {
         }
 

--- a/src/Nancy/Bootstrapper/NancyBootstrapperWithRequestContainerBase.cs
+++ b/src/Nancy/Bootstrapper/NancyBootstrapperWithRequestContainerBase.cs
@@ -40,9 +40,7 @@ namespace Nancy.Bootstrapper
         /// <returns>An <see cref="IEnumerable{T}"/> instance containing <see cref="NancyModule"/> instances.</returns>
         public override sealed IEnumerable<NancyModule> GetAllModules(NancyContext context)
         {
-            var requestContainer = this.GetRequestContainer(context);
-
-            this.ConfigureRequestContainer(requestContainer);
+            var requestContainer = this.GetConfiguredRequestContainer(context);
 
             return this.GetAllModules(requestContainer);
         }
@@ -55,9 +53,7 @@ namespace Nancy.Bootstrapper
         /// <returns>The <see cref="NancyModule"/> instance that was retrived by the <paramref name="moduleKey"/> parameter.</returns>
         public override sealed NancyModule GetModuleByKey(string moduleKey, NancyContext context)
         {
-            var requestContainer = this.GetRequestContainer(context);
-
-            this.ConfigureRequestContainer(requestContainer);
+            var requestContainer = this.GetConfiguredRequestContainer(context);
 
             return this.GetModuleByKey(requestContainer, moduleKey);
         }
@@ -70,14 +66,12 @@ namespace Nancy.Bootstrapper
         protected override sealed IPipelines InitializeRequestPipelines(NancyContext context)
         {
             var requestContainer = 
-                this.GetRequestContainer(context);
-
-            this.ConfigureRequestContainer(requestContainer);
+                this.GetConfiguredRequestContainer(context);
 
             var requestPipelines =
                 new Pipelines(this.ApplicationPipelines);
             
-            this.RequestStartup(requestContainer, requestPipelines);
+            this.RequestStartup(requestContainer, requestPipelines, context);
 
             return requestPipelines;
         }
@@ -87,7 +81,7 @@ namespace Nancy.Bootstrapper
         /// </summary>
         /// <param name="context">Current context</param>
         /// <returns>Request container instance</returns>
-        protected TContainer GetRequestContainer(NancyContext context)
+        protected TContainer GetConfiguredRequestContainer(NancyContext context)
         {
             object contextObject;
             context.Items.TryGetValue(this.ContextKey, out contextObject);
@@ -100,6 +94,8 @@ namespace Nancy.Bootstrapper
                 this.RegisterRequestContainerModules(requestContainer, this.moduleRegistrationTypeCache);
 
                 context.Items[this.ContextKey] = requestContainer;
+
+                this.ConfigureRequestContainer(requestContainer, context);
             }
 
             return requestContainer;
@@ -109,7 +105,8 @@ namespace Nancy.Bootstrapper
         /// Configure the request container
         /// </summary>
         /// <param name="container">Request container instance</param>
-        protected virtual void ConfigureRequestContainer(TContainer container)
+        /// <param name="context"></param>
+        protected virtual void ConfigureRequestContainer(TContainer container, NancyContext context)
         {
         }
 


### PR DESCRIPTION
Now both initialise request container and request startup both have
access to the context and request. Also fixed a small bug whereby
the request container was initialised twice per request.
