### PR TITLE
Set IgnoredAssemblies when initializing AppDomainAssemblyTypeScanner

### DIFF
--- a/src/Nancy/Bootstrapper/AppDomainAssemblyTypeScanner.cs
+++ b/src/Nancy/Bootstrapper/AppDomainAssemblyTypeScanner.cs
@@ -15,6 +15,7 @@ namespace Nancy.Bootstrapper
     {
         static AppDomainAssemblyTypeScanner()
         {
+            IgnoredAssemblies = NancyInternalConfiguration.DefaultIgnoredAssemblies;
             LoadNancyAssemblies();
         }
 


### PR DESCRIPTION
The value of IgnoredAssemblies is null when  AppDomainAssemblyTypeScanner#UpdateAssemblies initializes, which causes problems when scanning certain assemblies (like Microsoft.Web.Mvc).

Another fix is to simply catch the type load exception (https://github.com/runesoerensen/Nancy/compare/fix-typeload-exception) when "GetExportedTypes" is loaded, but it seems like the above solution would allow for the (supposedly intended) configurability of what assemblies should be ignored.
