### PR TITLE
Implemented ViewBag in RazorViewEngine

### DIFF
--- a/src/Nancy.Tests/Fakes/FakeViewEngine.cs
+++ b/src/Nancy.Tests/Fakes/FakeViewEngine.cs
@@ -1,4 +1,6 @@
-﻿namespace Nancy.Tests.Fakes
+﻿using System.Dynamic;
+
+namespace Nancy.Tests.Fakes
 {
     using System.Collections.Generic;
     using Nancy.ViewEngines;
@@ -19,7 +21,7 @@
         {
         }
 
-        public Response RenderView(ViewLocationResult viewLocationResult, dynamic model, IRenderContext renderContext)
+        public Response RenderView(ViewLocationResult viewLocationResult, dynamic model, IRenderContext renderContext, ExpandoObject viewBag = null)
         {
             this.Model = model;
             return new HtmlResponse();

--- a/src/Nancy.Tests/Unit/ViewEngines/DefaultViewFactoryFixture.cs
+++ b/src/Nancy.Tests/Unit/ViewEngines/DefaultViewFactoryFixture.cs
@@ -73,7 +73,7 @@ namespace Nancy.Tests.Unit.ViewEngines
             factory.RenderView("view.html", new object(), new ViewLocationContext());
 
             // Then
-            A.CallTo(() => viewEngines[0].RenderView(A<ViewLocationResult>.Ignored, A<object>.Ignored, context)).MustHaveHappened();
+            A.CallTo(() => viewEngines[0].RenderView(A<ViewLocationResult>.Ignored, A<object>.Ignored, context, null)).MustHaveHappened();
         }
 
         [Fact]
@@ -200,7 +200,7 @@ namespace Nancy.Tests.Unit.ViewEngines
             factory.RenderView("foo", null, new ViewLocationContext());
 
             // Then
-            A.CallTo(() => viewEngines[0].RenderView(location, null, A<IRenderContext>.Ignored)).MustHaveHappened();
+            A.CallTo(() => viewEngines[0].RenderView(location, null, A<IRenderContext>.Ignored, null)).MustHaveHappened();
         }
 
         [Fact]
@@ -222,7 +222,7 @@ namespace Nancy.Tests.Unit.ViewEngines
             factory.RenderView("foo", null, new ViewLocationContext());
 
             // Then
-            A.CallTo(() => viewEngines[0].RenderView(location, null, A<IRenderContext>.Ignored)).MustHaveHappened();
+            A.CallTo(() => viewEngines[0].RenderView(location, null, A<IRenderContext>.Ignored, null)).MustHaveHappened();
         }
 
         [Fact]
@@ -236,7 +236,7 @@ namespace Nancy.Tests.Unit.ViewEngines
             Action<Stream> actionReturnedFromEngine = x => { };
 
             A.CallTo(() => viewEngines[0].Extensions).Returns(new[] { "html" });
-            A.CallTo(() => viewEngines[0].RenderView(A<ViewLocationResult>.Ignored, null, A<IRenderContext>.Ignored)).Returns(actionReturnedFromEngine);
+            A.CallTo(() => viewEngines[0].RenderView(A<ViewLocationResult>.Ignored, null, A<IRenderContext>.Ignored, null)).Returns(actionReturnedFromEngine);
 
             var location = new ViewLocationResult("location", "name", "html", GetEmptyContentReader());
             A.CallTo(() => this.resolver.GetViewLocation(A<string>.Ignored, A<object>.Ignored, A<ViewLocationContext>.Ignored)).Returns(location);
@@ -258,7 +258,7 @@ namespace Nancy.Tests.Unit.ViewEngines
             };
 
             A.CallTo(() => viewEngines[0].Extensions).Returns(new[] { "html" });
-            A.CallTo(() => viewEngines[0].RenderView(A<ViewLocationResult>.Ignored, null, A<IRenderContext>.Ignored)).Throws(new Exception());
+            A.CallTo(() => viewEngines[0].RenderView(A<ViewLocationResult>.Ignored, null, A<IRenderContext>.Ignored, null)).Throws(new Exception());
 
             var location = new ViewLocationResult("location", "name", "html", GetEmptyContentReader());
             A.CallTo(() => this.resolver.GetViewLocation(A<string>.Ignored, A<object>.Ignored, A<ViewLocationContext>.Ignored)).Returns(location);
