### PR TITLE
Allow setting Form Auth cookie's 'Secure' attribute via ModuleExtensions API

### DIFF
--- a/src/Nancy.Authentication.Forms.Tests/FormsAuthenticationFixture.cs
+++ b/src/Nancy.Authentication.Forms.Tests/FormsAuthenticationFixture.cs
@@ -218,6 +218,34 @@ namespace Nancy.Authentication.Forms.Tests
         }
 
         [Fact]
+        public void Should_set_secure_attribute_if_secure_specified_when_logging_in_with_redirect()
+        {
+            // Given
+            FormsAuthentication.Enable(A.Fake<IPipelines>(), this.config);
+
+            // When
+			var result = FormsAuthentication.UserLoggedInRedirectResponse(context, userGuid, DateTime.Now.AddDays(1), secure: true);
+
+            // Then
+            result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName).First()
+                .Secure.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Should_set_secure_attribute_if_secure_specified_when_logging_in_without_redirect()
+        {
+            // Given
+            FormsAuthentication.Enable(A.Fake<IPipelines>(), this.config);
+
+            // When
+            var result = FormsAuthentication.UserLoggedInResponse(userGuid, DateTime.Now.AddDays(1), secure: true);
+
+            // Then
+            result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName).First()
+                .Secure.ShouldBeTrue();
+        }
+
+        [Fact]
         public void Should_encrypt_cookie_when_logging_in_with_redirect()
         {
             var mockEncrypter = A.Fake<IEncryptionProvider>();

--- a/src/Nancy.Authentication.Forms/FormsAuthentication.cs
+++ b/src/Nancy.Authentication.Forms/FormsAuthentication.cs
@@ -61,16 +61,17 @@ namespace Nancy.Authentication.Forms
             pipelines.AfterRequest.AddItemToEndOfPipeline(GetRedirectToLoginHook(configuration));
         }
 
-        /// <summary>
-        /// Creates a response that sets the authentication cookie and redirects
-        /// the user back to where they came from.
-        /// </summary>
-        /// <param name="context">Current context</param>
-        /// <param name="userIdentifier">User identifier guid</param>
-        /// <param name="cookieExpiry">Optional expiry date for the cookie (for 'Remember me')</param>
-        /// <param name="fallbackRedirectUrl">Url to redirect to if none in the querystring</param>
-        /// <returns>Nancy response with redirect.</returns>
-        public static Response UserLoggedInRedirectResponse(NancyContext context, Guid userIdentifier, DateTime? cookieExpiry = null, string fallbackRedirectUrl = "/")
+    	/// <summary>
+    	/// Creates a response that sets the authentication cookie and redirects
+    	/// the user back to where they came from.
+    	/// </summary>
+    	/// <param name="context">Current context</param>
+    	/// <param name="userIdentifier">User identifier guid</param>
+    	/// <param name="cookieExpiry">Optional expiry date for the cookie (for 'Remember me')</param>
+    	/// <param name="fallbackRedirectUrl">Url to redirect to if none in the querystring</param>
+		/// <param name="secure">Optional flag to control whether the cookie is secure (i.e. HTTPS only). Defaults to false.</param>
+    	/// <returns>Nancy response with redirect.</returns>
+    	public static Response UserLoggedInRedirectResponse(NancyContext context, Guid userIdentifier, DateTime? cookieExpiry = null, string fallbackRedirectUrl = "/", bool secure = false)
         {
             var redirectUrl = fallbackRedirectUrl;
             string redirectQuerystringKey = GetRedirectQuerystringKey(currentConfiguration);
@@ -81,7 +82,7 @@ namespace Nancy.Authentication.Forms
             }
 
             var response = context.GetRedirect(redirectUrl);
-            var authenticationCookie = BuildCookie(userIdentifier, cookieExpiry, currentConfiguration);
+			var authenticationCookie = BuildCookie(userIdentifier, cookieExpiry, secure, currentConfiguration);
             response.AddCookie(authenticationCookie);
 
             return response;
@@ -92,14 +93,15 @@ namespace Nancy.Authentication.Forms
         /// </summary>
         /// <param name="userIdentifier">User identifier guid</param>
         /// <param name="cookieExpiry">Optional expiry date for the cookie (for 'Remember me')</param>
+		/// <param name="secure">Optional flag to control whether the cookie is secure (i.e. HTTPS only). Defaults to false.</param>
         /// <returns>Nancy response with status <see cref="HttpStatusCode.OK"/></returns>
