### PR TITLE
render child requests in razor views

### DIFF
--- a/src/Nancy.Demo.Hosting.Aspnet/MainModule.cs
+++ b/src/Nancy.Demo.Hosting.Aspnet/MainModule.cs
@@ -88,6 +88,18 @@ namespace Nancy.Demo.Hosting.Aspnet
                 return View[new SomeViewModel()];
             };
 
+            Get["/viewwithchildview"] = x =>
+            {
+                var model = new RatPack { FirstName = "Parent" };
+                return View["viewwithchildview.cshtml", model];
+            };
+            Get["/childview"] = x =>
+            {
+                var firstNameFromQueryString = Request.Query["FirstName"];
+                var model = new RatPack { FirstName = firstNameFromQueryString };
+                return View["childview.cshtml", model];
+            };
+
             Get["/spark"] = x => {
                 var model = new RatPack { FirstName = "Bright" };
                 return View["spark.spark", model];

--- a/src/Nancy.Demo.Hosting.Aspnet/Nancy.Demo.Hosting.Aspnet.csproj
+++ b/src/Nancy.Demo.Hosting.Aspnet/Nancy.Demo.Hosting.Aspnet.csproj
@@ -108,6 +108,8 @@
     <Content Include="Content\scripts.js" />
     <Content Include="Views\razor-error.cshtml" />
     <Content Include="Views\razor-layout-error.cshtml" />
+    <Content Include="Views\viewwithchildview.cshtml" />
+    <Content Include="Views\childview.cshtml" />
     <None Include="Views\FileUpload.sshtml">
       <SubType>Designer</SubType>
     </None>

--- a/src/Nancy.Demo.Hosting.Aspnet/Views/childview.cshtml
+++ b/src/Nancy.Demo.Hosting.Aspnet/Views/childview.cshtml
@@ -1,0 +1,5 @@
+﻿<div>
+    <h1>View: ChildView</h1>
+    <h1>First Name From (Child) Model: @Model.FirstName</h1>
+    <p>This is the child view being rendered within parent view!</p>
+</div>

--- a/src/Nancy.Demo.Hosting.Aspnet/Views/viewwithchildview.cshtml
+++ b/src/Nancy.Demo.Hosting.Aspnet/Views/viewwithchildview.cshtml
@@ -1,0 +1,11 @@
+﻿<html>
+<head>
+    <title>Razor View Engine Demo</title>
+</head>
+<body>
+    <h1>View: ViewWithChildView</h1>
+    <h1>First Name From Model: @Model.FirstName</h1>
+    <p>This is a sample of using a child view within a parent view!</p>
+	@Html.Get("/childview", new { firstName = "ImmaChild" })
+</body>
+</html>

--- a/src/Nancy.ViewEngines.Razor/HtmlHelpers.cs
+++ b/src/Nancy.ViewEngines.Razor/HtmlHelpers.cs
@@ -1,4 +1,9 @@
-﻿namespace Nancy.ViewEngines.Razor
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using Nancy.Helpers;
+
+namespace Nancy.ViewEngines.Razor
 {
     using System;
     using System.IO;
@@ -94,5 +99,71 @@
 
             return new NonEncodedHtmlString(String.Format("<input type=\"hidden\" name=\"{0}\" value=\"{1}\"/>", tokenKeyValue.Key, tokenKeyValue.Value));
         }
+
+        /// <summary>
+        /// Allows you to perform a child request and insert the output somewhere into a parent view.
+        /// </summary>
+        /// <param name="route">the route you wish to </param>
+        /// <param name="queryStringParams"></param>
+        /// <returns></returns>
+        public IHtmlString Get(string route, object queryStringParams)
+        {
+            return Get(route, GetDictionaryFromObjectProps(queryStringParams));
+        }
+
+        public IHtmlString Get(string route, IDictionary<string, object> queryStringParams)
+        {
+            var currentContext = this.RenderContext.Context;
+            var headers = new Dictionary<string, IEnumerable<string>>();
+            foreach (var key in currentContext.Request.Headers.Keys)
+            {
+                headers[key] = currentContext.Request.Headers[key];
+            }
+
+            var queryString = GetQueryString(queryStringParams);
+
+            var nancyEngine = currentContext.NancyEngine;
+            var req = new Request("GET", route, headers, null, currentContext.Request.Url.Scheme, queryString, currentContext.Request.UserHostAddress);
+            var childContext = nancyEngine.HandleRequest(req);
+
+            Action<Stream> action = childContext.Response.Contents;
+            var mem = new MemoryStream();
+            action.Invoke(mem);
+            mem.Position = 0;
+            var reader = new StreamReader(mem);
+
+            return new NonEncodedHtmlString(reader.ReadToEnd());
+        }
+
+
+        private static Dictionary<string, object> GetDictionaryFromObjectProps(object parameters)
+        {
+            var publicAttributes = BindingFlags.Public | BindingFlags.Instance;
+            var dictionary = new Dictionary<string, object>();
+
+            foreach (PropertyInfo property in parameters.GetType().GetProperties(publicAttributes))
+            {
+                if (property.CanRead)
+                    dictionary.Add(property.Name, property.GetValue(parameters, null));
+            }
+
+            return dictionary;
+        }
+
+        private static string GetQueryString(IDictionary<string, object> d)
+        {
+            if (d == null || d.Count == 0)
+                return "";
+
+            var paramList = new List<string>();
+            foreach (var keyAndVal in d)
+            {
+                var val = keyAndVal.Value == null ? "" : keyAndVal.Value.ToString();
+                paramList.Add(string.Format("{0}={1}", HttpUtility.UrlEncode(keyAndVal.Key), HttpUtility.UrlEncode(val)));
+            }
+
+            return string.Join("&", paramList.ToArray());
+        }
+
     }
 }

--- a/src/Nancy/NancyContext.cs
+++ b/src/Nancy/NancyContext.cs
@@ -55,6 +55,8 @@ namespace Nancy
             }
         }
 
+        public INancyEngine NancyEngine { get; set; }
+
         /// <summary>
         /// Gets or sets the outgoing response
         /// </summary>

--- a/src/Nancy/NancyEngine.cs
+++ b/src/Nancy/NancyEngine.cs
@@ -73,6 +73,7 @@
 
             var context = this.contextFactory.Create();
             context.Request = request;
+            context.NancyEngine = this;
 
             var pipelines =
                 this.RequestPipelinesFactory.Invoke(context);


### PR DESCRIPTION
This is a proof of concept on rendering child requests within views.
This allows for more modular view pieces than you get with Partial
views, as the parent doesn't have to worry about constructing the model
for the child view piece.  To see the proof in action, launch the
Nancy.Demo.Hosting.Aspnet project and browse to the /viewwithchildview
route.
