### PR TITLE
Allow Nancy users to use the latest version of Spark

### DIFF
--- a/src/Nancy.ViewEngines.Spark/nancy.viewengines.spark.nuspec
+++ b/src/Nancy.ViewEngines.Spark/nancy.viewengines.spark.nuspec
@@ -14,7 +14,7 @@
     <projectUrl>http://nancyfx.org</projectUrl>
     <dependencies>
       <dependency id="Nancy" />
-      <dependency id="Spark" version="[1.5.1]" />
+      <dependency id="Spark" version="1.5.1" />
     </dependencies> 
     <tags>Nancy Viewengine Spark</tags>
   </metadata>


### PR DESCRIPTION
Currently, we're stuck in v1.5.1 and I have to manually reference Spark v1.6.1 from visual studio because Nuget will only allow Nancy to run with Spark v1.5.1
