### PR TITLE
Ignoring Nancy.Testing assembly

### DIFF
--- a/src/Nancy/Bootstrapper/NancyInternalConfiguration.cs
+++ b/src/Nancy/Bootstrapper/NancyInternalConfiguration.cs
@@ -42,6 +42,7 @@ namespace Nancy.Bootstrapper
                 asm => asm.FullName.StartsWith("IronPython", StringComparison.InvariantCulture),
                 asm => asm.FullName.StartsWith("IronRuby", StringComparison.InvariantCulture),
                 asm => asm.FullName.StartsWith("xunit", StringComparison.InvariantCulture),
+                asm => asm.FullName.StartsWith("Nancy.Testing", StringComparison.InvariantCulture),
             };
 
         /// <summary>


### PR DESCRIPTION
The AppDomainAssemblyTypeScanner will not scan Nancy.Testing when
it's been added to the default ignored assemblies. This prevents
it from finding stuff like the FakeNancyModule

Fixes #647
