### PR TITLE
Added Nancy context to UserMapper

### DIFF
--- a/src/Nancy.Authentication.Forms.Tests/FormsAuthenticationFixture.cs
+++ b/src/Nancy.Authentication.Forms.Tests/FormsAuthenticationFixture.cs
@@ -348,7 +348,7 @@ namespace Nancy.Authentication.Forms.Tests
 
             fakePipelines.BeforeRequest.Invoke(this.context);
 
-            A.CallTo(() => mockMapper.GetUserFromIdentifier(this.context, this.userGuid))
+            A.CallTo(() => mockMapper.GetUserFromIdentifier(this.userGuid, this.context))
                 .MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -359,7 +359,7 @@ namespace Nancy.Authentication.Forms.Tests
             var fakeMapper = A.Fake<IUserMapper>();
             var fakeUser = A.Fake<IUserIdentity>();
             fakeUser.UserName = "Bob";
-            A.CallTo(() => fakeMapper.GetUserFromIdentifier(this.context, this.userGuid)).Returns(fakeUser);
+            A.CallTo(() => fakeMapper.GetUserFromIdentifier(this.userGuid, this.context)).Returns(fakeUser);
             this.config.UserMapper = fakeMapper;
             FormsAuthentication.Enable(fakePipelines, this.config);
             this.context.Request.Cookies.Add(FormsAuthentication.FormsAuthenticationCookieName, this.validCookieValue);
@@ -376,7 +376,7 @@ namespace Nancy.Authentication.Forms.Tests
             var fakeMapper = A.Fake<IUserMapper>();
             var fakeUser = A.Fake<IUserIdentity>();
             fakeUser.UserName = "Bob";
-            A.CallTo(() => fakeMapper.GetUserFromIdentifier(this.context, this.userGuid)).Returns(fakeUser);
+            A.CallTo(() => fakeMapper.GetUserFromIdentifier(this.userGuid, this.context)).Returns(fakeUser);
             this.config.UserMapper = fakeMapper;
             FormsAuthentication.Enable(fakePipelines, this.config);
             this.context.Request.Cookies.Add(FormsAuthentication.FormsAuthenticationCookieName, this.cookieWithInvalidHmac);
@@ -393,7 +393,7 @@ namespace Nancy.Authentication.Forms.Tests
             var fakeMapper = A.Fake<IUserMapper>();
             var fakeUser = A.Fake<IUserIdentity>();
             fakeUser.UserName = "Bob";
-            A.CallTo(() => fakeMapper.GetUserFromIdentifier(this.context, this.userGuid)).Returns(fakeUser);
+            A.CallTo(() => fakeMapper.GetUserFromIdentifier(this.userGuid, this.context)).Returns(fakeUser);
             this.config.UserMapper = fakeMapper;
             FormsAuthentication.Enable(fakePipelines, this.config);
             this.context.Request.Cookies.Add(FormsAuthentication.FormsAuthenticationCookieName, this.cookieWithEmptyHmac);
@@ -410,7 +410,7 @@ namespace Nancy.Authentication.Forms.Tests
             var fakeMapper = A.Fake<IUserMapper>();
             var fakeUser = A.Fake<IUserIdentity>();
             fakeUser.UserName = "Bob";
-            A.CallTo(() => fakeMapper.GetUserFromIdentifier(this.context, this.userGuid)).Returns(fakeUser);
+            A.CallTo(() => fakeMapper.GetUserFromIdentifier(this.userGuid, this.context)).Returns(fakeUser);
             this.config.UserMapper = fakeMapper;
             FormsAuthentication.Enable(fakePipelines, this.config);
             this.context.Request.Cookies.Add(FormsAuthentication.FormsAuthenticationCookieName, this.cookieWithNoHmac);
@@ -427,7 +427,7 @@ namespace Nancy.Authentication.Forms.Tests
             var fakeMapper = A.Fake<IUserMapper>();
             var fakeUser = A.Fake<IUserIdentity>();
             fakeUser.UserName = "Bob";
-            A.CallTo(() => fakeMapper.GetUserFromIdentifier(this.context, this.userGuid)).Returns(fakeUser);
+            A.CallTo(() => fakeMapper.GetUserFromIdentifier(this.userGuid, this.context)).Returns(fakeUser);
             this.config.UserMapper = fakeMapper;
             FormsAuthentication.Enable(fakePipelines, this.config);
             this.context.Request.Cookies.Add(FormsAuthentication.FormsAuthenticationCookieName, this.cookieWithBrokenEncryptedData);

--- a/src/Nancy.Authentication.Forms/FormsAuthentication.cs
+++ b/src/Nancy.Authentication.Forms/FormsAuthentication.cs
@@ -165,7 +165,7 @@ namespace Nancy.Authentication.Forms
                     if (userGuid != Guid.Empty)
                     {
 
-                      context.CurrentUser = configuration.UserMapper.GetUserFromIdentifier(context, userGuid);
+                      context.CurrentUser = configuration.UserMapper.GetUserFromIdentifier(userGuid, context);
                     }
 
                     return null;

--- a/src/Nancy.Authentication.Forms/IUsernameMapper.cs
+++ b/src/Nancy.Authentication.Forms/IUsernameMapper.cs
@@ -13,9 +13,9 @@ namespace Nancy.Authentication.Forms
         /// <summary>
         /// Get the real username from an indentifier
         /// </summary>
-        /// <param name="context">The current NancyFx context</param>
         /// <param name="identifier">User identifier</param>
+        /// <param name="context">The current NancyFx context</param>
         /// <returns>Matching populated IUserIdentity object, or empty</returns>
-        IUserIdentity GetUserFromIdentifier(NancyContext context, Guid identifier);
+        IUserIdentity GetUserFromIdentifier(Guid identifier, NancyContext context);
     }
 }

--- a/src/Nancy.Demo.Authentication.Forms/UserDatabase.cs
+++ b/src/Nancy.Demo.Authentication.Forms/UserDatabase.cs
@@ -18,7 +18,7 @@ namespace Nancy.Demo.Authentication.Forms
             users.Add(new Tuple<string, string, Guid>("user", "password", new Guid("56E1E49E-B7E8-4EEA-8459-7A906AC4D4C0")));
         }
 
-        public IUserIdentity GetUserFromIdentifier(NancyContext context, Guid identifier)
+        public IUserIdentity GetUserFromIdentifier(Guid identifier, NancyContext context)
         {
             var userRecord = users.Where(u => u.Item3 == identifier).FirstOrDefault();
 


### PR DESCRIPTION
Added the Nancy context to the UserMapper call to get access to the full Nancy environment. for example : Gives you the opportunity to store things in the Session after looking up the user.
