### PR TITLE
pass NancyContext in HandlesStatusCode correctly

### DIFF
--- a/src/Nancy/NancyEngine.cs
+++ b/src/Nancy/NancyEngine.cs
@@ -177,7 +177,7 @@
                 return;
             }
 
-            foreach (var errorHandler in this.errorHandlers.Where(e => e.HandlesStatusCode(context.Response.StatusCode, null)))
+            foreach (var errorHandler in this.errorHandlers.Where(e => e.HandlesStatusCode(context.Response.StatusCode, context)))
             {
                 errorHandler.Handle(context.Response.StatusCode, context);
             }


### PR DESCRIPTION
``` csharp
public bool HandlesStatusCode(HttpStatusCode statusCode, NancyContext context);
```

context always seems to be null. with this pull request it correctly passes the value of context.
