### PR TITLE
Resets request stream at zero after parsing values

### DIFF
--- a/src/Nancy.Tests/Specifications/RequestSpec.cs
+++ b/src/Nancy.Tests/Specifications/RequestSpec.cs
@@ -1,7 +1,5 @@
 namespace Nancy.Tests.Specifications
 {
-    using Nancy.Routing;
-
     public abstract class RequestSpec
     {
         protected static INancyEngine engine;

--- a/src/Nancy/Request.cs
+++ b/src/Nancy/Request.cs
@@ -203,6 +203,7 @@ namespace Nancy
             {
                 var reader = new StreamReader(this.Body);
                 this.form = reader.ReadToEnd().AsQueryDictionary();
+                this.Body.Position = 0;
             }
 
             if (!mimeType.Equals("multipart/form-data", StringComparison.OrdinalIgnoreCase))
@@ -229,6 +230,8 @@ namespace Nancy
                                        ));
                 }
             }
+
+            this.Body.Position = 0;
         }
 
         private void RewriteMethod()


### PR DESCRIPTION
The stream was not reset to the beginning after reading url and
multipart encoded values.

Fixes issue #410
