### PR TITLE
Changed regex for parameter pattern to allow _ (underscore)

### DIFF
--- a/src/Nancy.Tests/Unit/Routing/DefaultRoutePatternMatcherFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/DefaultRoutePatternMatcherFixture.cs
@@ -122,7 +122,7 @@ namespace Nancy.Tests.Unit.Routing
         {
             // Given
             var parameter = Uri.EscapeUriString("baa ram ewe{}");
-            
+
             // When
             var results = this.matcher.Match("/foo/" + parameter, "/foo/{bar}");
 
@@ -141,6 +141,19 @@ namespace Nancy.Tests.Unit.Routing
 
             // Then
             ((string)results.Parameters["bar"]).ShouldEqual(parameter);
+        }
+
+        [Fact]
+        public void Should_allow_underscore_in_parameter_key()
+        {
+            // Given
+            const string parameter = "lol";
+
+            // When
+            var results = this.matcher.Match("/foo/" + parameter, "/foo/{b_ar}");
+
+            // Then
+            ((string)results.Parameters["b_ar"]).ShouldEqual(parameter);
         }
     }
 }

--- a/src/Nancy/Extensions/StringExtensions.cs
+++ b/src/Nancy/Extensions/StringExtensions.cs
@@ -14,7 +14,7 @@ namespace Nancy.Extensions
         /// <value>A <see cref="Regex"/> object.</value>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private static readonly Regex ParameterExpression =
-            new Regex(@"^\{(?<name>[A-Za-z0-9]*)\}", RegexOptions.Compiled);
+            new Regex(@"^\{(?<name>[A-Za-z0-9_]*)\}", RegexOptions.Compiled);
 
         /// <summary>   
         /// Extracts the name of a parameter from a segment.


### PR DESCRIPTION
Changed the regex used for route matching to allow _ (underscore) to make it possible to have paramters with names like foo_id

Ie: this will be possible /foo/{bar_id}