@@ -283,7 +283,7 @@ namespace Nancy.Tests.Unit.ViewEngines
             };
 
             A.CallTo(() => viewEngines[0].Extensions).Returns(new[] { "html" });
-            A.CallTo(() => viewEngines[0].RenderView(A<ViewLocationResult>.Ignored, null, null)).Throws(new Exception());
+            A.CallTo(() => viewEngines[0].RenderView(A<ViewLocationResult>.Ignored, null, null, null)).Throws(new Exception());
 
             var location = new ViewLocationResult("location", "name", "html", GetEmptyContentReader());
             A.CallTo(() => this.resolver.GetViewLocation(A<string>.Ignored, A<object>.Ignored, A<ViewLocationContext>.Ignored)).Returns(location);
@@ -295,7 +295,7 @@ namespace Nancy.Tests.Unit.ViewEngines
             factory.RenderView("foo", model, new ViewLocationContext());
 
             // Then
-            A.CallTo(() => viewEngines[0].RenderView(A<ViewLocationResult>.Ignored, model, A<IRenderContext>.Ignored)).MustHaveHappened();
+            A.CallTo(() => viewEngines[0].RenderView(A<ViewLocationResult>.Ignored, model, A<IRenderContext>.Ignored, null)).MustHaveHappened();
         }
 
         [Fact]
@@ -318,7 +318,7 @@ namespace Nancy.Tests.Unit.ViewEngines
             factory.RenderView("foo", model, new ViewLocationContext());
 
             // Then
-            A.CallTo(() => viewEngines[0].RenderView(A<ViewLocationResult>.Ignored, A<object>.That.Matches(x => x.GetType().Equals(typeof(ExpandoObject))), A<IRenderContext>.Ignored)).MustHaveHappened();
+            A.CallTo(() => viewEngines[0].RenderView(A<ViewLocationResult>.Ignored, A<object>.That.Matches(x => x.GetType().Equals(typeof(ExpandoObject))), A<IRenderContext>.Ignored, null)).MustHaveHappened();
         }
 
         [Fact]

