### PR TITLE
Disable Nancy-Version header by default (Issue #489)

### DIFF
--- a/src/Nancy.Tests/Unit/NancyEngineFixture.cs
+++ b/src/Nancy.Tests/Unit/NancyEngineFixture.cs
@@ -131,7 +131,7 @@ namespace Nancy.Tests.Unit
 
             result.Response.ShouldBeSameAs(this.response);
         }
-
+		
         [Fact]
         public void Should_add_nancy_version_number_header_on_returned_response()
         {
@@ -144,11 +144,26 @@ namespace Nancy.Tests.Unit
             // Then
             result.Response.Headers.ContainsKey("Nancy-Version").ShouldBeTrue();
         }
+	
+		[Fact]
+        public void Should_not_add_nancy_version_number_header_on_returned_response_when_disabled_in_static_configuration()
+        {
+            // Given
+			StaticConfiguration.EnableVersionHeader = false;
+            var request = new Request("GET", "/", "http");
 
+            // When
+            var result = this.engine.HandleRequest(request);
+
+            // Then
+            result.Response.Headers.ContainsKey("Nancy-Version").ShouldBeFalse();
+        }
+		
         [Fact]
         public void Should_not_throw_exception_when_setting_nancy_version_header_and_it_already_existed()
         {
             // Given
+            StaticConfiguration.EnableVersionHeader = true;
             var cachedResponse = new Response();
             cachedResponse.Headers.Add("Nancy-Version", "1.2.3.4");
             Func<NancyContext, Response> preRequestHook = (ctx) => cachedResponse;
@@ -177,6 +192,7 @@ namespace Nancy.Tests.Unit
         public void Should_set_nancy_version_number_on_returned_response()
         {
             // Given
+            StaticConfiguration.EnableVersionHeader = true;
             var request = new Request("GET", "/", "http");
             var nancyVersion = typeof(INancyEngine).Assembly.GetName().Version;
 

--- a/src/Nancy/NancyEngine.cs
+++ b/src/Nancy/NancyEngine.cs
@@ -118,6 +118,10 @@
             {
                 return;
             }
+            if (!StaticConfiguration.EnableVersionHeader)
+            {
+                return;
+            }
 
             var version =
                 typeof(INancyEngine).Assembly.GetName().Version;

--- a/src/Nancy/StaticConfiguration.cs
+++ b/src/Nancy/StaticConfiguration.cs
@@ -10,7 +10,7 @@ namespace Nancy
     {
         private static bool? isRunningDebug;
         private static bool? disableCaches;
-
+  
         private static bool? disableErrorTraces;
 
         static StaticConfiguration()
@@ -48,6 +48,11 @@ namespace Nancy
                 disableErrorTraces = value;
             }
         }
+		
+        /// <summary>
+        /// Gets or sets a value indicating whether or not to enable the Nancy-Version header from being sent with the response headers.
+        /// </summary>
+        public static bool EnableVersionHeader { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether or not to enable case sensitivity in query, parameters (DynamicDictionary) and model binding. Enable this to conform with RFC3986.


### PR DESCRIPTION
Disable the Nancy-Version header from all responses by default. Create configuration setting to enable the version header.
- Add StaticConfiguration.EnableVersionHeader option
- Add test for disabled (default) version header
- Update existing tests with StaticConfiguration.EnableVersionHeader option set to true
