### PR TITLE
When view name occurs in the path the view cannot be resolved

### DIFF
--- a/src/Nancy.Tests/Unit/ViewEngines/DefaultViewLocatorFixture.cs
+++ b/src/Nancy.Tests/Unit/ViewEngines/DefaultViewLocatorFixture.cs
@@ -289,6 +289,22 @@ namespace Nancy.Tests.Unit.ViewEngines
             result.ShouldBeSameAs(expectedView);
         }
 
+        [Fact]
+        public void Should_be_able_to_locate_view_by_name_when_the_viewname_occures_in_the_location()
+        {
+           // Given
+           var expectedView = new ViewLocationResult( "views/hello", "hello", "cshtml", () => null );
+           //var additionalView = new ViewLocationResult( "views", "index", "spark", () => null );
+           var cache = new FakeViewLocationCache( expectedView );
+           var locator = CreateViewLocator( cache );
+
+           // When
+           var result = locator.LocateView( "views/hello/hello", null );
+
+           // Then
+           result.ShouldBeSameAs( expectedView );
+        }
+
         private static DefaultViewLocator CreateViewLocator(IViewLocationCache viewLocationCache)
         {
             return new DefaultViewLocator(viewLocationCache);

--- a/src/Nancy/ViewEngines/DefaultViewLocator.cs
+++ b/src/Nancy/ViewEngines/DefaultViewLocator.cs
@@ -65,9 +65,10 @@
 
         private static bool LocationMatchesView(string viewName, ViewLocationResult viewLocationResult)
         {
-            var location = viewName
-                .Replace(Path.GetFileName(viewName), string.Empty)
-                .TrimEnd(new [] { '/' });
+            var filename = Path.GetFileName( viewName );
+            var index = viewName.LastIndexOf(filename, System.StringComparison.OrdinalIgnoreCase );
+            var location = index >= 0 ? viewName.Remove( index, filename.Length ) : viewName;
+            location = location.TrimEnd( new[] { '/' } );
 
             return viewLocationResult.Location.Equals(location, StringComparison.OrdinalIgnoreCase);
         }


### PR DESCRIPTION
The view is located correctly but not returned by the DefaultViewLocator because the LocationMatchesView method removes all occurrences of the view name from the path. It should only strip off the file name to verify the view location.
From what I can tell, this will only occur for views resolved from the model name because otherwise the file extension of the view file is included.
### Reproduction:

``` c#
public class HelloModule : NancyModule
{
    public HelloModule()
    {
       Get["/"] = parameters => View[ new HelloModel{ Greeting = "Hello World!"}];
    }
}

public class HelloModel
{
   public string Greeting { get; set; }
}
```

And create a view in _Views/Hello/Hello.sshtml_
### Result:

> Nancy.RequestExecutionException: Oh noes! ---> Nancy.ViewEngines.ViewNotFoundException: Unable to locate view 'Hello'
> Currently available view engine extensions: sshtml,html,htm,cshtml,vbhtml
> Locations inspected: Hello,views/Hello,views//Hello,/Hello,views/Hello/Hello,Hello/Hello,/views/Hello/Hello
