### PR TITLE
Added an access point for the Module and Route of the current request fro

### DIFF
--- a/src/Nancy/NancyContext.cs
+++ b/src/Nancy/NancyContext.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using Nancy.Routing;
 using Nancy.Security;
 
 namespace Nancy
@@ -11,12 +13,16 @@ namespace Nancy
     /// </summary>
     public sealed class NancyContext : IDisposable
     {
+
+
         /// <summary>
         /// Initializes a new instance of the <see cref="NancyContext"/> class.
         /// </summary>
         public NancyContext()
         {
+
             this.Items = new Dictionary<string, object>();
+
         }
 
         /// <summary>
@@ -40,6 +46,16 @@ namespace Nancy
         public Response Response { get; set; }
 
         /// <summary>
+        /// Gets the current root.
+        /// </summary>
+        public Route Route { get; internal set; }
+
+        /// <summary>
+        /// Gets the current module.
+        /// </summary>
+        public NancyModule Module { get; internal set; }
+
+        /// <summary>
         /// Gets or sets the current user
         /// </summary>
         public IUserIdentity CurrentUser { get; set; }
@@ -49,12 +65,16 @@ namespace Nancy
         /// </summary>
         public void Dispose()
         {
+
             foreach (var disposableItem in this.Items.Values.OfType<IDisposable>())
             {
                 disposableItem.Dispose();
             }
 
             this.Items.Clear();
+
         }
+
     }
+
 }

--- a/src/Nancy/NancyEngine.cs
+++ b/src/Nancy/NancyEngine.cs
@@ -139,24 +139,30 @@
 
         private void InvokeRequestLifeCycle(NancyContext context, IPipelines pipelines)
         {
+
             try
             {
+
+                var resolveResult = this.resolver.Resolve(context, this.routeCache);
+
                 InvokePreRequestHook(context, pipelines.BeforeRequest);
 
                 if (context.Response == null) 
                 {
-                    this.ResolveAndInvokeRoute(context);
+                    this.ResolveAndInvokeRoute(context, resolveResult);
                 }
 
                 if (pipelines.AfterRequest != null) 
                 {
                     pipelines.AfterRequest.Invoke(context);
                 }
+
             }
             catch (Exception ex)
             {
                 InvokeOnErrorHook(context, pipelines.OnError, ex);
             }
+
         }
 
         private static void InvokePreRequestHook(NancyContext context, BeforePipeline pipeline)
@@ -197,9 +203,8 @@
             }
         }
 
-        private void ResolveAndInvokeRoute(NancyContext context)
+        private void ResolveAndInvokeRoute(NancyContext context, Tuple<Route, DynamicDictionary, System.Func<NancyContext, Response>, System.Action<NancyContext>> resolveResult)
         {
-            var resolveResult = this.resolver.Resolve(context, this.routeCache);
 
             context.Parameters = resolveResult.Item2; 
             var resolveResultPreReq = resolveResult.Item3;
@@ -220,6 +225,7 @@
             {
                 resolveResultPostReq.Invoke(context);
             }
+
         }
 
         private static void ExecuteRoutePreReq(NancyContext context, Func<NancyContext, Response> resolveResultPreReq)

--- a/src/Nancy/Routing/DefaultNancyModuleBuilder.cs
+++ b/src/Nancy/Routing/DefaultNancyModuleBuilder.cs
@@ -34,6 +34,7 @@
         public NancyModule BuildModule(NancyModule module, NancyContext context)
         {
             module.Context = context;
+            module.Context.Module = module;
             module.Response = this.responseFormatterFactory.Create(context);
             module.ViewFactory = this.viewFactory;
             module.ModelBinderLocator = this.modelBinderLocator;

--- a/src/Nancy/Routing/DefaultRouteResolver.cs
+++ b/src/Nancy/Routing/DefaultRouteResolver.cs
@@ -74,12 +74,16 @@
 
         private ResolveResult CreateRouteAndParametersFromMatch(NancyContext context, RouteCandidate routeMatchToReturn)
         {
+
             var associatedModule =
                 this.GetInitializedModuleForMatch(context, routeMatchToReturn);
 
             var route = associatedModule.Routes.ElementAt(routeMatchToReturn.Item2);
 
+            context.Route = route;
+
             return new ResolveResult(route, routeMatchToReturn.Item4.Parameters, associatedModule.Before, associatedModule.After);
+
         }
 
         private NancyModule GetInitializedModuleForMatch(NancyContext context, RouteCandidate routeMatchToReturn)


### PR DESCRIPTION
Added an access point for the Module and Route of the current request from NancyContext.

It is useful when executing pre-request hooks, so as to perform per-route / module action. Much like ActionDescription and ControllerDescription in ASP.NET MVC.
