### PR TITLE
Fix for TFS build problems with post-build xcopy steps

### DIFF
--- a/src/Nancy.ViewEngines.Razor/GetNancyRazorBuildProviderPostBuildCmd.ps1
+++ b/src/Nancy.ViewEngines.Razor/GetNancyRazorBuildProviderPostBuildCmd.ps1
@@ -6,6 +6,6 @@ $ViewEngineDir = Join-Path $path "lib\Net40"
 
 $NancyRazorBuildProviderPostBuildCmd = "
 if `$(ConfigurationName) == Debug (
-xcopy /s /y /R `"$BuildProvidersDir\Nancy.ViewEngines.Razor.BuildProviders.dll`" `"`$(ProjectDir)bin`"
-xcopy /s /y /R `"$ViewEngineDir\Nancy.ViewEngines.Razor.dll`" `"`$(ProjectDir)bin`"
+xcopy /s /y /R `"$BuildProvidersDir\Nancy.ViewEngines.Razor.BuildProviders.dll`" `"`$(ProjectDir)bin\`"
+xcopy /s /y /R `"$ViewEngineDir\Nancy.ViewEngines.Razor.dll`" `"`$(ProjectDir)bin\`"
 )"


### PR DESCRIPTION
Added trailing slashes () to post-build xcopy steps to fix an issue when building under
TFS whereby XCOPY tries to prompt the user to choose to copy into the bin folder, or copy as a file called 'bin'. This was causing the TFS build process to hang forever, requireing the build to be stopped.
