### PR TITLE
Don't overwrite response contents on error (fixes #429)

### DIFF
--- a/src/Nancy.Tests/Unit/ErrorHandling/DefaultErrorHandlerFixture.cs
+++ b/src/Nancy.Tests/Unit/ErrorHandling/DefaultErrorHandlerFixture.cs
@@ -60,6 +60,18 @@ namespace Nancy.Tests.Unit.ErrorHandling
         }
 
         [Fact]
+        public void Should_not_overwrite_response_contents()
+        {
+            var context = new NancyContext();
+            Action<Stream> contents = stream => { };
+            context.Response = new Response() { StatusCode = HttpStatusCode.NotFound, Contents = contents };
+
+            this.errorHandler.Handle(HttpStatusCode.NotFound, context);
+
+            context.Response.Contents.ShouldEqual(contents);
+        }
+
+        [Fact]
         public void Should_create_response_if_it_doesnt_exist_in_context()
         {
             var context = new NancyContext();

--- a/src/Nancy/ErrorHandling/DefaultErrorHandler.cs
+++ b/src/Nancy/ErrorHandling/DefaultErrorHandler.cs
@@ -51,6 +51,11 @@ namespace Nancy.ErrorHandling
         /// <returns>Nancy Response</returns>
         public void Handle(HttpStatusCode statusCode, NancyContext context)
         {
+            if (context.Response != null && context.Response.Contents != null)
+            {
+                return;
+            }
+
             string errorPage;
 
             if (!this.errorPages.TryGetValue(statusCode, out errorPage))
@@ -74,6 +79,11 @@ namespace Nancy.ErrorHandling
 
         private void ModifyResponse(HttpStatusCode statusCode, NancyContext context, string errorPage)
         {
+            if (context.Response != null && context.Response.Contents != null)
+            {
+                return;
+            }
+
             if (context.Response == null)
             {
                 context.Response = new Response() { StatusCode = statusCode };


### PR DESCRIPTION
The default error handler should accept custom error contents for the errors it handles.

Since this fix simply checks for the response's contents being set, it doesn't handle this case:

``` c#
Get["/"] = parameters =>
{
    Response.Contents = stream => WriteSomethingTo(Stream);
    // later...
    if (SomeReason)
    {
        return 404;
    }
}
```

Conceivably, someone does this right now and expects the default error page to appear. With this fix, they'd still get the response contents. (Which is what I'd expect to happen, personally. I set the contents, they should show up. But others' expectations may differ.)
