### PR TITLE
added static readonly NonEncodedHtmlString.Empty

### DIFF
--- a/src/Nancy.ViewEngines.Razor/NonEncodedHtmlString.cs
+++ b/src/Nancy.ViewEngines.Razor/NonEncodedHtmlString.cs
@@ -5,6 +5,11 @@
     /// </summary>
     public class NonEncodedHtmlString : IHtmlString
     {
+        /// <summary>
+        /// Represents the empty <see cref="NonEncodedHtmlString"/>. This field is readonly.
+        /// </summary>
+        public static readonly NonEncodedHtmlString Empty = new NonEncodedHtmlString(string.Empty);
+
         private readonly string value;
 
         /// <summary>


### PR DESCRIPTION
this is similar to `string.Empty`.

Rather then creating a new instance for every empty NonEncodedHtmlString, I found this quite handy `NonEncodedHtmlString.Empty`
