### PR TITLE
Added BindTo method to bind data to existing instance

### DIFF
--- a/src/Nancy/ModelBinding/ModuleExtensions.cs
+++ b/src/Nancy/ModelBinding/ModuleExtensions.cs
@@ -29,7 +29,7 @@ namespace Nancy.ModelBinding
         }
 
         /// <summary>
-        /// 
+        /// Bind the incoming request to an existing instance
         /// </summary>
         /// <typeparam name="TModel">Model type</typeparam>
         /// <param name="module">Current module</param>
@@ -39,7 +39,7 @@ namespace Nancy.ModelBinding
         {
             if (instance == null)
             {
-                throw new ArgumentNullException("instance", "Bind instance is null");
+                throw new ArgumentNullException("instance", "The instance parameter cannot be null");
             }
 
             var boundModel = module.Bind(blacklistedProperties);


### PR DESCRIPTION
This enables the user to do:

//Get instance with ID of 1
Dinner myDinner = GetDataFromDatabase(1);

//Bind posted data to instance
this.Bind(myDinner);

//Save instance to database. As the instance is the same and properties have changed the data will be saved
Session.SaveChanges();