-        public static Response UserLoggedInResponse(Guid userIdentifier, DateTime? cookieExpiry = null)
+        public static Response UserLoggedInResponse(Guid userIdentifier, DateTime? cookieExpiry = null, bool secure = false)
         {
             var response =
                 (Response)HttpStatusCode.OK;
 
-            var authenticationCookie = 
-                BuildCookie(userIdentifier, cookieExpiry, currentConfiguration);
+            var authenticationCookie =
+				BuildCookie(userIdentifier, cookieExpiry, secure, currentConfiguration);
 
             response.AddCookie(authenticationCookie);
 
@@ -212,18 +214,19 @@ namespace Nancy.Authentication.Forms
             return returnGuid;
         }
 
-        /// <summary>
-        /// Build the forms authentication cookie
-        /// </summary>
-        /// <param name="userIdentifier">Authenticated user identifier</param>
-        /// <param name="cookieExpiry">Optional expiry date for the cookie (for 'Remember me')</param>
-        /// <param name="configuration">Current configuration</param>
-        /// <returns>Nancy cookie instance</returns>
-        private static INancyCookie BuildCookie(Guid userIdentifier, DateTime? cookieExpiry, FormsAuthenticationConfiguration configuration)
+    	/// <summary>
+    	/// Build the forms authentication cookie
+    	/// </summary>
+    	/// <param name="userIdentifier">Authenticated user identifier</param>
+    	/// <param name="cookieExpiry">Optional expiry date for the cookie (for 'Remember me')</param>
+		/// <param name="secure">Whether the cookie is secure (i.e. HTTPS only)</param>
+    	/// <param name="configuration">Current configuration</param>
+    	/// <returns>Nancy cookie instance</returns>
+    	private static INancyCookie BuildCookie(Guid userIdentifier, DateTime? cookieExpiry, bool secure, FormsAuthenticationConfiguration configuration)
         {
             var cookieContents = EncryptAndSignCookie(userIdentifier.ToString(), configuration);
 
-            var cookie = new NancyCookie(formsAuthenticationCookieName, cookieContents, true) { Expires = cookieExpiry };
+			var cookie = new NancyCookie(formsAuthenticationCookieName, cookieContents, true, secure) { Expires = cookieExpiry };
 
             return cookie;
         }

--- a/src/Nancy.Authentication.Forms/ModuleExtensions.cs
+++ b/src/Nancy.Authentication.Forms/ModuleExtensions.cs
@@ -30,10 +30,11 @@ namespace Nancy.Authentication.Forms
         /// <param name="userIdentifier">User identifier guid</param>
         /// <param name="cookieExpiry">Optional expiry date for the cookie (for 'Remember me')</param>
         /// <param name="fallbackRedirectUrl">Url to redirect to if none in the querystring</param>
+		/// <param name="secure">Optional flag to control whether the cookie is secure (i.e. HTTPS only). Defaults to false.</param>
         /// <returns>Nancy response instance</returns>
-        public static Response LoginAndRedirect(this NancyModule module, Guid userIdentifier, DateTime? cookieExpiry = null, string fallbackRedirectUrl = "/")
+        public static Response LoginAndRedirect(this NancyModule module, Guid userIdentifier, DateTime? cookieExpiry = null, string fallbackRedirectUrl = "/", bool secure = false)
         {
-            return FormsAuthentication.UserLoggedInRedirectResponse(module.Context, userIdentifier, cookieExpiry, fallbackRedirectUrl);
+            return FormsAuthentication.UserLoggedInRedirectResponse(module.Context, userIdentifier, cookieExpiry, fallbackRedirectUrl, secure);
         }
 
         /// <summary>
@@ -42,10 +43,11 @@ namespace Nancy.Authentication.Forms
         /// <param name="module">Nancy module</param>
         /// <param name="userIdentifier">User identifier guid</param>
         /// <param name="cookieExpiry">Optional expiry date for the cookie (for 'Remember me')</param>
+		/// <param name="secure">Optional flag to control whether the cookie is secure (i.e. HTTPS only). Defaults to false.</param>
         /// <returns>Nancy response instance</returns>
-        public static Response LoginWithoutRedirect(this NancyModule module, Guid userIdentifier, DateTime? cookieExpiry = null)
+		public static Response LoginWithoutRedirect(this NancyModule module, Guid userIdentifier, DateTime? cookieExpiry = null, bool secure = false)
         {
-            return FormsAuthentication.UserLoggedInResponse(userIdentifier, cookieExpiry);
+			return FormsAuthentication.UserLoggedInResponse(userIdentifier, cookieExpiry, secure);
         }
 
         /// <summary>


### PR DESCRIPTION
There wasn't a way to do this nicely (without routing around for the forms auth cookie in the Cookies collection). So I've exposed it via the public API. I defaulted the flag to false to keep backwards compatibility.
