### PR TITLE
Moved registration of IRazorConfiguration

### DIFF
--- a/src/Nancy.ViewEngines.Razor/RazorViewEngine.cs
+++ b/src/Nancy.ViewEngines.Razor/RazorViewEngine.cs
@@ -33,15 +33,6 @@
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="RazorViewEngine"/> class with a default configuration.
-        /// </summary>
-        /// <remarks>Well create an instance of the engine using the <see cref="DefaultRazorConfiguration"/>.</remarks>
-        public RazorViewEngine()
-            : this(new DefaultRazorConfiguration())
-        {
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="RazorViewEngine"/> class.
         /// </summary>
         /// <param name="configuration">The <see cref="IRazorConfiguration"/> that should be used by the engine.</param>

--- a/src/Nancy.ViewEngines.Razor/RazorViewEngineApplicationStartupRegistrations.cs
+++ b/src/Nancy.ViewEngines.Razor/RazorViewEngineApplicationStartupRegistrations.cs
@@ -1,0 +1,35 @@
+namespace Nancy.ViewEngines.Razor
+{
+    using System.Collections.Generic;
+    using Bootstrapper;
+
+    /// <summary>
+    /// Default dependency registrations for the <see cref="RazorViewEngine"/> class.
+    /// </summary>
+    public class RazorViewEngineApplicationRegistrations : IApplicationRegistrations
+    {
+        /// <summary>
+        /// Gets the type registrations to register for this startup task
+        /// </summary>
+        public IEnumerable<TypeRegistration> TypeRegistrations
+        {
+            get { return new[] { new TypeRegistration(typeof(IRazorConfiguration), typeof(DefaultRazorConfiguration)) }; }
+        }
+
+        /// <summary>
+        /// Gets the collection registrations to register for this startup task
+        /// </summary>
+        public IEnumerable<CollectionTypeRegistration> CollectionTypeRegistrations
+        {
+            get { return null; }
+        }
+
+        /// <summary>
+        /// Gets the instance registrations to register for this startup task
+        /// </summary>
+        public IEnumerable<InstanceRegistration> InstanceRegistrations
+        {
+            get { return null; }
+        }
+    }
+}


### PR DESCRIPTION
It now takes place in an IApplicationRegistrations implementation.

Fixes #662
