### PR TITLE
Disabled global razor rendering hook from mvc

### DIFF
--- a/src/Nancy.ViewEngines.Razor/nancy.viewengines.razor.nuspec
+++ b/src/Nancy.ViewEngines.Razor/nancy.viewengines.razor.nuspec
@@ -21,6 +21,7 @@
     <file src="build\binaries\Nancy.Viewengines.Razor.dll" target="lib\net40" />
     <file src="build\binaries\Nancy.Viewengines.Razor.pdb" target="lib\net40" />
     <file src="build\binaries\System.Web.Razor.dll" target="lib\net40" />
+	<file src="src\Nancy.Viewengines.Razor\web.config.transform" target="content" />
     <file src="src\Nancy.Viewengines.Razor\**\*.cs" target="src" />
   </files>
 </package>

--- a/src/Nancy.ViewEngines.Razor/web.config.transform
+++ b/src/Nancy.ViewEngines.Razor/web.config.transform
@@ -1,0 +1,5 @@
+<configuration>
+  <appSettings>
+   <add key="webPages:Enabled" value="false" />
+  </appSettings>
+</configuration>


### PR DESCRIPTION
MVC installs a global hook for rendering razor views which would
intercept some Nancy paths and render the razor view without invoking
Nancy. This fix will add a section to the web.config, when you install
the Nancy razor nuget, which will disable this behavior and let Nancy
handle all requests.

Fixes issue #415
