### PR TITLE
Changed auto registration behavior

### DIFF
--- a/src/Nancy.Testing/ConfigurableBootstrapper.cs
+++ b/src/Nancy.Testing/ConfigurableBootstrapper.cs
@@ -25,7 +25,7 @@ namespace Nancy.Testing
         private readonly List<InstanceRegistration> registeredInstances;
         private readonly NancyInternalConfiguration configuration;
         private readonly ConfigurableModuleCatalog catalog;
-        private bool disableAutoRegistration;
+        private bool enableAutoRegistration;
         private DiagnosticsConfiguration diagnosticConfiguration;
 
         /// <summary>
@@ -215,7 +215,7 @@ namespace Nancy.Testing
         /// <param name="container">Container instance</param>
         protected override void ConfigureApplicationContainer(TinyIoCContainer container)
         {
-            if (!this.disableAutoRegistration)
+            if (this.enableAutoRegistration)
             {
                 container.AutoRegister();
                 this.RegisterBootstrapperTypes(container);
@@ -534,9 +534,9 @@ namespace Nancy.Testing
             /// Disables the auto registration behavior of the bootstrapper
             /// </summary>
             /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator DisableAutoRegistration()
+            public ConfigurableBoostrapperConfigurator EnableAutoRegistration()
             {
-                this.bootstrapper.disableAutoRegistration = true;
+                this.bootstrapper.enableAutoRegistration = true;
                 return this;
             }
 

--- a/src/Nancy.Tests/Unit/Diagnostics/DiagnosticsHookFixture.cs
+++ b/src/Nancy.Tests/Unit/Diagnostics/DiagnosticsHookFixture.cs
@@ -6,7 +6,6 @@
     using Nancy.Cryptography;
     using Nancy.Diagnostics;
     using Nancy.Testing;
-
     using Xunit;
 
     public class DiagnosticsHookFixture
@@ -26,96 +25,158 @@
         [Fact]
         public void Should_return_info_page_if_password_null()
         {
+            // Given
             var diagsConfig = new DiagnosticsConfiguration { Password = null, CryptographyConfiguration = this.cryptoConfig };
-            var bootstrapper = new ConfigurableBootstrapper(b => b.DiagnosticsConfiguration(diagsConfig));
+
+            var bootstrapper = new ConfigurableBootstrapper(with =>{
+                with.EnableAutoRegistration();
+                with.DiagnosticsConfiguration(diagsConfig);
+            });
+
             var browser = new Browser(bootstrapper);
 
+            // When
             var result = browser.Get("/_Nancy");
 
+            // Then
             Assert.True(result.Body.AsString().Contains("Diagnostics Disabled"));
         }
 
         [Fact]
         public void Should_return_info_page_if_password_empty()
         {
+            // Given
             var diagsConfig = new DiagnosticsConfiguration { Password = string.Empty, CryptographyConfiguration = this.cryptoConfig };
-            var bootstrapper = new ConfigurableBootstrapper(b => b.DiagnosticsConfiguration(diagsConfig));
+
+            var bootstrapper = new ConfigurableBootstrapper(with =>
+            {
+                with.EnableAutoRegistration();
+                with.DiagnosticsConfiguration(diagsConfig);
+            });
+
             var browser = new Browser(bootstrapper);
 
+            // When
             var result = browser.Get("/_Nancy");
 
-	    Assert.True(result.Body.AsString().Contains("Diagnostics Disabled"));
+            // Then
+            Assert.True(result.Body.AsString().Contains("Diagnostics Disabled"));
         }
 
         [Fact]
         public void Should_return_login_page_with_no_auth_cookie()
         {
+            // Given
             var diagsConfig = new DiagnosticsConfiguration { Password = "password", CryptographyConfiguration = this.cryptoConfig };
-            var bootstrapper = new ConfigurableBootstrapper(b => b.DiagnosticsConfiguration(diagsConfig));
+
+            var bootstrapper = new ConfigurableBootstrapper(with =>
+            {
+                with.EnableAutoRegistration();
+                with.DiagnosticsConfiguration(diagsConfig);
+            });
+
             var browser = new Browser(bootstrapper);
 
+            // When
             var result = browser.Get("/_Nancy");
 
+            // Then
             result.Body["#login"].ShouldExistOnce();
         }
 
         [Fact]
         public void Should_return_main_page_with_valid_auth_cookie()
         {
+            // Given
             var diagsConfig = new DiagnosticsConfiguration { Password = "password", CryptographyConfiguration = this.cryptoConfig };
-            var bootstrapper = new ConfigurableBootstrapper(b => b.DiagnosticsConfiguration(diagsConfig));
+
+            var bootstrapper = new ConfigurableBootstrapper(with =>
+            {
+                with.EnableAutoRegistration();
+                with.DiagnosticsConfiguration(diagsConfig);
+            });
+
             var browser = new Browser(bootstrapper);
 
+            // When
             var result = browser.Get("/_Nancy", with =>
                 {
                     with.Cookie(DiagsCookieName, this.GetSessionCookieValue("password"));
                 });
 
+            // Then
             result.Body["#infoBox"].ShouldExistOnce();
         }
 
         [Fact]
         public void Should_return_login_page_with_expired_auth_cookie()
         {
+            // Given
             var diagsConfig = new DiagnosticsConfiguration { Password = "password", CryptographyConfiguration = this.cryptoConfig };
-            var bootstrapper = new ConfigurableBootstrapper(b => b.DiagnosticsConfiguration(diagsConfig));
+
+            var bootstrapper = new ConfigurableBootstrapper(with =>
+            {
+                with.EnableAutoRegistration();
+                with.DiagnosticsConfiguration(diagsConfig);
+            });
+
             var browser = new Browser(bootstrapper);
 
+            // When
             var result = browser.Get("/_Nancy", with =>
             {
                 with.Cookie(DiagsCookieName, this.GetSessionCookieValue("password", DateTime.Now.AddMinutes(-10)));
             });
 
+            // Then
             result.Body["#login"].ShouldExistOnce();
         }
 
         [Fact]
         public void Should_return_login_page_with_auth_cookie_with_incorrect_password()
         {
+            // Given
             var diagsConfig = new DiagnosticsConfiguration { Password = "password", CryptographyConfiguration = this.cryptoConfig };
-            var bootstrapper = new ConfigurableBootstrapper(b => b.DiagnosticsConfiguration(diagsConfig));
+
+            var bootstrapper = new ConfigurableBootstrapper(with =>
+            {
+                with.EnableAutoRegistration();
+                with.DiagnosticsConfiguration(diagsConfig);
+            });
+
             var browser = new Browser(bootstrapper);
 
+            // When
             var result = browser.Get("/_Nancy", with =>
             {
                 with.Cookie(DiagsCookieName, this.GetSessionCookieValue("wrongPassword"));
             });
 
+            // Then
             result.Body["#login"].ShouldExistOnce();
         }
 
         [Fact]
         public void Should_not_accept_invalid_password()
         {
+            // Given
             var diagsConfig = new DiagnosticsConfiguration { Password = "password", CryptographyConfiguration = this.cryptoConfig };
-            var bootstrapper = new ConfigurableBootstrapper(b => b.DiagnosticsConfiguration(diagsConfig));
+
+            var bootstrapper = new ConfigurableBootstrapper(with =>
+            {
+                with.EnableAutoRegistration();
+                with.DiagnosticsConfiguration(diagsConfig);
+            });
+
             var browser = new Browser(bootstrapper);
 
+            // When
             var result = browser.Post("/_Nancy", with =>
             {
                 with.FormValue("Password", "wrongpassword");
             });
 
+            // Then
             result.Body["#login"].ShouldExistOnce();
             result.Cookies.Any(c => c.Name == DiagsCookieName && !string.IsNullOrEmpty(c.Value)).ShouldBeFalse();
         }
@@ -123,15 +184,24 @@
         [Fact]
         public void Should_set_login_cookie_when_password_correct()
         {
+            // Given
             var diagsConfig = new DiagnosticsConfiguration { Password = "password", CryptographyConfiguration = this.cryptoConfig };
-            var bootstrapper = new ConfigurableBootstrapper(b => b.DiagnosticsConfiguration(diagsConfig));
+
+            var bootstrapper = new ConfigurableBootstrapper(with =>
+            {
+                with.EnableAutoRegistration();
+                with.DiagnosticsConfiguration(diagsConfig);
+            });
+
             var browser = new Browser(bootstrapper);
 
+            // When
             var result = browser.Post("/_Nancy/", with =>
             {
                 with.FormValue("Password", "password");
             });
 
+            // Then
             result.Cookies.Any(c => c.Name == DiagsCookieName).ShouldBeTrue();
             string.IsNullOrEmpty(result.Cookies.First(c => c.Name == DiagsCookieName).Value).ShouldBeFalse();
         }
@@ -139,13 +209,24 @@
         [Fact]
         public void Should_use_rolling_expiry_for_auth_cookie()
         {
+            // Given
             var diagsConfig = new DiagnosticsConfiguration { Password = "password", CryptographyConfiguration = this.cryptoConfig };
-            var bootstrapper = new ConfigurableBootstrapper(b => b.DiagnosticsConfiguration(diagsConfig));
+
+            var bootstrapper = new ConfigurableBootstrapper(with =>
+            {
+                with.EnableAutoRegistration();
+                with.DiagnosticsConfiguration(diagsConfig);
+            });
+
             var browser = new Browser(bootstrapper);
-
             var expiryDate = DateTime.Now.AddMinutes(5);
-            var result = browser.Get("/_Nancy", with => with.Cookie(DiagsCookieName, this.GetSessionCookieValue("password", expiryDate)));
 
+            // When
+            var result = browser.Get("/_Nancy", with =>{
+                with.Cookie(DiagsCookieName, this.GetSessionCookieValue("password", expiryDate));
+            });
+
+            // Then
             result.Cookies.Any(c => c.Name == DiagsCookieName).ShouldBeTrue();
             this.DecodeCookie(result.Cookies.First(c => c.Name == DiagsCookieName))
                 .Expiry.ShouldNotEqual(expiryDate);

--- a/src/Nancy.ViewEngines.DotLiquid.Tests/Functional/PartialRenderingFixture.cs
+++ b/src/Nancy.ViewEngines.DotLiquid.Tests/Functional/PartialRenderingFixture.cs
@@ -10,7 +10,6 @@ namespace Nancy.ViewEngines.DotLiquid.Tests.Functional
         public PartialRenderingFixture()
         {
             var bootstrapper = new ConfigurableBootstrapper(with => {
-                with.DisableAutoRegistration();
                 with.Module<PartialRenderingModule>();
                 with.RootPathProvider<RootPathProvider>();
             });


### PR DESCRIPTION
The DisableAutoRegistration function on the ConfigurableBootstrapper
has been replaced by EnableAutoRegistration. This means that with this
patch, the auto-registration will be disabled by default instead of
enabled. The reason for this are primarily for performance but also
to help make tests be more implicit in setting up the context in
which they execute.

Fixes #643
