### PR TITLE
Added rate limit HTTP status codes. 420,429.

### DIFF
--- a/src/Nancy/HttpStatusCode.cs
+++ b/src/Nancy/HttpStatusCode.cs
@@ -171,6 +171,10 @@ namespace Nancy
         /// </summary>
         ImATeapot = 418,
         /// <summary>
+        /// 420 Enhance Your Calm
+        /// </summary>
+        EnhanceYourCalm = 420,
+        /// <summary>
         /// 422 UnprocessableEntity
         /// </summary>
         UnprocessableEntity = 422,
@@ -190,6 +194,10 @@ namespace Nancy
         /// 426 UpgradeRequired
         /// </summary>
         UpgradeRequired = 426,
+        /// <summary>
+        /// 429 Too Many Requests
+        /// </summary>
+        TooManyRequests = 429,
         /// <summary>
         /// 444 NoResponse
         /// </summary>


### PR DESCRIPTION
420 Enhance Your Calm (Twitter)
Returned by the Twitter Search and Trends API when the client is being rate limited. Other services may wish to implement the 429 Too Many Requests response code instead.

429 Too Many Requests (RFC 6585)
The user has sent too many requests in a given amount of time. Intended for use with rate limiting schemes.
