### PR TITLE
Request is now disposed and the request stream cleans any temporary file...

### DIFF
--- a/src/Nancy.Tests/Unit/IO/RequestStreamFixture.cs
+++ b/src/Nancy.Tests/Unit/IO/RequestStreamFixture.cs
@@ -349,6 +349,23 @@ namespace Nancy.Tests.Unit.IO
         }
 
         [Fact]
+        public void Should_delete_temporary_file_when_stream_was_flushed_to_disk_and_closed()
+        {
+            // Given
+            var buffer = new byte[100];
+            var request = RequestStream.FromStream(this.stream, 0, 10, false);
+            A.CallTo(() => this.stream.Length).Returns(100);
+            request.Write(buffer, 0, buffer.Length);
+
+            // When
+            request.Close();
+
+            // Then
+            A.CallTo(() => this.stream.Close()).MustHaveHappened();
+
+        }
+
+        [Fact]
         public void Should_read_from_underlaying_stream_when_read_is_called()
         {
             // Given

--- a/src/Nancy/IO/RequestStream.cs
+++ b/src/Nancy/IO/RequestStream.cs
@@ -13,6 +13,7 @@
         private bool disableStreamSwitching;
         private readonly long thresholdLength;
         private Stream stream;
+        private string filePath;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestStream"/> class.
@@ -176,6 +177,12 @@
         public override void Close()
         {
             this.stream.Close();
+
+            if (!string.IsNullOrEmpty(this.filePath) && File.Exists(this.filePath))
+            {
+                File.Delete(this.filePath);
+            }
+
         }
 
         /// <summary>
@@ -301,12 +308,12 @@
             }
         }
 
-        private static FileStream CreateTemporaryFileStream()
+        private FileStream CreateTemporaryFileStream()
         {
             var fileName = Path.GetTempFileName();
-            var filePath = Path.Combine(Path.GetTempPath(), fileName);
+            this.filePath = Path.Combine(Path.GetTempPath(), fileName);
 
-            return new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 8192, true);
+            return new FileStream(this.filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 8192, true);
         }
 
         private Stream CreateDefaultMemoryStream(long expectedLength)

--- a/src/Nancy/NancyEngine.cs
+++ b/src/Nancy/NancyEngine.cs
@@ -90,6 +90,8 @@
 
             this.SaveTraceInformation(context);
 
+            request.Dispose();
+
             return context;
         }
 

--- a/src/Nancy/Request.cs
+++ b/src/Nancy/Request.cs
@@ -249,5 +249,11 @@ namespace Nancy
 
             this.Method = this.Form["_method"];
         }
+
+        public void Dispose()
+        {
+            Body.Close();
+        }
     }
+
 }


### PR DESCRIPTION
... it might have created

Should resolve issue  #517
