### PR TITLE
Use UTF8 with BOM

### DIFF
--- a/src/Nancy.Demo.Caching/CachedResponse.cs
+++ b/src/Nancy.Demo.Caching/CachedResponse.cs
@@ -34,7 +34,7 @@
         {
             return stream =>
             {
-                var writer = new StreamWriter(stream) { AutoFlush = true };
+                var writer = new StreamWriter(stream, Encoding.UTF8) { AutoFlush = true };
                 writer.Write(contents);
             };
         }

--- a/src/Nancy.Demo.Hosting.Aspnet/HereBeAResponseYouScurvyDog.cs
+++ b/src/Nancy.Demo.Hosting.Aspnet/HereBeAResponseYouScurvyDog.cs
@@ -29,7 +29,7 @@
         {
             return stream =>
             {
-                var writer = new StreamWriter(stream) { AutoFlush = true };
+                var writer = new StreamWriter(stream, Encoding.UTF8) { AutoFlush = true };
                 writer.Write(contents.Piratize());
             };
         }

--- a/src/Nancy.ViewEngines.NDjango/NDjangoViewEngine.cs
+++ b/src/Nancy.ViewEngines.NDjango/NDjangoViewEngine.cs
@@ -1,4 +1,6 @@
-﻿namespace Nancy.ViewEngines.NDjango
+﻿using System.Text;
+
+namespace Nancy.ViewEngines.NDjango
 {
     using System;
     using System.Collections.Generic;
@@ -54,7 +56,7 @@
                 
                 var reader = templateManager.GetTemplate(viewLocationResult.Location).Walk(templateManager, context);
 
-                var writer = new StreamWriter(stream);
+                var writer = new StreamWriter(stream, Encoding.UTF8);
 
                 writer.Write(reader.ReadToEnd());           
                 writer.Flush();

--- a/src/Nancy.ViewEngines.Nustache/NustacheViewEngine.cs
+++ b/src/Nancy.ViewEngines.Nustache/NustacheViewEngine.cs
@@ -1,4 +1,6 @@
-﻿namespace Nancy.ViewEngines.Nustache
+﻿using System.Text;
+
+namespace Nancy.ViewEngines.Nustache
 {
     using System;
     using System.Collections.Generic;
@@ -67,7 +69,7 @@
                         this.GetOrCompileTemplate(viewLocationResult, renderContext);
 
                     var writer =
-                        new StreamWriter(stream);
+                        new StreamWriter(stream, Encoding.UTF8);
 
                     template.Render(model, writer, null);
                 }

--- a/src/Nancy.ViewEngines.Razor/RazorViewEngine.cs
+++ b/src/Nancy.ViewEngines.Razor/RazorViewEngine.cs
@@ -88,7 +88,7 @@
 
             response.Contents = stream =>
             {
-                var writer = new StreamWriter(stream);
+                var writer = new StreamWriter(stream, Encoding.UTF8);
                 var view = this.GetViewInstance(viewLocationResult, renderContext, referencingAssembly, model);
                 view.ExecuteView(null, null);
                 var body = view.Body;

--- a/src/Nancy.ViewEngines.Spark/SparkViewEngine.cs
+++ b/src/Nancy.ViewEngines.Spark/SparkViewEngine.cs
@@ -1,4 +1,6 @@
-﻿namespace Nancy.ViewEngines.Spark
+﻿using System.Text;
+
+namespace Nancy.ViewEngines.Spark
 {
     using System;
     using System.Collections.Generic;
@@ -119,7 +121,7 @@
                     this.CreateView(viewLocationResult, model ?? new ExpandoObject(), renderContext);
 
                 var writer =
-                    new StreamWriter(stream);
+                    new StreamWriter(stream, Encoding.UTF8);
 
                 sparkViewEngineResult.View.Writer = writer;
                 sparkViewEngineResult.View.Model = model;

--- a/src/Nancy/Jsonp.cs
+++ b/src/Nancy/Jsonp.cs
@@ -60,7 +60,7 @@ namespace Nancy
                 context.Response.Contents = stream =>
                 {
                     // disposing of stream is handled elsewhere
-                    StreamWriter writer = new StreamWriter(stream)
+                    StreamWriter writer = new StreamWriter(stream, Encoding.UTF8)
                     {
                         AutoFlush = true
                     };

--- a/src/Nancy/Response.cs
+++ b/src/Nancy/Response.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace Nancy
 {
     using System;
@@ -100,7 +102,7 @@ namespace Nancy
         {
             return stream =>
             {
-                var writer = new StreamWriter(stream) { AutoFlush = true };
+                var writer = new StreamWriter(stream, Encoding.UTF8) { AutoFlush = true };
                 writer.Write(contents);
             };
         }

--- a/src/Nancy/Responses/DefaultJsonSerializer.cs
+++ b/src/Nancy/Responses/DefaultJsonSerializer.cs
@@ -1,4 +1,6 @@
-﻿namespace Nancy.Responses
+﻿using System.Text;
+
+namespace Nancy.Responses
 {
     using System;
     using System.IO;
@@ -27,7 +29,7 @@
         /// <returns>Serialised object</returns>
         public void Serialize<TModel>(string contentType, TModel model, Stream outputStream)
         {
-            using (var writer = new StreamWriter(new UnclosableStreamWrapper(outputStream)))
+            using (var writer = new StreamWriter(new UnclosableStreamWrapper(outputStream), Encoding.UTF8))
             {
                 var serializer = new JavaScriptSerializer(null, false, JsonSettings.MaxJsonLength, JsonSettings.MaxRecursions);
             

--- a/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngineWrapper.cs
+++ b/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngineWrapper.cs
@@ -1,4 +1,6 @@
-﻿namespace Nancy.ViewEngines.SuperSimpleViewEngine
+﻿using System.Text;
+
+namespace Nancy.ViewEngines.SuperSimpleViewEngine
 {
     using System;
     using System.Collections.Generic;
@@ -45,7 +47,7 @@
         {
             return new HtmlResponse(contents: s =>
                 {
-                    var writer = new StreamWriter(s);
+                    var writer = new StreamWriter(s, Encoding.UTF8);
                     var templateContents = renderContext.ViewCache.GetOrAdd(viewLocationResult, vr => vr.Contents.Invoke().ReadToEnd());
 
                     writer.Write(this.viewEngine.Render(templateContents, model, new NancyViewEngineHost(renderContext)));


### PR DESCRIPTION
Explicitly set encoding to `Encoding.UTF8`, which is UTF8 with BOM, to responses, serializers and renderers.
This solves the issue of non ascii characters, so that the default behavior of Nancy is UTF8 with BOM.
See a discussion here: https://groups.google.com/d/topic/nancy-web-framework/07G3oQF8XAM/discussion
