### PR TITLE
response.WithStatusCode extension method

### DIFF
--- a/src/Nancy.Tests/Unit/ResponseExtensionsFixture.cs
+++ b/src/Nancy.Tests/Unit/ResponseExtensionsFixture.cs
@@ -149,7 +149,7 @@
         }
 
         [Fact]
-        public void Should_set_the_content_type()
+        public void Should_set_the_content_type_enum()
         {
             var response = new Response();
 
@@ -164,6 +164,16 @@
             var respone = new Response();
 
             var result = respone.WithStatusCode(HttpStatusCode.NotFound);
+
+            respone.StatusCode.ShouldEqual(HttpStatusCode.NotFound);
+        }
+
+        [Fact]
+        public void Should_set_status_code_int()
+        {
+            var respone = new Response();
+
+            var result = respone.WithStatusCode(404);
 
             respone.StatusCode.ShouldEqual(HttpStatusCode.NotFound);
         }

--- a/src/Nancy/ResponseExtensions.cs
+++ b/src/Nancy/ResponseExtensions.cs
@@ -102,12 +102,24 @@ namespace Nancy
         /// <summary>
         /// Sets the status code of the response
         /// </summary>
-        /// <param name="response">Resposne object</param>
+        /// <param name="response">Response object</param>
         /// <param name="statusCode">The http status code</param>
         /// <returns>Modified response</returns>
         public static Response WithStatusCode(this Response response, HttpStatusCode statusCode)
         {
             response.StatusCode = statusCode;
+            return response;
+        }
+
+        /// <summary>
+        /// Sets the status code of the response
+        /// </summary>
+        /// <param name="response">Response object</param>
+        /// <param name="statusCode">The http status code</param>
+        /// <returns>Modified response</returns>
+        public static Response WithStatusCode(this Response response, int statusCode)
+        {
+            response.StatusCode = (HttpStatusCode) statusCode;
             return response;
         }
 


### PR DESCRIPTION
added extension method for changing status code so. It can take status code as both HttpStatusCode enum or int.

This is specially useful when using it with `View["404"]`;

currently we need to create a new variable to change view.

``` csharp
var view = View["404"];
view.StatusCode = HttpStatusCode.NotFound;
return view;
```

With this extension method you can now use either 

``` csharp
return View["404"].WithStatusCode(404);
```

or 

``` csharp
return view["404"].WithStatusCode(HttpStatusCode.NotFound);
```
