### PR TITLE
Self- and WCF hosting no longer share rootpathprovider

### DIFF
--- a/src/Nancy.Hosting.Self/FileSystemRootPathProvider.cs
+++ b/src/Nancy.Hosting.Self/FileSystemRootPathProvider.cs
@@ -1,0 +1,16 @@
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace Nancy.Hosting.Self
+{
+    public class FileSystemRootPathProvider : IRootPathProvider
+    {
+        public string GetRootPath()
+        {
+            var assembly = Assembly.GetEntryAssembly();
+
+            return assembly == null ? Environment.CurrentDirectory : Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+        }
+    }
+}

--- a/src/Nancy.Hosting.Self/Nancy.Hosting.Self.csproj
+++ b/src/Nancy.Hosting.Self/Nancy.Hosting.Self.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -80,12 +80,10 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\Nancy.Hosting.Wcf\FileSystemRootPathProvider.cs">
-      <Link>FileSystemRootPathProvider.cs</Link>
-    </Compile>
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="FileSystemRootPathProvider.cs" />
     <Compile Include="NancyHost.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Created a filesystemrootpathprovider for hosting.self instead of linking  from hosting.wcf

Fixed #521
