### PR TITLE
Fixed so spark can find views in the root

### DIFF
--- a/src/Nancy.Demo.Hosting.Aspnet/Nancy.Demo.Hosting.Aspnet.csproj
+++ b/src/Nancy.Demo.Hosting.Aspnet/Nancy.Demo.Hosting.Aspnet.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/Nancy.ViewEngines.Spark.Tests/Nancy.ViewEngines.Spark.Tests.csproj
+++ b/src/Nancy.ViewEngines.Spark.Tests/Nancy.ViewEngines.Spark.Tests.csproj
@@ -103,6 +103,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="NancyViewFolderFixture.cs" />
     <Compile Include="ViewModels\FakeViewModel.cs" />
     <Compile Include="SparkViewEngineFixture.cs" />
   </ItemGroup>

--- a/src/Nancy.ViewEngines.Spark.Tests/NancyViewFolderFixture.cs
+++ b/src/Nancy.ViewEngines.Spark.Tests/NancyViewFolderFixture.cs
@@ -1,0 +1,122 @@
+namespace Nancy.ViewEngines.Spark.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using FakeItEasy;
+    using Xunit;
+    using Nancy.Tests;
+
+    public class NancyViewFolderFixture
+    {
+        private readonly IViewCache cache;
+        private readonly IEnumerable<string> extensions;
+
+        public NancyViewFolderFixture()
+        {
+            this.cache = A.Fake<IViewCache>();
+            this.extensions = new[] {"spark"};
+        }
+
+        [Fact]
+        public void Should_throw_filenotfoundexception_when_view_source_cannot_be_returned_for_view()
+        {
+            // Given
+            var viewFolder = CreateViewFolder(new ViewLocationResult(
+                string.Empty,
+                "view",
+                "spark",
+                () => new StreamReader(new MemoryStream())));
+
+            // When
+            var exception = Record.Exception(() => viewFolder.GetViewSource("notfound.spark"));
+
+            // Then
+            exception.ShouldBeOfType<FileNotFoundException>();
+        }
+
+        [Fact]
+        public void Should_get_view_source_for_view_without_location()
+        {
+            // Given
+            var viewFolder = CreateViewFolder(new ViewLocationResult(
+                string.Empty,
+                "view",
+                "spark",
+                () => new StreamReader(new MemoryStream())));
+
+            // When
+            var result = viewFolder.GetViewSource("view.spark");
+
+            // Then
+            result.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void Should_get_view_source_for_view_with_location()
+        {
+            // Given
+            var viewFolder = CreateViewFolder(new ViewLocationResult(
+                "location",
+                "view",
+                "spark",
+                () => new StreamReader(new MemoryStream())));
+
+            // When
+            var result = viewFolder.GetViewSource("location/view.spark");
+
+            // Then
+            result.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void Should_return_true_for_hashview_when_matching_views_without_location()
+        {
+            // Given
+            var viewFolder = CreateViewFolder(new ViewLocationResult(
+                string.Empty,
+                "view",
+                "spark",
+                () => new StreamReader(new MemoryStream())));
+
+            // When
+            var result = viewFolder.HasView("view.spark");
+
+            // Then
+            result.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Should_return_true_for_hashview_when_matching_views_with_location()
+        {
+            // Given
+            var viewFolder = CreateViewFolder(new ViewLocationResult(
+                "location",
+                "view",
+                "spark",
+                () => new StreamReader(new MemoryStream())));
+
+            // When
+            var result = viewFolder.HasView("location/view.spark");
+
+            // Then
+            result.ShouldBeTrue();
+        }
+
+        private NancyViewFolder CreateViewFolder(params ViewLocationResult[] results)
+        {
+            var context =
+                CreateContext(results);
+
+            return new NancyViewFolder(context);
+        }
+
+        private ViewEngineStartupContext CreateContext(params ViewLocationResult[] results)
+        {
+            return new ViewEngineStartupContext(
+                this.cache,
+                results,
+                this.extensions);
+        }
+    }
+}

--- a/src/Nancy.ViewEngines.Spark/NancyViewFolder.cs
+++ b/src/Nancy.ViewEngines.Spark/NancyViewFolder.cs
@@ -7,20 +7,34 @@ namespace Nancy.ViewEngines.Spark
     using System.Text;
     using global::Spark.FileSystem;
 
+    /// <summary>
+    /// Implementation of the IViewFolder interface to have Spark use views that's been discovered by Nancy's view locator.
+    /// </summary>
     public class NancyViewFolder : IViewFolder
     {
         private readonly ViewEngineStartupContext viewEngineStartupContext;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NancyViewFolder"/> class, using the provided
+        /// <see cref="viewEngineStartupContext"/> instance.
+        /// </summary>
+        /// <param name="viewEngineStartupContext"></param>
         public NancyViewFolder(ViewEngineStartupContext viewEngineStartupContext)
         {
             this.viewEngineStartupContext = viewEngineStartupContext;
         }
 
+        /// <summary>
+        /// Gets the source of the requested view.
+        /// </summary>
+        /// <param name="path">The view to get the source for</param>
+        /// <returns>A <see cref="IViewFile"/> instance.</returns>
         public IViewFile GetViewSource(string path)
         {
             var searchPath = ConvertPath(path);
 
-            var viewLocationResult = this.viewEngineStartupContext.ViewLocationResults.FirstOrDefault(v => String.Equals(v.Location + "/" + v.Name + "." + v.Extension, searchPath, StringComparison.OrdinalIgnoreCase));
+            var viewLocationResult = this.viewEngineStartupContext.ViewLocationResults
+                .FirstOrDefault(v => CompareViewPaths(GetSafeViewPath(v), searchPath));
 
             if (viewLocationResult == null)
             {
@@ -30,6 +44,11 @@ namespace Nancy.ViewEngines.Spark
             return new NancyViewFile(viewLocationResult);
         }
 
+        /// <summary>
+        /// Lists all view for the specified <paramref name="path"/>.
+        /// </summary>
+        /// <param name="path">The path to return views for.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> that contains the matched views.</returns>
         public IList<string> ListViews(string path)
         {
             return this.viewEngineStartupContext.
@@ -42,16 +61,34 @@ namespace Nancy.ViewEngines.Spark
                 ToList();
         }
 
+        /// <summary>
+        /// Gets a value that indicates wether or not the view folder contains a specific view.
+        /// </summary>
+        /// <param name="path">The view to check for.</param>
+        /// <returns><see langword="true"/> if the view exists in the view folder; otherwise <see langword="false"/>.</returns>
         public bool HasView(string path)
         {
-            var searchPath = ConvertPath(path);
+            var searchPath = 
+                ConvertPath(path);
 
-            return this.viewEngineStartupContext.ViewLocationResults.Any(v => String.Equals(v.Location + "/" + v.Name + "." + v.Extension, searchPath, StringComparison.OrdinalIgnoreCase));
+            return this.viewEngineStartupContext.ViewLocationResults.Any(v => CompareViewPaths(GetSafeViewPath(v), searchPath));
+        }
+
+        private static bool CompareViewPaths(string storedViewPath, string requestedViewPath)
+        {
+            return String.Equals(storedViewPath, requestedViewPath, StringComparison.OrdinalIgnoreCase);
         }
 
         private static string ConvertPath(string path)
         {
             return path.Replace(@"\", "/");
+        }
+
+        private static string GetSafeViewPath(ViewLocationResult result)
+        {
+            return string.IsNullOrEmpty(result.Location) ? 
+                string.Concat(result.Name, ".", result.Extension) : 
+                string.Concat(result.Location, "/", result.Name, ".", result.Extension);
         }
 
         public class NancyViewFile : IViewFile


### PR DESCRIPTION
Spark had issues finding views that were stored in the root because
it would concatenate an invalid path from the ViewLocationResults
when the Location property were empty.

Fixes issue #411
