### PR TITLE
Diagnostics login page - focus on Password js error

### DIFF
--- a/src/Nancy/Diagnostics/Views/login.sshtml
+++ b/src/Nancy/Diagnostics/Views/login.sshtml
@@ -20,7 +20,7 @@
 	</div>
 	<div class="grid_3">&nbsp;</div>
 	<script language="javascript" type="text/javascript">
-		Password.focus();
+		document.getElementById("Password").focus();
 	</script>
 @EndSection
 


### PR DESCRIPTION
Diagnostics login page - focus on Password field now uses javascript all browsers (including IE) should like.
