### PR TITLE
Made RequestHeaders writeable

### DIFF
--- a/src/Nancy.Tests/Unit/RequestHeadersFixture.cs
+++ b/src/Nancy.Tests/Unit/RequestHeadersFixture.cs
@@ -1314,6 +1314,715 @@
             result.ShouldBeSameAs(expectedValues);
         }
 
+        [Fact]
+        public void Should_allow_accept_headers_to_be_overwritten()
+        {
+            // Given
+            var expectedValues = new[] {
+                new Tuple<string, decimal>("text/plain", 0.8m), 
+                new Tuple<string, decimal>("text/ninja", 0.5m), 
+            };
+
+            var rawHeaders = 
+                new Dictionary<string, IEnumerable<string>> { { "Accept", new [] { "initial value" } } };
+
+            var headers = 
+                new RequestHeaders(rawHeaders) {Accept = expectedValues};
+
+            // When
+            var values = headers.Accept.ToList();
+
+            // Then
+            values[0].Item1.ShouldEqual("text/plain");
+            values[0].Item2.ShouldEqual(0.8m);
+            values[1].Item1.ShouldEqual("text/ninja");
+            values[1].Item2.ShouldEqual(0.5m);
+        }
+
+        [Fact]
+        public void Should_remove_accept_if_assigned_null()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Accept", new[] { "text/plain" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { Accept = null };
+
+            // When
+            var values = headers.Keys;
+
+            // Then
+            values.Contains("Accept").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_allow_accept_charset_headers_to_be_overwritten()
+        {
+            // Given
+            var expectedValues = new[] {
+                new Tuple<string, decimal>("utf-8", 0.7m), 
+                new Tuple<string, decimal>("iso-8859-5", 0.3m), 
+            };
+
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Accept-Charset", new[] { "utf-7" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { AcceptCharset = expectedValues };
+
+            // When
+            var values = headers.AcceptCharset.ToList();
+
+            // Then
+            values[0].Item1.ShouldEqual("utf-8");
+            values[0].Item2.ShouldEqual(0.7m);
+            values[1].Item1.ShouldEqual("iso-8859-5");
+            values[1].Item2.ShouldEqual(0.3m);
+        }
+
+        [Fact]
+        public void Should_remove_accept_charset_if_assigned_null()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Accept-Charset", new[] { "iso-8859-5" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { AcceptCharset = null };
+
+            // When
+            var values = headers.Keys;
+
+            // Then
+            values.Contains("Accept-Charset").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_allow_accept_encoding_headers_to_be_overwritten()
+        {
+            // Given
+            var expectedValues = new[] {
+                "compress", 
+                "gzip", 
+            };
+
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Accept-Encoding", new[] { "sdch" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { AcceptEncoding = expectedValues };
+
+            // When
+            var values = headers.AcceptEncoding.ToList();
+
+            // Then
+            values[0].ShouldEqual("compress");
+            values[1].ShouldEqual("gzip");
+        }
+
+        [Fact]
+        public void Should_remove_accept_encoding_if_assigned_null()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Accept-Encoding", new[] { "compress" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { AcceptEncoding = null };
+
+            // When
+            var values = headers.Keys;
+
+            // Then
+            values.Contains("Accept-Encoding").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_allow_accept_language_headers_to_be_overwritten()
+        {
+            // Given
+            var expectedValues = new[] {
+                new Tuple<string, decimal>("en-US", 0.7m), 
+                new Tuple<string, decimal>("sv-SE", 0.3m)
+            };
+
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Accept-Language", new[] { "da" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { AcceptLanguage = expectedValues };
+
+            // When
+            var values = headers.AcceptLanguage.ToList();
+
+            // Then
+            values[0].Item1.ShouldEqual("en-US");
+            values[0].Item2.ShouldEqual(0.7m);
+            values[1].Item1.ShouldEqual("sv-SE");
+            values[1].Item2.ShouldEqual(0.3m);
+        }
+
+        [Fact]
+        public void Should_remove_accept_language_if_assigned_null()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Accept-Language", new[] { "en-US" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { AcceptLanguage = null };
+
+            // When
+            var values = headers.Keys;
+
+            // Then
+            values.Contains("Accept-Language").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_allow_accept_authorization_to_be_overwritten()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Authorization", new[] { "Basic 12345LDKJDFJDDSFDFvfdf==" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { Authorization = "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==" };
+
+            // When
+            var values = headers.Authorization;
+
+            // Then
+            values.ShouldEqual("Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
+        }
+
+        [Fact]
+        public void Should_remove_authorization_if_assigned_null()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Authorization", new[] { "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { Authorization = null };
+
+            // When
+            var values = headers.Keys;
+
+            // Then
+            values.Contains("Authorization").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_allow_cache_control_headers_to_be_overwritten()
+        {
+            // Given
+            var expectedValues = new[] {
+                "public", 
+                "max-age=123445", 
+            };
+
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Cache-Control", new[] { "no-transform" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { CacheControl = expectedValues };
+
+            // When
+            var values = headers.CacheControl.ToList();
+
+            // Then
+            values[0].ShouldEqual("public");
+            values[1].ShouldEqual("max-age=123445");
+        }
+
+        [Fact]
+        public void Should_remove_cache_control_if_assigned_null()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Cache-Control", new[] { "public" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { CacheControl = null };
+
+            // When
+            var values = headers.Keys;
+
+            // Then
+            values.Contains("Cache-Control").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_allow_connection_to_be_overwritten()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Connection", new[] { "closed" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { Connection = "keep-alive" };
+
+            // When
+            var values = headers.Connection;
+
+            // Then
+            values.ShouldEqual("keep-alive");
+        }
+
+        [Fact]
+        public void Should_remove_connection_if_assigned_null()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Connection", new[] { "text/plain" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { Connection = null };
+
+            // When
+            var values = headers.Keys;
+
+            // Then
+            values.Contains("Connection").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_allow_content_length_to_be_overwritten()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Content-Length", new[] { "12345" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { ContentLength = 54321 };
+
+            // When
+            var values = headers.ContentLength;
+
+            // Then
+            values.ShouldEqual(54321L);
+        }
+
+        [Fact]
+        public void Should_remove_content_length_if_assigned_zero()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Content-Length", new[] { "12345" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { ContentLength = 0 };
+
+            // When
+            var values = headers.Keys;
+
+            // Then
+            values.Contains("Content-Length").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_allow_content_type_to_be_overwritten()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Content-Type", new[] { "application/json" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { ContentType = "text/html" };
+
+            // When
+            var values = headers.ContentType;
+
+            // Then
+            values.ShouldEqual("text/html");
+        }
+
+        [Fact]
+        public void Should_remove_content_type_if_assigned_null()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Content-Type", new[] { "text/plain" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { ContentType = null };
+
+            // When
+            var values = headers.Keys;
+
+            // Then
+            values.Contains("Content-Type").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_allow_date_to_be_overwritten()
+        {
+            // Given
+            var expectedValue =
+                new DateTime(2012, 12, 15, 8, 12, 31);
+
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Date", new[] { "Tue, 15 Nov 2011 08:12:31 GMT" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { Date = expectedValue };
+
+            // When
+            var values = headers.Date;
+
+            // Then
+            values.ShouldEqual(expectedValue);
+        }
+
+        [Fact]
+        public void Should_remove_date_if_assigned_null()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Date", new[] { "Tue, 15 Nov 2011 08:12:31 GMT" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { Date = null };
+
+            // When
+            var values = headers.Keys;
+
+            // Then
+            values.Contains("Date").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_allow_host_to_be_overwritten()
+        {
+            // Given
+            const string expectedValue = "www.nancyfx.org";
+
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Host", new[] { "en.wikipedia.org" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { Host = expectedValue };
+
+            // When
+            var values = headers.Host;
+
+            // Then
+            values.ShouldEqual(expectedValue);
+        }
+
+        [Fact]
+        public void Should_remove_host_if_assigned_null()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Host", new[] { "www.nancyfx.org" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { Host = null };
+
+            // When
+            var values = headers.Keys;
+
+            // Then
+            values.Contains("Host").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_allow_if_match_headers_to_be_overwritten()
+        {
+            // Given
+            var expectedValues = new[] {
+                "fsdfsd", "c3pdfgdfgjiozzzz" 
+            };
+
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "If-Match", new[] { "xyzzy", "c3piozzzz" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { IfMatch = expectedValues };
+
+            // When
+            var values = headers.IfMatch.ToArray();
+
+            // Then
+            values.ShouldEqualSequence(expectedValues);
+        }
+
+        [Fact]
+        public void Should_remove_if_match_if_assigned_null()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "If-Match", new[] { "fsdfsd" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { IfMatch = null };
+
+            // When
+            var values = headers.Keys;
+
+            // Then
+            values.Contains("If-Match").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_allow_if_modified_since_to_be_overwritten()
+        {
+            // Given
+            var expectedValue =
+                new DateTime(2012, 12, 15, 8, 12, 31);
+
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "If-Modified-Since", new[] { "Tue, 15 Nov 2011 08:12:31 GMT" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { IfModifiedSince = expectedValue };
+
+            // When
+            var values = headers.IfModifiedSince;
+
+            // Then
+            values.ShouldEqual(expectedValue);
+        }
+
+        [Fact]
+        public void Should_remove_if_modified_since_if_assigned_null()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "If-Modified-Since", new[] { "Tue, 15 Nov 2011 08:12:31 GMT" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { IfModifiedSince = null };
+
+            // When
+            var values = headers.Keys;
+
+            // Then
+            values.Contains("If-Modified-Since").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_allow_if_none_match_to_be_overwritten()
+        {
+            // Given
+            var expectedValues = new[] {
+                "fsdfsd", "c3pdfgdfgjiozzzz" 
+            };
+
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "If-None-Match", new[] { "xyzzy", "c3piozzzz" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { IfNoneMatch = expectedValues };
+
+            // When
+            var values = headers.IfNoneMatch.ToArray();
+
+            // Then
+            values.ShouldEqualSequence(expectedValues);
+        }
+
+        [Fact]
+        public void Should_remove_if_none_match_if_assigned_null()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "If-None-Match", new[] { "fsdfsd" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { IfNoneMatch = null };
+
+            // When
+            var values = headers.Keys;
+
+            // Then
+            values.Contains("If-None-Match").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_allow_if_range_to_be_overwritten()
+        {
+            // Given
+            const string expectedValue = "737060cd8c284d8af7ad3082f209582d";
+
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "If-Range", new[] { "737060ed712v4d8af7ad3082f209582d" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { IfRange = expectedValue };
+
+            // When
+            var values = headers.IfRange;
+
+            // Then
+            values.ShouldEqual(expectedValue);
+        }
+
+        [Fact]
+        public void Should_remove_if_range_if_assigned_null()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "If-Range", new[] { "737060cd8c284d8af7ad3082f209582d" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { IfRange = null };
+
+            // When
+            var values = headers.Keys;
+
+            // Then
+            values.Contains("If-Range").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_allow_if_unmodified_since_to_be_overwritten()
+        {
+            // Given
+            var expectedValue =
+                new DateTime(2012, 12, 15, 8, 12, 31);
+
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "If-Unmodified-Since", new[] { "Tue, 15 Nov 2011 08:12:31 GMT" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { IfUnmodifiedSince = expectedValue };
+
+            // When
+            var values = headers.IfUnmodifiedSince;
+
+            // Then
+            values.ShouldEqual(expectedValue);
+        }
+
+        [Fact]
+        public void Should_remove_if_unmodified_since_if_assigned_null()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "If-Unmodified-Since", new[] { "Tue, 15 Nov 2011 08:12:31 GMT" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { IfUnmodifiedSince = null };
+
+            // When
+            var values = headers.Keys;
+
+            // Then
+            values.Contains("If-Unmodified-Since").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_allow_max_forwards_to_be_overwritten()
+        {
+            // Given
+            const int expectedValue = 10;
+
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Max-Forwards", new[] { "3" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { MaxForwards = expectedValue };
+
+            // When
+            var values = headers.MaxForwards;
+
+            // Then
+            values.ShouldEqual(expectedValue);
+        }
+
+        [Fact]
+        public void Should_remove_max_forwards_if_assigned_zero()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Max-Forwards", new[] { "2" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { MaxForwards = 0 };
+
+            // When
+            var values = headers.Keys;
+
+            // Then
+            values.Contains("Max-Forwards").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_allow_referrer_to_be_overwritten()
+        {
+            // Given
+            const string expectedValue = "www.nancyfx.org";
+
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Referer", new[] { "en.wikipedia.com" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { Referrer = expectedValue };
+
+            // When
+            var values = headers.Referrer;
+
+            // Then
+            values.ShouldEqual(expectedValue);
+        }
+
+        [Fact]
+        public void Should_remove_referrer_header_if_assigned_null()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "Referer", new[] { "en.wikipedia.com" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { Referrer = null };
+
+            // When
+            var values = headers.Keys;
+
+            // Then
+            values.Contains("Referer").ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_allow_user_agent_to_be_overwritten()
+        {
+            // Given
+            const string expectedValue = "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:15.0) Gecko/20120427 Firefox/15.0a1";
+
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "User-Agent", new[] { "Mozilla/5.0 (Windows NT 5.1) AppleWebKit/535.1 (KHTML, like Gecko) Chrome/14.0.815.0 Safari/535.1" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { UserAgent = expectedValue };
+
+            // When
+            var values = headers.UserAgent;
+
+            // Then
+            values.ShouldEqual(expectedValue);
+        }
+
+        [Fact]
+        public void Should_remove_user_agent_header_if_assigned_null()
+        {
+            // Given
+            var rawHeaders =
+                new Dictionary<string, IEnumerable<string>> { { "User-Agent", new[] { "Mozilla/5.0 (Windows NT 5.1) AppleWebKit/535.1 (KHTML, like Gecko) Chrome/14.0.815.0 Safari/535.1" } } };
+
+            var headers =
+                new RequestHeaders(rawHeaders) { UserAgent = null };
+
+            // When
+            var values = headers.Keys;
+
+            // Then
+            values.Contains("User-Agent").ShouldBeFalse();
+        }
+
         private static void ValidateCookie(INancyCookie cookie, string name, string value)
         {
             cookie.Name.ShouldEqual(name);

--- a/src/Nancy/RequestHeaders.cs
+++ b/src/Nancy/RequestHeaders.cs
@@ -31,6 +31,7 @@ namespace Nancy
         public IEnumerable<Tuple<string, decimal>> Accept
         {
             get { return GetWeightedValues("Accept").ToList(); }
+            set { this.SetHeaderValues("Accept", value, GetWeightedValuesAsStrings); }
         }
 
         /// <summary>
@@ -40,6 +41,7 @@ namespace Nancy
         public IEnumerable<Tuple<string, decimal>> AcceptCharset
         {
             get { return this.GetWeightedValues("Accept-Charset"); }
+            set { this.SetHeaderValues("Accept-Charset", value, GetWeightedValuesAsStrings); }
         }
 
         /// <summary>
@@ -49,6 +51,7 @@ namespace Nancy
         public IEnumerable<string> AcceptEncoding
         {
             get { return this.GetSplitValues("Accept-Encoding"); }
+            set { this.SetHeaderValues("Accept-Encoding", value, x => x); }
         }
 
         /// <summary>
@@ -58,6 +61,7 @@ namespace Nancy
         public IEnumerable<Tuple<string, decimal>> AcceptLanguage
         {
             get { return this.GetWeightedValues("Accept-Language"); }
+            set { this.SetHeaderValues("Accept-Language", value, GetWeightedValuesAsStrings); }
         }
 
         /// <summary>
@@ -67,6 +71,7 @@ namespace Nancy
         public string Authorization
         {
             get { return this.GetValue("Authorization", x => x.First()); }
+            set { this.SetHeaderValues("Authorization", value, x => new[] { x }); }
         }
 
         /// <summary>
@@ -76,6 +81,7 @@ namespace Nancy
         public IEnumerable<string> CacheControl
         {
             get { return this.GetValue("Cache-Control"); }
+            set { this.SetHeaderValues("Cache-Control", value, x => x); }
         }
         
         /// <summary>
@@ -94,6 +100,7 @@ namespace Nancy
         public string Connection
         {
             get { return this.GetValue("Connection", x => x.First()); }
+            set { this.SetHeaderValues("Connection", value, x => new[] { x }); }
         }
 
         /// <summary>
@@ -103,6 +110,7 @@ namespace Nancy
         public long ContentLength
         {
             get { return this.GetValue("Content-Length", x => Convert.ToInt64(x.First())); }
+            set { this.SetHeaderValues("Content-Length", value, x => new[] { x.ToString(CultureInfo.InvariantCulture) }); }
         }
 
         /// <summary>
@@ -112,6 +120,7 @@ namespace Nancy
         public string ContentType
         {
             get { return this.GetValue("Content-Type", x => x.First()); }
+            set { this.SetHeaderValues("Content-Type", value, x => new[] { x }); }
         }
 
         /// <summary>
@@ -121,6 +130,7 @@ namespace Nancy
         public DateTime? Date
         {
             get { return this.GetValue("Date", x => ParseDateTime(x.First())); }
+            set { this.SetHeaderValues("Date", value, x => new[] { GetDateAsString(value) }); }
         }
 
         /// <summary>
@@ -130,6 +140,7 @@ namespace Nancy
         public string Host
         {
             get { return this.GetValue("Host", x => x.First()); }
+            set { this.SetHeaderValues("Host", value, x => new[] { x }); }
         }
 
         /// <summary>
@@ -139,6 +150,7 @@ namespace Nancy
         public IEnumerable<string> IfMatch
         {
             get { return this.GetValue("If-Match"); }
+            set { this.SetHeaderValues("If-Match", value, x => x); }
         }
 
         /// <summary>
@@ -148,6 +160,7 @@ namespace Nancy
         public DateTime? IfModifiedSince
         {
             get { return this.GetValue("If-Modified-Since", x => ParseDateTime(x.First())); }
+            set { this.SetHeaderValues("If-Modified-Since", value, x => new[] { GetDateAsString(value) }); }
         }
 
         /// <summary>
@@ -157,6 +170,7 @@ namespace Nancy
         public IEnumerable<string> IfNoneMatch
         {
             get { return this.GetValue("If-None-Match"); }
+            set { this.SetHeaderValues("If-None-Match", value, x => x); }
         }
 
         /// <summary>
@@ -166,6 +180,7 @@ namespace Nancy
         public string IfRange
         {
             get { return this.GetValue("If-Range", x => x.First()); }
+            set { this.SetHeaderValues("If-Range", value, x => new[] { x }); }
         }
 
         /// <summary>
@@ -175,6 +190,8 @@ namespace Nancy
         public DateTime? IfUnmodifiedSince
         {
             get { return this.GetValue("If-Unmodified-Since", x => ParseDateTime(x.First())); }
+            set { this.SetHeaderValues("If-Unmodified-Since", value, x => new[] { GetDateAsString(value) }); }
+
         }
 
         /// <summary>
@@ -193,6 +210,7 @@ namespace Nancy
         public int MaxForwards
         {
             get { return this.GetValue("Max-Forwards", x => Convert.ToInt32(x.First())); }
+            set { this.SetHeaderValues("Max-Forwards", value, x => new[] { x.ToString(CultureInfo.InvariantCulture) }); }
         }
 
         /// <summary>
@@ -202,6 +220,7 @@ namespace Nancy
         public string Referrer
         {
             get { return this.GetValue("Referer", x => x.First()); }
+            set { this.SetHeaderValues("Referer", value, x => new[] { x }); }
         }
 
         /// <summary>
@@ -211,6 +230,7 @@ namespace Nancy
         public string UserAgent
         {
             get { return this.GetValue("User-Agent", x => x.First()); }
+            set { this.SetHeaderValues("User-Agent", value, x => new[] { x }); }
         }
 
         /// <summary>
@@ -253,6 +273,11 @@ namespace Nancy
                     this.headers[name] :
                     Enumerable.Empty<string>();
             }
+        }
+
+        private static string GetDateAsString(DateTime? value)
+        {
+            return !value.HasValue ? null : value.Value.ToString("R", CultureInfo.InvariantCulture);
         }
 
         private IEnumerable<string> GetSplitValues(string header)
@@ -333,13 +358,17 @@ namespace Nancy
             }
 
             return converter.Invoke(this.headers[name]);
-        } 
+        }
+
+        private static IEnumerable<string> GetWeightedValuesAsStrings(IEnumerable<Tuple<string, decimal>> values)
+        {
+            return values.Select(x => string.Concat(x.Item1, ";q=", x.Item2.ToString(CultureInfo.InvariantCulture)));
+        }
 
         private static bool IsGenericEnumerable(Type T)
         {
             return !(T == typeof(string)) && T.IsGenericType && T.GetGenericTypeDefinition() == typeof(IEnumerable<>);
         }
-
 
         private static DateTime? ParseDateTime(string value)
         {
@@ -350,6 +379,21 @@ namespace Nancy
                 return result;
             }
             return null;
+        }
+
+        private void SetHeaderValues<T>(string header, T value, Func<T, IEnumerable<string>> valueTransformer)
+        {
+            if (EqualityComparer<T>.Default.Equals(value, default(T)))
+            {
+                if (this.headers.ContainsKey(header))
+                {
+                    this.headers.Remove(header);
+                }
+            }
+            else
+            {
+                this.headers[header] = valueTransformer.Invoke(value);
+            }
         }
     }
 }


### PR DESCRIPTION
You can now change the value of the request headers. If you assign a header
the default value of the return type (for instance null for a string) then
the header will be removed from the keys collection until a new value is
assigned

Fixes #281
