### PR TITLE
Minor fix to DefaultResourceReader.GetResourceExtension()

### DIFF
--- a/src/Nancy/ViewEngines/DefaultResourceReader.cs
+++ b/src/Nancy/ViewEngines/DefaultResourceReader.cs
@@ -32,7 +32,8 @@
 
         private static string GetResourceExtension(string resourceName)
         {
-            return Path.GetExtension(resourceName).Substring(1);
+            var extension = Path.GetExtension(resourceName);
+            return string.IsNullOrEmpty(extension) ? string.Empty : extension.Substring(1);
         }
     }
 }


### PR DESCRIPTION
Patch is pretty self explanatory. 

Simply handles a null or empty value returned by Path.GetExtension().
