### PR TITLE
Self host content-length header issue

### DIFF
--- a/src/Nancy.Hosting.Self/NancyHost.cs
+++ b/src/Nancy.Hosting.Self/NancyHost.cs
@@ -131,6 +131,11 @@
                 response.Headers.Add(HttpResponseHeader.SetCookie, nancyCookie.ToString());
             }
 
+            if (nancyResponse.ContentLength64.HasValue)
+            {
+              response.ContentLength64 = nancyResponse.ContentLength64.Value;
+            }
+
             response.ContentType = nancyResponse.ContentType;
             response.StatusCode = (int)nancyResponse.StatusCode;
 

--- a/src/Nancy/Response.cs
+++ b/src/Nancy/Response.cs
@@ -35,6 +35,11 @@ namespace Nancy
         public string ContentType { get; set; }
 
         /// <summary>
+        /// Gets or sets the number of bytes in the body data included in the response.
+        /// </summary>
+        public long? ContentLength64 { get; set; }
+
+        /// <summary>
         /// Gets the delegate that will render contents to the response stream.
         /// </summary>
         /// <value>An <see cref="Action{T}"/> delegate, containing the code that will render contents to the response stream.</value>


### PR DESCRIPTION
On self hosting setting content-length using header property throwing exception. I added ContentLength64 property for setting content-length header value. We can also grab content-length from nancy response's header collection and then set it to HttpListenerResponse's ContentLength64 property explicitly but I don't think it's a clean solution.
