### PR TITLE
Fix for primitive JSON test in Jsonp hook

### DIFF
--- a/src/Nancy/Json/Json.cs
+++ b/src/Nancy/Json/Json.cs
@@ -97,5 +97,30 @@ namespace Nancy.Json
             }
             
         }
+
+        /// <summary>
+        /// Attempts to detect if the content type is JSON.
+        /// Supports:
+        ///   application/json
+        ///   text/json
+        ///   application/vnd[something]+json
+        /// Matches are case insentitive to try and be as "accepting" as possible.
+        /// </summary>
+        /// <param name="contentType">Request content type</param>
+        /// <returns>True if content type is JSON, false otherwise</returns>
+        public static bool IsJsonContentType(string contentType)
+        {
+            if (String.IsNullOrEmpty(contentType))
+            {
+                return false;
+            }
+
+            var contentMimeType = contentType.Split(';')[0];
+
+            return contentMimeType.Equals("application/json", StringComparison.InvariantCultureIgnoreCase) ||
+                   contentMimeType.Equals("text/json", StringComparison.InvariantCultureIgnoreCase) ||
+                  (contentMimeType.StartsWith("application/vnd", StringComparison.InvariantCultureIgnoreCase) &&
+                   contentMimeType.EndsWith("+json", StringComparison.InvariantCultureIgnoreCase));
+        }
 	}
 }

--- a/src/Nancy/Jsonp.cs
+++ b/src/Nancy/Jsonp.cs
@@ -45,7 +45,7 @@ namespace Nancy
         /// <param name="context">Current Nancy Context</param>
         private static void PrepareJsonp(NancyContext context)
         {
-            bool isJson = context.Response.ContentType == "application/json";
+            bool isJson = Nancy.Json.Json.IsJsonContentType(context.Response.ContentType);
             bool hasCallback = context.Request.Query["callback"].HasValue;
 
             if (isJson && hasCallback)

--- a/src/Nancy/ModelBinding/DefaultBodyDeserializers/JsonBodyDeserializer.cs
+++ b/src/Nancy/ModelBinding/DefaultBodyDeserializers/JsonBodyDeserializer.cs
@@ -20,7 +20,7 @@ namespace Nancy.ModelBinding.DefaultBodyDeserializers
         /// <returns>True if supported, false otherwise</returns>
         public bool CanDeserialize(string contentType)
         {
-            return this.IsJsonType(contentType);
+            return Json.IsJsonContentType(contentType);
         }
 
         /// <summary>
@@ -69,31 +69,6 @@ namespace Nancy.ModelBinding.DefaultBodyDeserializers
         private void CopyPropertyValue(PropertyInfo property, object sourceObject, object destinationObject)
         {
             property.SetValue(destinationObject, property.GetValue(sourceObject, null), null);
-        }
-
-        /// <summary>
-        /// Attempts to detect if the content type is JSON.
-        /// Supports:
-        ///   application/json
-        ///   text/json
-        ///   application/vnd[something]+json
-        /// Matches are case insentitive to try and be as "accepting" as possible.
-        /// </summary>
-        /// <param name="contentType">Request content type</param>
-        /// <returns>True if content type is JSON, false otherwise</returns>
-        private bool IsJsonType(string contentType)
-        {
-            if (String.IsNullOrEmpty(contentType))
-            {
-                return false;
-            }
-
-            var contentMimeType = contentType.Split(';')[0];
-
-            return contentMimeType.Equals("application/json", StringComparison.InvariantCultureIgnoreCase) ||
-                   contentMimeType.Equals("text/json", StringComparison.InvariantCultureIgnoreCase) ||
-                  (contentMimeType.StartsWith("application/vnd", StringComparison.InvariantCultureIgnoreCase) &&
-                   contentMimeType.EndsWith("+json", StringComparison.InvariantCultureIgnoreCase));
         }
     }
 }


### PR DESCRIPTION
Moved IsJsonType (renamed to IsJsonContentType) from a private method in JsonBodyDeserialiser into a public method on the Json class.  This is now used in the Jsonp Hook.
