### PR TITLE
Made helpers and url helper interfaces generic

### DIFF
--- a/src/Nancy.ViewEngines.Razor/HtmlHelpers.cs
+++ b/src/Nancy.ViewEngines.Razor/HtmlHelpers.cs
@@ -7,7 +7,7 @@
     /// Helpers to generate html content.
     /// </summary>
     /// <typeparam name="TModel">The type of the model.</typeparam>
-    public class HtmlHelpers<TModel> : IHtmlHelpers
+    public class HtmlHelpers<TModel> : IHtmlHelpers<TModel>
     {
         private readonly TModel model;
         public readonly RazorViewEngine engine;

--- a/src/Nancy.ViewEngines.Razor/IHtmlHelpers.cs
+++ b/src/Nancy.ViewEngines.Razor/IHtmlHelpers.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Defines the functionality of a html helper
     /// </summary>
-    public interface IHtmlHelpers
+    public interface IHtmlHelpers<TModel>
     {
         /// <summary>
         /// Renders a partial with the given view name.

--- a/src/Nancy.ViewEngines.Razor/IUrlHelpers.cs
+++ b/src/Nancy.ViewEngines.Razor/IUrlHelpers.cs
@@ -1,0 +1,11 @@
+namespace Nancy.ViewEngines.Razor
+{
+    public interface IUrlHelpers<TModel>
+    {
+        /// <summary>
+        /// Retrieves the absolute url of the specified path.
+        /// </summary>
+        /// <param name="path">The path.</param>
+        string Content(string path);
+    }
+}

--- a/src/Nancy.ViewEngines.Razor/Nancy.ViewEngines.Razor.csproj
+++ b/src/Nancy.ViewEngines.Razor/Nancy.ViewEngines.Razor.csproj
@@ -98,6 +98,7 @@
     <Compile Include="IHtmlString.cs" />
     <Compile Include="IRazorConfiguration.cs" />
     <Compile Include="IRazorViewRenderer.cs" />
+    <Compile Include="IUrlHelpers.cs" />
     <Compile Include="ModelFinder.cs" />
     <Compile Include="ModelSpan.cs" />
     <Compile Include="CSharp\NancyCSharpRazorCodeGenerator.cs" />

--- a/src/Nancy.ViewEngines.Razor/NancyRazorViewBase.cs
+++ b/src/Nancy.ViewEngines.Razor/NancyRazorViewBase.cs
@@ -225,7 +225,7 @@
         /// <summary>
         /// Gets the Html helper.
         /// </summary>
-        public IHtmlHelpers Html { get; private set; }
+        public IHtmlHelpers<TModel> Html { get; private set; }
 
         /// <summary>
         /// Gets the model.
@@ -235,7 +235,7 @@
         /// <summary>
         /// Gets the Url helper.
         /// </summary>
-        public UrlHelpers<TModel> Url { get; private set; }
+        public IUrlHelpers<TModel> Url { get; private set; }
 
         /// <summary>
         /// Initializes the specified engine.

--- a/src/Nancy.ViewEngines.Razor/UrlHelpers.cs
+++ b/src/Nancy.ViewEngines.Razor/UrlHelpers.cs
@@ -4,7 +4,7 @@ namespace Nancy.ViewEngines.Razor
     /// Helpers for url related functions.
     /// </summary>
     /// <typeparam name="TModel">The type of the model.</typeparam>
-    public class UrlHelpers<TModel>
+    public class UrlHelpers<TModel> : IUrlHelpers<TModel>
     {
         private readonly RazorViewEngine razorViewEngine;
         private readonly IRenderContext renderContext;


### PR DESCRIPTION
It now means all html helper extension methods will need to be generic, but I think that's fine as they can just ignore the generic param:

```
public static void MoreStuff<TModel>(this IHtmlHelpers<TModel> helpers)
{
}
```
