### PR TITLE
If the input is null and I cast to string then it should be null

### DIFF
--- a/src/Nancy.Tests/Unit/DynamicDictionaryValueFixture.cs
+++ b/src/Nancy.Tests/Unit/DynamicDictionaryValueFixture.cs
@@ -377,5 +377,12 @@
             Assert.Equal(expected, actual);
         }
 
+        [Fact]
+        public void Should_return_null_when_value_is_null_and_casting_to_string()
+        {
+            dynamic value = new DynamicDictionaryValue(null);
+            String actual = value;
+            Assert.Null(actual);
+        }
     }
 }

--- a/src/Nancy/DynamicDictionaryValue.cs
+++ b/src/Nancy/DynamicDictionaryValue.cs
@@ -214,7 +214,9 @@
 
         public static implicit operator string(DynamicDictionaryValue dynamicValue)
         {
-            return dynamicValue.ToString();
+            return dynamicValue.HasValue
+                       ? Convert.ToString(dynamicValue.value)
+                       : null;
         }
 
         public static implicit operator int(DynamicDictionaryValue dynamicValue)


### PR DESCRIPTION
Found this when testing a custom model binder.
