### PR TITLE
Updated view location convention order

### DIFF
--- a/src/Nancy.Tests/Unit/Conventions/DefaultViewLocationConventionsFixture.cs
+++ b/src/Nancy.Tests/Unit/Conventions/DefaultViewLocationConventionsFixture.cs
@@ -186,6 +186,40 @@ namespace Nancy.Tests.Unit.Conventions
         }
 
         [Fact]
+        public void Should_return_empty_result_convention_that_returns_viewname_in_modulepath_subfolder_of_views_folder_when_modulepath_is_empty()
+        {
+            // Given
+            this.viewLocationConventions.Initialise(this.conventions);
+            var convention = this.conventions.ViewLocationConventions[0];
+
+            // When
+            var result = convention.Invoke(
+                "viewname",
+                null,
+                new ViewLocationContext { ModulePath = string.Empty });
+
+            // Then
+            result.ShouldEqual(string.Empty);
+        }
+
+        [Fact]
+        public void Should_return_empty_result_convention_that_returns_viewname_in_modulepath_subfolder_of_views_folder_when_modulepath_is_null()
+        {
+            // Given
+            this.viewLocationConventions.Initialise(this.conventions);
+            var convention = this.conventions.ViewLocationConventions[0];
+
+            // When
+            var result = convention.Invoke(
+                "viewname",
+                null,
+                new ViewLocationContext { ModulePath = null });
+
+            // Then
+            result.ShouldEqual(string.Empty);
+        }
+
+        [Fact]
         public void Should_define_convention_that_returns_viewname_in_modulepath_folder()
         {
             // Given
@@ -200,6 +234,40 @@ namespace Nancy.Tests.Unit.Conventions
 
             // Then
             result.ShouldEqual("modulepath/viewname");
+        }
+
+        [Fact]
+        public void Should_return_empty_result_for_convention_that_returns_viewname_in_modulepath_folder_when_modulepath_is_empty()
+        {
+            // Given
+            this.viewLocationConventions.Initialise(this.conventions);
+            var convention = this.conventions.ViewLocationConventions[2];
+
+            // When
+            var result = convention.Invoke(
+                "viewname",
+                null,
+                new ViewLocationContext { ModulePath = string.Empty });
+
+            // Then
+            result.ShouldEqual(string.Empty);
+        }
+
+        [Fact]
+        public void Should_return_empty_result_for_convention_that_returns_viewname_in_modulepath_folder_when_modulepath_is_null()
+        {
+            // Given
+            this.viewLocationConventions.Initialise(this.conventions);
+            var convention = this.conventions.ViewLocationConventions[2];
+
+            // When
+            var result = convention.Invoke(
+                "viewname",
+                null,
+                new ViewLocationContext { ModulePath = null });
+
+            // Then
+            result.ShouldEqual(string.Empty);
         }
 
         [Fact]

--- a/src/Nancy/Conventions/DefaultViewLocationConventions.cs
+++ b/src/Nancy/Conventions/DefaultViewLocationConventions.cs
@@ -39,16 +39,16 @@
         {
             conventions.ViewLocationConventions = new List<Func<string, object, ViewLocationContext, string>>
             {
-                (viewName, model, viewLocationContext) => {
-                    return string.Concat("views/", viewLocationContext.ModulePath.TrimStart(new[] {'/'}), "/", viewName);
+                (viewName, model, viewLocationContext) =>{
+                    return string.IsNullOrEmpty(viewLocationContext.ModulePath) ? string.Empty : string.Concat("views/", viewLocationContext.ModulePath.TrimStart(new[] {'/'}), "/", viewName);
                 },
 
                 (viewName, model, viewLocationContext) => {
                     return string.Concat("views/", viewLocationContext.ModuleName, "/", viewName);
                 },
 
-                (viewName, model, viewLocationContext) => {
-                    return string.Concat(viewLocationContext.ModulePath.TrimStart(new[] { '/' }), "/", viewName);
+                (viewName, model, viewLocationContext) =>{
+                    return string.IsNullOrEmpty(viewLocationContext.ModulePath) ? string.Empty : string.Concat(viewLocationContext.ModulePath.TrimStart(new[] { '/' }), "/", viewName);
                 },
 
                 (viewName, model, viewLocationContext) => {


### PR DESCRIPTION
The conventions will now use the most strict convention first and
work its way back to the less strict one. The new order is
- views/modulepath/viewname
- views/modulename/viewname
- modulepath/viewname
- modulename/viewname
- views/viewname
- viewname

Fixes #632
This is a breaking change!
