### PR TITLE
Allow Nancy to run on machines with FIPS Compliance enabled

### DIFF
--- a/src/Nancy/Cryptography/CryptographyConfiguration.cs
+++ b/src/Nancy/Cryptography/CryptographyConfiguration.cs
@@ -1,23 +1,21 @@
-﻿namespace Nancy.Cryptography
+﻿using System;
+
+namespace Nancy.Cryptography
 {
     /// <summary>
     /// Cryptographic setup for classes that use encryption and HMAC
     /// </summary>
     public class CryptographyConfiguration
     {
-        /// <summary>
-        /// Initializes static members of the <see cref="CryptographyConfiguration"/> class.
-        /// </summary>
-        static CryptographyConfiguration()
-        {
-            Default = new CryptographyConfiguration(
-                    new RijndaelEncryptionProvider(new RandomKeyGenerator()),
-                    new DefaultHmacProvider(new RandomKeyGenerator()));
+        private static readonly Lazy<CryptographyConfiguration> DefaultConfiguration =
+            new Lazy<CryptographyConfiguration>(() => new CryptographyConfiguration(
+                                                          new RijndaelEncryptionProvider(new RandomKeyGenerator()),
+                                                          new DefaultHmacProvider(new RandomKeyGenerator())));
 
-            NoEncryption = new CryptographyConfiguration(
-                    new NoEncryptionProvider(),
-                    new DefaultHmacProvider(new RandomKeyGenerator()));
-        }
+        private static readonly Lazy<CryptographyConfiguration> NoEncryptionConfiguration =
+            new Lazy<CryptographyConfiguration>(() => new CryptographyConfiguration(
+                                                          new NoEncryptionProvider(),
+                                                          new DefaultHmacProvider(new RandomKeyGenerator())));
 
         /// <summary>
         /// Creates a new instance of the CryptographyConfiguration class
@@ -33,12 +31,18 @@
         /// <summary>
         /// Gets the default configuration - Rijndael encryption, HMACSHA256 HMAC, random keys
         /// </summary>
-        public static CryptographyConfiguration Default { get; private set; }
+        public static CryptographyConfiguration Default
+        {
+            get { return DefaultConfiguration.Value; }
+        }
 
         /// <summary>
         /// Gets configuration with no encryption and HMACSHA256 HMAC with a random key
         /// </summary>
-        public static CryptographyConfiguration NoEncryption { get; private set; }
+        public static CryptographyConfiguration NoEncryption
+        {
+            get { return NoEncryptionConfiguration.Value; }
+        }
 
         /// <summary>
         /// Gets the encryption provider

--- a/src/Nancy/Diagnostics/DiagnosticsConfiguration.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsConfiguration.cs
@@ -7,6 +7,16 @@
     /// </summary>
     public class DiagnosticsConfiguration
     {
+ 
+        public DiagnosticsConfiguration() : this(CryptographyConfiguration.Default)
+        {
+        }
+
+        public DiagnosticsConfiguration(CryptographyConfiguration cryptographyConfiguration)
+        {
+            CryptographyConfiguration = cryptographyConfiguration;
+        }
+
         /// <summary>
         /// Gets or sets password for accessing the diagnostics screen.
         /// This shoudl be secure :-)
@@ -24,11 +34,6 @@
         public bool Valid
         {
             get { return !string.IsNullOrWhiteSpace(this.Password); }
-        }
-
-        public DiagnosticsConfiguration()
-        {
-            this.CryptographyConfiguration = CryptographyConfiguration.Default;
         }
     }
 }


### PR DESCRIPTION
When attempting to run Nancy on Windows Server 2008 R2 with FIPS compliance turned on, the following exception occurs:

```
[InvalidOperationException: This implementation is not part of the Windows Platform FIPS validated     cryptographic algorithms.]
System.Security.Cryptography.SHA256Managed..ctor() +2464045
System.Security.Cryptography.HMACSHA256..ctor(Byte[] key) +51
System.Security.Cryptography.HMACSHA256..ctor() +24
Nancy.Cryptography.DefaultHmacProvider..ctor(IKeyGenerator keyGenerator) +46          
Nancy.Cryptography.CryptographyConfiguration..cctor() +111
```

FIPS Compliance is required for running on many US government machines. It can be enabled in Local Security Policy -> Local Policiies -> Security Options -> System Cryptography: Use FIPS compliant algorithms for encryption, hashing, and signing.

I attempted to circumvent this error by creating my own CryptographyConfiguration using FIPS-compliant algorithms (e.g. HMACSHA1 and DES Encryption), but still got the exception.

The error occurs because the static CryptographyConfiguration.Default instance uses non-FIPS compliant algorithms, and this instance gets created even if you provide your own configuration.

I have modifed CryptographyConfiguration to lazy-load the Default and NoEncryption instances, and allowed the user to inject a CryptographyConfiguration to the DiagnosticsConfiguration. This allows the user to bypass initializing the Default configuration if needed.
