### PR TITLE
Only copy RazorBuildProvider around when in debug mode

### DIFF
--- a/src/Nancy.ViewEngines.Razor/GetNancyRazorBuildProviderPostBuildCmd.ps1
+++ b/src/Nancy.ViewEngines.Razor/GetNancyRazorBuildProviderPostBuildCmd.ps1
@@ -5,5 +5,7 @@ $BuildProvidersDir = Join-Path $path "BuildProviders"
 $ViewEngineDir = Join-Path $path "lib\Net40"
 
 $NancyRazorBuildProviderPostBuildCmd = "
-start /MIN xcopy /s /y /R `"$BuildProvidersDir\Nancy.ViewEngines.Razor.BuildProviders.dll`" `"`$(ProjectDir)bin`"
-start /MIN xcopy /s /y /R `"$ViewEngineDir\Nancy.ViewEngines.Razor.dll`" `"`$(ProjectDir)bin`""
+if `$(ConfigurationName) == Debug (
+xcopy /s /y /R `"$BuildProvidersDir\Nancy.ViewEngines.Razor.BuildProviders.dll`" `"`$(ProjectDir)bin`"
+xcopy /s /y /R `"$ViewEngineDir\Nancy.ViewEngines.Razor.dll`" `"`$(ProjectDir)bin`"
+)"


### PR DESCRIPTION
This configuration is safe for deployment at AppHarbor and still work nicely in development. It is what I use for AppHarbify.

I haven't actually built and tested a nuget package out of this, but I am pretty sure I have it all escaped properly.
