### PR TITLE
Refactored error handling process

### DIFF
--- a/src/Nancy.Testing/ConfigurableBootstrapper.cs
+++ b/src/Nancy.Testing/ConfigurableBootstrapper.cs
@@ -374,21 +374,6 @@ namespace Nancy.Testing
         }
 
         /// <summary>
-        /// <para>
-        /// The error hook
-        /// </para>
-        /// <para>
-        /// The error hook is called if an exception is thrown at any time during the pipeline.
-        /// If no error hook exists a standard InternalServerError response is returned
-        /// </para>
-        /// </summary>
-        public ErrorPipeline OnError
-        {
-            get { return this.ApplicationPipelines.OnError; }
-            set { this.ApplicationPipelines.OnError = value; }
-        }
-
-        /// <summary>
         /// Provides an API for configuring a <see cref="ConfigurableBootstrapper"/> instance.
         /// </summary>
         public class ConfigurableBoostrapperConfigurator

--- a/src/Nancy.Tests/Unit/Bootstrapper/PipelinesFixture.cs
+++ b/src/Nancy.Tests/Unit/Bootstrapper/PipelinesFixture.cs
@@ -28,16 +28,6 @@
         }
 
         [Fact]
-        public void Should_create_default_error_hook_when_created_with_default_ctor()
-        {
-            // Given, When
-            var pipelines = new Pipelines();
-
-            // Then
-            pipelines.OnError.ShouldNotBeNull();
-        }
-
-        [Fact]
         public void Should_clone_after_request_hooks_when_created_with_existing_pipeline()
         {
             // Given
@@ -69,20 +59,5 @@
             pipelines.BeforeRequest.PipelineItems.First().Delegate.ShouldBeSameAs(hook);
         }
 
-        [Fact]
-        public void Should_clone_error_hooks_when_created_with_existing_pipeline()
-        {
-            // Given
-            Func<NancyContext, Exception, Response> hook = (ctx, ex) => null;
-
-            var existing = new Pipelines();
-            existing.OnError.AddItemToEndOfPipeline(hook);
-
-            // When
-            var pipelines = new Pipelines(existing);
-
-            // Then
-            pipelines.OnError.PipelineItems.First().Delegate.ShouldBeSameAs(hook);
-        }
     }
 }

--- a/src/Nancy/Bootstrapper/IPipelines.cs
+++ b/src/Nancy/Bootstrapper/IPipelines.cs
@@ -25,15 +25,5 @@ namespace Nancy.Bootstrapper
         /// </summary>
         AfterPipeline AfterRequest { get; set; }
 
-        /// <summary>
-        /// <para>
-        /// The error hook
-        /// </para>
-        /// <para>
-        /// The error hook is called if an exception is thrown at any time during the pipeline.
-        /// If no error hook exists a standard InternalServerError response is returned
-        /// </para>
-        /// </summary>
-        ErrorPipeline OnError { get; set; }
     }
 }

--- a/src/Nancy/Bootstrapper/Pipelines.cs
+++ b/src/Nancy/Bootstrapper/Pipelines.cs
@@ -14,7 +14,6 @@ namespace Nancy.Bootstrapper
         {
             this.AfterRequest = new AfterPipeline();
             this.BeforeRequest = new BeforePipeline();
-            this.OnError = new ErrorPipeline();
         }
 
         /// <summary>
@@ -39,13 +38,6 @@ namespace Nancy.Bootstrapper
                 this.BeforeRequest.AddItemToEndOfPipeline(pipelineItem);
             }
 
-            this.OnError = 
-                new ErrorPipeline(pipelines.OnError.PipelineItems.Count());
-
-            foreach (var pipelineItem in pipelines.OnError.PipelineItems)
-            {
-                this.OnError.AddItemToEndOfPipeline(pipelineItem);
-            }
         }
 
         /// <summary>
@@ -71,15 +63,5 @@ namespace Nancy.Bootstrapper
         /// </summary>
         public AfterPipeline AfterRequest { get; set; }
 
-        /// <summary>
-        /// <para>
-        /// The error hook
-        /// </para>
-        /// <para>
-        /// The error hook is called if an exception is thrown at any time during the pipeline.
-        /// If no error hook exists a standard InternalServerError response is returned
-        /// </para>
-        /// </summary>
-        public ErrorPipeline OnError { get; set; }
     }
 }

--- a/src/Nancy/Extensions/ContextExtensions.cs
+++ b/src/Nancy/Extensions/ContextExtensions.cs
@@ -67,10 +67,7 @@ namespace Nancy.Extensions
         /// <returns>Exception details</returns>
         public static string GetExceptionDetails(this NancyContext context)
         {
-            object errorObject;
-            context.Items.TryGetValue(NancyEngine.ERROR_KEY, out errorObject);
-
-            return (errorObject as string) ?? "None";
+            return (context.Exception != null) ? context.Exception.ToString() : "None";
         }
     }
 }

--- a/src/Nancy/NancyContext.cs
+++ b/src/Nancy/NancyContext.cs
@@ -40,6 +40,11 @@ namespace Nancy
         public Response Response { get; set; }
 
         /// <summary>
+        /// Gets or sets the exception, if any ocurred
+        /// </summary>
+        public Exception Exception { get; set; }
+
+        /// <summary>
         /// Gets or sets the current user
         /// </summary>
         public IUserIdentity CurrentUser { get; set; }


### PR DESCRIPTION
The OnErrorHook and error handling process doesn't let the request lifecycle to flow properly. The following things were fixed:
- If an error occurs, the recorded exception details only show a limited stack trace.
- If an error occurs while processing a route, the post request hooks are never fired.
- Removed dependency on ERROR_KEY context item to record exception details. Added an Exception property to NancyContext
- Removed Error pipeline altogether. Instead of that, users can add a regular post-request hook from which they have access to the Exception property and its details from the context, and manipulate the response as needed.

The main aim of this changes is to allow post-request hooks that perform clean-up tasks to execute, disregarding the result of the route processing.
