### PR TITLE
Fixed #458 - the default 500 error page is replaced by a real exception

### DIFF
--- a/src/Nancy.Testing.Tests/ConfigurableBootstrapperFixture.cs
+++ b/src/Nancy.Testing.Tests/ConfigurableBootstrapperFixture.cs
@@ -109,6 +109,24 @@
             }
         }
 
+        [Fact]
+        public void Should_throw_exceptions_if_any_occur_in_route()
+        {
+            var bootstrapper = new ConfigurableBootstrapper(with =>
+                {
+                    with.Module<BlowUpModule>();
+                });
+            bootstrapper.Initialise();
+            var engine = bootstrapper.GetEngine();
+            var request = new Request("GET", "/", "http");
+
+            var result = Record.Exception(() => engine.HandleRequest(request));
+
+            result.ShouldNotBeNull();
+            result.ShouldBeOfType<Exception>();
+            result.ToString().ShouldContain("Oh noes!");
+        }
+
         public IEnumerable<string> GetConfigurableBootstrapperMembers()
         {
             var ignoreList = new[]
@@ -144,6 +162,14 @@
             public void HandleRequest(Request request, Action<NancyContext> onComplete, Action<Exception> onError)
             {
                 throw new NotImplementedException();
+            }
+        }
+
+        private class BlowUpModule : NancyModule
+        {
+            public BlowUpModule()
+            {
+                Get["/"] = _ => { throw new InvalidOperationException("Oh noes!"); };
             }
         }
     }

--- a/src/Nancy.Testing/ConfigurableBootstrapper.cs
+++ b/src/Nancy.Testing/ConfigurableBootstrapper.cs
@@ -48,6 +48,8 @@ namespace Nancy.Testing
                 var configurator =
                     new ConfigurableBoostrapperConfigurator(this);
 
+                configurator.ErrorHandler<PassThroughErrorHandler>();
+
                 configuration.Invoke(configurator);
             }
         }

--- a/src/Nancy.Testing/Nancy.Testing.csproj
+++ b/src/Nancy.Testing/Nancy.Testing.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -113,6 +113,7 @@
     <Compile Include="IBrowserContextValues.cs" />
     <Compile Include="IndexHelper.cs" />
     <Compile Include="NodeWrapper.cs" />
+    <Compile Include="PassThroughErrorHandler.cs" />
     <Compile Include="PathHelper.cs" />
     <Compile Include="QueryWrapper.cs" />
     <Compile Include="AssertExtensions.cs" />

--- a/src/Nancy.Testing/PassThroughErrorHandler.cs
+++ b/src/Nancy.Testing/PassThroughErrorHandler.cs
@@ -1,0 +1,18 @@
+using System;
+using Nancy.ErrorHandling;
+
+namespace Nancy.Testing
+{
+    public class PassThroughErrorHandler : IErrorHandler
+    {
+        public bool HandlesStatusCode(HttpStatusCode statusCode)
+        {
+            return statusCode == HttpStatusCode.InternalServerError;
+        }
+
+        public void Handle(HttpStatusCode statusCode, NancyContext context)
+        {
+            throw new Exception("ConfigurableBootstrapper Exception", context.Items[NancyEngine.ERROR_EXCEPTION] as Exception);
+        }
+    }
+}

--- a/src/Nancy/NancyEngine.cs
+++ b/src/Nancy/NancyEngine.cs
@@ -13,8 +13,8 @@
     /// </summary>
     public class NancyEngine : INancyEngine
     {
-        internal const string ERROR_KEY = "ERROR_TRACE";
-        internal const string ERROR_EXCEPTION = "ERROR_EXCEPTION";
+        public const string ERROR_KEY = "ERROR_TRACE";
+        public const string ERROR_EXCEPTION = "ERROR_EXCEPTION";
 
         private readonly IRouteResolver resolver;
         private readonly IRouteCache routeCache;


### PR DESCRIPTION
Now if something throws during route invocation it actually bubbles up as an exception in the test, rather than the test returning the error page as the response body.
