### PR TITLE
allow assmblies besides Nancy.dll to use the EmbeddedFileResponse

### DIFF
--- a/src/Nancy/Diagnostics/EmbeddedFileResponse.cs
+++ b/src/Nancy/Diagnostics/EmbeddedFileResponse.cs
@@ -47,7 +47,7 @@
             resourceName =
                 string.Concat(resourcePath, ".", resourceName);
 
-            return this.GetType().Assembly.GetManifestResourceStream(resourceName);
+            return assembly.GetManifestResourceStream(resourceName);
         }
 
         private static string GetFileNameFromResourceName(string resourcePath, string resourceName)


### PR DESCRIPTION
Currently EmbeddedFileResponse works only if the resource is inside Nancy.dll. This patch will allow us to use EmbeddedFileResponse in our own .dll files.
