### PR TITLE
Move version header from engine to a startup class

### DIFF
--- a/src/Nancy.Tests/Nancy.Tests.csproj
+++ b/src/Nancy.Tests/Nancy.Tests.csproj
@@ -186,6 +186,7 @@
     <Compile Include="Unit\Routing\RouteFixture.cs" />
     <Compile Include="Unit\DynamicDictionaryFixture.cs" />
     <Compile Include="Unit\Routing\DefaultRouteResolverFixture.cs" />
+    <Compile Include="Unit\VersionHeaderStartupFixture.cs" />
     <Compile Include="Unit\Security\CsrfStartupFixture.cs" />
     <Compile Include="Unit\Security\DefaultCsrfTokenValidatorFixture.cs" />
     <Compile Include="Unit\Security\ModuleSecurityFixture.cs" />

--- a/src/Nancy.Tests/Unit/VersionHeaderStartupFixture.cs
+++ b/src/Nancy.Tests/Unit/VersionHeaderStartupFixture.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using Nancy.Bootstrapper;
+using Nancy.Tests.Fakes;
+using Xunit;
+
+namespace Nancy.Tests.Unit
+{
+    public class VersionHeaderStartupFixture
+    {
+        private readonly IPipelines pipelines;
+        private readonly VersionHeaderStartup versionHeaderStartup;
+        private readonly Request request;
+        private readonly Response response;
+        private readonly Version version;
+
+        public VersionHeaderStartupFixture()
+        {
+            this.pipelines = new MockPipelines();
+         
+            VersionHeaderStartup.Enable();
+         
+            this.versionHeaderStartup = new VersionHeaderStartup(new VersionHeader());
+
+            this.request = new FakeRequest("GET", "/");
+            this.response = new Response();
+            this.version = typeof(INancyEngine).Assembly.GetName().Version;
+        }
+
+        [Fact]
+        public void Should_not_add_nancy_version_number_header_on_returned_response_if_disabled()
+        {
+            var context = new NancyContext { Request = this.request, Response = this.response };
+            VersionHeaderStartup.Disable();
+            versionHeaderStartup.Initialize(this.pipelines);
+            this.pipelines.AfterRequest.Invoke(context);
+
+            this.response.Headers.ContainsKey("Nancy-Version").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_add_nancy_version_number_header_on_returned_response()
+        {
+            var context = new NancyContext { Request = this.request, Response = this.response };
+
+            versionHeaderStartup.Initialize(this.pipelines);
+            this.pipelines.AfterRequest.Invoke(context);
+
+            this.response.Headers.ContainsKey("Nancy-Version").ShouldBeTrue();
+        }
+
+
+        [Fact]
+        public void Should_set_nancy_version_number_on_returned_response()
+        {
+            var context = new NancyContext
+                {
+                    Request = this.request,
+                    Response = this.response
+                };
+
+            versionHeaderStartup.Initialize(this.pipelines);
+            this.pipelines.AfterRequest.Invoke(context);
+
+            this.response.Headers["Nancy-Version"].ShouldEqual(this.version.ToString());
+        }
+    }
+}

--- a/src/Nancy/Bootstrapper/VersionHeader.cs
+++ b/src/Nancy/Bootstrapper/VersionHeader.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Nancy.Bootstrapper
+{
+    public class VersionHeader
+    {
+        const string PipelineItemKey = "__VersionHeader";
+
+        public void AddToPipeline(IPipelines pipelines)
+        {
+            var versionHeaderItem = new PipelineItem<Action<NancyContext>>(PipelineItemKey, context =>
+                {
+                    if (context.Response == null)
+                    {
+                        return;
+                    }
+
+                    var version = typeof(INancyEngine).Assembly.GetName().Version;
+                    context.Response.Headers["Nancy-Version"] = version.ToString();
+                });
+
+            pipelines.AfterRequest += versionHeaderItem;
+        }
+    }
+}

--- a/src/Nancy/Bootstrapper/VersionHeaderStartup.cs
+++ b/src/Nancy/Bootstrapper/VersionHeaderStartup.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+
+namespace Nancy.Bootstrapper
+{
+    public class VersionHeaderStartup : IStartup
+    {
+        readonly VersionHeader versionHeader;
+
+        public VersionHeaderStartup(VersionHeader versionHeader)
+        {
+            this.versionHeader = versionHeader;
+        }
+
+        /// <summary>
+        /// Gets the type registrations to register for this startup task`
+        /// </summary>
+        public IEnumerable<TypeRegistration> TypeRegistrations
+        {
+            get { return null; }
+        }
+
+        /// <summary>
+        /// Gets the collection registrations to register for this startup task
+        /// </summary>
+        public IEnumerable<CollectionTypeRegistration> CollectionTypeRegistrations
+        {
+            get { return null; }
+        }
+
+        /// <summary>
+        /// Gets the instance registrations to register for this startup task
+        /// </summary>
+        public IEnumerable<InstanceRegistration> InstanceRegistrations
+        {
+            get { return null; }
+        }
+
+        /// <summary>
+        /// Perform any initialisation tasks
+        /// </summary>
+        /// <param name="pipelines">Application pipelines</param>
+        public void Initialize(IPipelines pipelines)
+        {
+            if (enabled)
+                versionHeader.AddToPipeline(pipelines);
+        }
+
+        public static bool enabled;
+        public static void Enable()
+        {
+            enabled = true;
+        }
+
+        public static void Disable()
+        {
+            enabled = false;
+        }
+    }
+}

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -96,6 +96,8 @@
     <Compile Include="Bootstrapper\IStartup.cs" />
     <Compile Include="Bootstrapper\NancyInternalConfiguration.cs" />
     <Compile Include="Bootstrapper\Pipelines.cs" />
+    <Compile Include="Bootstrapper\VersionHeader.cs" />
+    <Compile Include="Bootstrapper\VersionHeaderStartup.cs" />
     <Compile Include="Conventions\DefaultStaticContentsConventions.cs" />
     <Compile Include="Conventions\DefaultViewLocationConventions.cs" />
     <Compile Include="Conventions\IConvention.cs" />

--- a/src/Nancy/NancyEngine.cs
+++ b/src/Nancy/NancyEngine.cs
@@ -85,7 +85,6 @@
                 this.RequestPipelinesFactory.Invoke(context);
 
             this.InvokeRequestLifeCycle(context, pipelines);
-            AddNancyVersionHeaderToResponse(context);
 
             CheckErrorHandler(context);
 
@@ -176,19 +175,6 @@
                         onError.Invoke(e);
                     }
                 });
-        }
-
-        private static void AddNancyVersionHeaderToResponse(NancyContext context)
-        {
-            if (context.Response == null)
-            {
-                return;
-            }
-
-            var version =
-                typeof(INancyEngine).Assembly.GetName().Version;
-
-            context.Response.Headers["Nancy-Version"] = version.ToString();
         }
 
         private void CheckErrorHandler(NancyContext context)


### PR DESCRIPTION
- remove code from nancyengine that adds version header to the response
- add startup object that will add version header to response if VersionHeaderStartup.Enable() is called
- Moved applicable tests to VersionHeaderStartupFixture