--- a/src/Nancy.ViewEngines.DotLiquid/DotLiquidViewEngine.cs
+++ b/src/Nancy.ViewEngines.DotLiquid/DotLiquidViewEngine.cs
@@ -1,4 +1,6 @@
-﻿namespace Nancy.ViewEngines.DotLiquid
+﻿using System.Dynamic;
+
+namespace Nancy.ViewEngines.DotLiquid
 {
     using System;
     using System.Collections.Generic;
@@ -44,14 +46,15 @@
         {
         }
 
-        /// <summary>
-        /// Renders the view.
-        /// </summary>
-        /// <param name="viewLocationResult">A <see cref="ViewLocationResult"/> instance, containing information on how to get the view template.</param>
-        /// <param name="model">The model that should be passed into the view</param>
-        /// <param name="renderContext"></param>
-        /// <returns>A response</returns>
-        public Response RenderView(ViewLocationResult viewLocationResult, dynamic model, IRenderContext renderContext)
+    	/// <summary>
+    	/// Renders the view.
+    	/// </summary>
+    	/// <param name="viewLocationResult">A <see cref="ViewLocationResult"/> instance, containing information on how to get the view template.</param>
+    	/// <param name="model">The model that should be passed into the view</param>
+    	/// <param name="renderContext"></param>
+    	/// <param name="viewBag">Extra data available to a view</param>
+    	/// <returns>A response</returns>
+    	public Response RenderView(ViewLocationResult viewLocationResult, dynamic model, IRenderContext renderContext, ExpandoObject viewBag = null)
         {
             return new HtmlResponse(contents: stream =>
             {

--- a/src/Nancy.ViewEngines.NDjango/NDjangoViewEngine.cs
+++ b/src/Nancy.ViewEngines.NDjango/NDjangoViewEngine.cs
@@ -1,4 +1,6 @@
-﻿namespace Nancy.ViewEngines.NDjango
+﻿using System.Dynamic;
+
+namespace Nancy.ViewEngines.NDjango
 {
     using System;
     using System.Collections.Generic;
@@ -35,14 +37,15 @@
             return o;
         }
 
-        /// <summary>
-        /// Renders the view.
-        /// </summary>
-        /// <param name="viewLocationResult">A <see cref="ViewLocationResult"/> instance, containing information on how to get the view template.</param>
-        /// <param name="model">The model that should be passed into the view</param>
-        /// <param name="renderContext"></param>
-        /// <returns>A response</returns>
-        public Response RenderView(ViewLocationResult viewLocationResult, dynamic model, IRenderContext renderContext)
+    	/// <summary>
+    	/// Renders the view.
+    	/// </summary>
+    	/// <param name="viewLocationResult">A <see cref="ViewLocationResult"/> instance, containing information on how to get the view template.</param>
+    	/// <param name="model">The model that should be passed into the view</param>
+    	/// <param name="renderContext"></param>
+    	/// <param name="viewBag">Extra data available to a view</param>
+    	/// <returns>A response</returns>
+		public Response RenderView(ViewLocationResult viewLocationResult, dynamic model, IRenderContext renderContext, ExpandoObject viewBag = null)
         {
             return new HtmlResponse(contents: stream =>
             {

--- a/src/Nancy.ViewEngines.Nustache/NustacheViewEngine.cs
+++ b/src/Nancy.ViewEngines.Nustache/NustacheViewEngine.cs
@@ -1,4 +1,6 @@
-﻿namespace Nancy.ViewEngines.Nustache
+﻿using System.Dynamic;
+
+namespace Nancy.ViewEngines.Nustache
 {
     using System;
     using System.Collections.Generic;
@@ -50,14 +52,15 @@
             };
         }
 
-        /// <summary>
-        /// Renders the view.
-        /// </summary>
-        /// <param name="viewLocationResult">A <see cref="ViewLocationResult"/> instance, containing information on how to get the view template.</param>
-        /// <param name="model">The model that should be passed into the view</param>
-        /// <param name="renderContext"></param>
-        /// <returns>A response</returns>
-        public Response RenderView(ViewLocationResult viewLocationResult, dynamic model, IRenderContext renderContext)
+    	/// <summary>
+    	/// Renders the view.
+    	/// </summary>
+    	/// <param name="viewLocationResult">A <see cref="ViewLocationResult"/> instance, containing information on how to get the view template.</param>
+    	/// <param name="model">The model that should be passed into the view</param>
+    	/// <param name="renderContext"></param>
+    	/// <param name="viewBag">Extra data available to a view</param>
+    	/// <returns>A response</returns>
+		public Response RenderView(ViewLocationResult viewLocationResult, dynamic model, IRenderContext renderContext, ExpandoObject viewBag = null)
         {
             return new HtmlResponse
             {

--- a/src/Nancy.ViewEngines.Razor.Tests/Nancy.ViewEngines.Razor.Tests.csproj
+++ b/src/Nancy.ViewEngines.Razor.Tests/Nancy.ViewEngines.Razor.Tests.csproj
@@ -65,8 +65,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System">
-    </Reference>
+    <Reference Include="System" />
     <Reference Include="System.Core">
     </Reference>
     <Reference Include="System.Xml.Linq">
@@ -99,6 +98,10 @@
     <Compile Include="RazorViewEngineFixture.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Nancy.Tests\Nancy.Tests.csproj">
+      <Project>{776D244D-BC4D-4BBB-A478-CAF2D04520E1}</Project>
+      <Name>Nancy.Tests</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Nancy.ViewEngines.Razor.Tests.Models\Nancy.ViewEngines.Razor.Tests.Models.csproj">
       <Project>{3F18F5DA-93E0-4513-8BF4-BC8EE5C4117C}</Project>
       <Name>Nancy.ViewEngines.Razor.Tests.Models</Name>
@@ -113,6 +116,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="TestViews\ViewThatUsesViewBag.cshtml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestViews\ViewThatUsesModelVB.vbhtml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/Nancy.ViewEngines.Razor.Tests/TestViews/ViewThatUsesModelCSharp.cshtml
+++ b/src/Nancy.ViewEngines.Razor.Tests/TestViews/ViewThatUsesModelCSharp.cshtml
@@ -1,3 +1,4 @@
-﻿@model System.DateTime
+﻿@inherits Nancy.ViewEngines.Razor.NancyRazorViewBase
+@model System.DateTime
 
 <h1>Hello at @Model.ToString("MM/dd/yyyy")</h1>

--- a/src/Nancy.ViewEngines.Razor.Tests/TestViews/ViewThatUsesViewBag.cshtml
+++ b/src/Nancy.ViewEngines.Razor.Tests/TestViews/ViewThatUsesViewBag.cshtml
@@ -1,0 +1,3 @@
+﻿<div>ViewBag!</div>
+
+@ViewBag.Message

--- a/src/Nancy.ViewEngines.Razor/CSharp/NancyCSharpRazorCodeParser.cs
+++ b/src/Nancy.ViewEngines.Razor/CSharp/NancyCSharpRazorCodeParser.cs
@@ -24,7 +24,7 @@
         protected override bool ParseInheritsStatement(CodeBlockInfo block)
         {
             this.endInheritsLocation = this.CurrentLocation;
-            var result = this.ParseInheritsStatement(block);
+            var result = base.ParseInheritsStatement(block);
             this.CheckForInheritsAndModelStatements();
             return result;
         }

--- a/src/Nancy.ViewEngines.Razor/NancyRazorViewBase.cs
+++ b/src/Nancy.ViewEngines.Razor/NancyRazorViewBase.cs
@@ -1,4 +1,6 @@
-﻿namespace Nancy.ViewEngines.Razor
+﻿using System.Dynamic;
+
+namespace Nancy.ViewEngines.Razor
 {
     using System;
     using System.Collections.Generic;
@@ -15,6 +17,11 @@
         private readonly StringBuilder contents;
         private string childBody;
         private IDictionary<string, string> childSections;
+
+        /// <summary>
+        /// Gets or sets the ViewBag associated with this View
+        /// </summary>
+        public dynamic ViewBag { get; set; }
 
         /// <summary>
         /// Gets the body.
@@ -87,7 +94,8 @@
         /// <param name="renderContext">The render context.</param>
         /// <param name="model">The model.</param>
         public virtual void Initialize(RazorViewEngine engine, IRenderContext renderContext, object model)
-        { }
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NancyRazorViewBase"/> class.

--- a/src/Nancy.ViewEngines.Spark/SparkViewEngine.cs
+++ b/src/Nancy.ViewEngines.Spark/SparkViewEngine.cs
@@ -115,7 +115,7 @@
             this.engine.ViewFolder = GetViewFolder(viewEngineStartupContext);
         }
 
-        public Response RenderView(ViewLocationResult viewLocationResult, dynamic model, IRenderContext renderContext)
+		public Response RenderView(ViewLocationResult viewLocationResult, dynamic model, IRenderContext renderContext, ExpandoObject viewBag = null)
         {
             return new HtmlResponse(contents: stream =>
             {

--- a/src/Nancy/NancyModule.cs
+++ b/src/Nancy/NancyModule.cs
@@ -1,3 +1,5 @@
+using System.Dynamic;
+
 namespace Nancy
 {
     using System;
@@ -18,6 +20,9 @@ namespace Nancy
     public abstract class NancyModule : IHideObjectMembers
     {
         private readonly List<Route> routes;
+        private readonly ExpandoObject viewBag;
+
+        protected dynamic ViewBag { get { return viewBag; } }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NancyModule"/> class.
@@ -37,6 +42,7 @@ namespace Nancy
             this.Before = new BeforePipeline();
             this.ModulePath = modulePath;
             this.routes = new List<Route>();
+            this.viewBag = new ExpandoObject();
         }
 
         /// <summary>
@@ -262,7 +268,7 @@ namespace Nancy
             /// <remarks>The view name is model.GetType().Name with any Model suffix removed.</remarks>
             public Response this[dynamic model]
             {
-                get { return this.module.ViewFactory.RenderView(null, model, this.GetViewLocationContext()); }
+                get { return this.module.ViewFactory.RenderView(null, model, this.GetViewLocationContext(), module.ViewBag); }
             }
 
             /// <summary>
@@ -273,7 +279,7 @@ namespace Nancy
             /// <remarks>The extension in the view name is optional. If it is omitted, then Nancy will try to resolve which of the available engines that should be used to render the view.</remarks>
             public Response this[string viewName]
             {
-                get { return this.module.ViewFactory.RenderView(viewName, null, this.GetViewLocationContext()); }
+                get { return this.module.ViewFactory.RenderView(viewName, null, this.GetViewLocationContext(), module.ViewBag); }
             }
 
             /// <summary>
@@ -285,7 +291,7 @@ namespace Nancy
             /// <remarks>The extension in the view name is optional. If it is omitted, then Nancy will try to resolve which of the available engines that should be used to render the view.</remarks>
             public Response this[string viewName, dynamic model]
             {
-                get { return this.module.ViewFactory.RenderView(viewName, model, this.GetViewLocationContext()); }
+                get { return this.module.ViewFactory.RenderView(viewName, model, this.GetViewLocationContext(), module.ViewBag); }
             }
 
             private ViewLocationContext GetViewLocationContext()

--- a/src/Nancy/ViewEngines/DefaultViewFactory.cs
+++ b/src/Nancy/ViewEngines/DefaultViewFactory.cs
@@ -39,8 +39,9 @@
         /// <param name="viewName">The name of the view to render.</param>
         /// <param name="model">The model that should be passed into the view.</param>
         /// <param name="viewLocationContext">A <see cref="ViewLocationContext"/> instance, containing information about the context for which the view is being rendered.</param>
+        /// <param name="viewBag">Dynamic view data that is not part of the model</param>
         /// <returns>A delegate that can be invoked with the <see cref="Stream"/> that the view should be rendered to.</returns>
-        public Response RenderView(string viewName, dynamic model, ViewLocationContext viewLocationContext)
+        public Response RenderView(string viewName, dynamic model, ViewLocationContext viewLocationContext, ExpandoObject viewBag = null)
         {
             if (viewName == null && model == null)
             {
@@ -60,10 +61,10 @@
             var actualViewName = 
                 viewName ?? GetViewNameFromModel(model);
 
-            return this.GetRenderedView(actualViewName, model, viewLocationContext);
+            return this.GetRenderedView(actualViewName, model, viewLocationContext, viewBag);
         }
 
-        private Response GetRenderedView(string viewName, dynamic model, ViewLocationContext viewLocationContext)
+        private Response GetRenderedView(string viewName, dynamic model, ViewLocationContext viewLocationContext, ExpandoObject viewBag)
         {
             var viewLocationResult =
                 this.viewResolver.GetViewLocation(viewName, model, viewLocationContext);
@@ -80,7 +81,8 @@
                 resolvedViewEngine,
                 viewLocationResult,
                 GetSafeModel(model),
-                this.renderContextFactory.GetRenderContext(viewLocationContext)
+                this.renderContextFactory.GetRenderContext(viewLocationContext),
+                viewBag
             );
         }
 
@@ -122,11 +124,11 @@
             return Regex.Replace(model.GetType().Name, "Model$", string.Empty);
         }
 
-        private static Response SafeInvokeViewEngine(IViewEngine viewEngine, ViewLocationResult locationResult, dynamic model, IRenderContext renderContext)
+        private static Response SafeInvokeViewEngine(IViewEngine viewEngine, ViewLocationResult locationResult, dynamic model, IRenderContext renderContext, ExpandoObject viewBag)
         {
             try
             {
-                return viewEngine.RenderView(locationResult, model, renderContext);
+                return viewEngine.RenderView(locationResult, model, renderContext, viewBag);
             }
             catch (Exception)
             {

--- a/src/Nancy/ViewEngines/IViewEngine.cs
+++ b/src/Nancy/ViewEngines/IViewEngine.cs
@@ -1,4 +1,6 @@
-﻿namespace Nancy.ViewEngines
+﻿using System.Dynamic;
+
+namespace Nancy.ViewEngines
 {
     using System;
     using System.Collections.Generic;
@@ -22,13 +24,14 @@
         /// <param name="viewEngineStartupContext">Startup context</param>
         void Initialize(ViewEngineStartupContext viewEngineStartupContext);
 
-        /// <summary>
-        /// Renders the view.
-        /// </summary>
-        /// <param name="viewLocationResult">A <see cref="ViewLocationResult"/> instance, containing information on how to get the view template.</param>
-        /// <param name="model">The model that should be passed into the view</param>
-        /// <param name="renderContext"></param>
-        /// <returns>A response</returns>
-        Response RenderView(ViewLocationResult viewLocationResult, dynamic model, IRenderContext renderContext);
+    	/// <summary>
+    	/// Renders the view.
+    	/// </summary>
+    	/// <param name="viewLocationResult">A <see cref="ViewLocationResult"/> instance, containing information on how to get the view template.</param>
+    	/// <param name="model">The model that should be passed into the view</param>
+    	/// <param name="renderContext"></param>
+    	/// <param name="viewBag">A dynamic object that can be accessed by the view</param>
+    	/// <returns>A response</returns>
+    	Response RenderView(ViewLocationResult viewLocationResult, dynamic model, IRenderContext renderContext, ExpandoObject viewBag = null);
     }
 }

--- a/src/Nancy/ViewEngines/IViewFactory.cs
+++ b/src/Nancy/ViewEngines/IViewFactory.cs
@@ -1,4 +1,6 @@
-﻿namespace Nancy.ViewEngines
+﻿using System.Dynamic;
+
+namespace Nancy.ViewEngines
 {
     using System;
     using System.IO;
@@ -14,7 +16,8 @@
         /// <param name="viewName">The name of the view to render.</param>
         /// <param name="model">The module path of the module that is rendering the view.</param>
         /// <param name="viewLocationContext">A <see cref="ViewLocationContext"/> instance, containing information about the context for which the view is being rendered.</param>
+        /// <param name="viewBag">Contains dynamic data for the view that is not part of the model</param>
         /// <returns>A response.</returns>
-        Response RenderView(string viewName, dynamic model, ViewLocationContext viewLocationContext);
+        Response RenderView(string viewName, dynamic model, ViewLocationContext viewLocationContext, ExpandoObject viewBag = null);
     }
 }

--- a/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngineWrapper.cs
+++ b/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngineWrapper.cs
@@ -1,4 +1,6 @@
-﻿namespace Nancy.ViewEngines.SuperSimpleViewEngine
+﻿using System.Dynamic;
+
+namespace Nancy.ViewEngines.SuperSimpleViewEngine
 {
     using System;
     using System.Collections.Generic;
@@ -40,8 +42,9 @@
         /// </summary>
         /// <param name="viewLocationResult">A <see cref="ViewLocationResult"/> instance, containing information on how to get the view template.</param>
         /// <param name="model">The model that should be passed into the view</param>
+        /// <param name="viewBag">Dynamic data that can be made available to the view</param>
         /// <returns>A response.</returns>
-        public Response RenderView(ViewLocationResult viewLocationResult, dynamic model, IRenderContext renderContext)
+        public Response RenderView(ViewLocationResult viewLocationResult, dynamic model, IRenderContext renderContext, ExpandoObject viewBag = null)
         {
             return new HtmlResponse(contents: s =>
                 {


### PR DESCRIPTION
Added ViewBag support for all ViewEngines.  Added a property ViewBag to NancyModule, it is passed down the view renderer chain (along with a View's model) to the selected ViewEngine.  With this pull request only the RazorViewEngine does anything with the viewbag parameter, the rest of the viewengines will need to implement their own support for rendering that data.
