### PR TITLE
Added Accept helpers to Browser

### DIFF
--- a/src/Nancy.Testing.Tests/BrowserContextExtensionsFixture.cs
+++ b/src/Nancy.Testing.Tests/BrowserContextExtensionsFixture.cs
@@ -1,0 +1,91 @@
+﻿namespace Nancy.Testing.Tests
+{
+    using System.Linq;
+    using Xunit;
+    using Nancy.Tests;
+
+    public class BrowserContextExtensionsFixture
+    {
+        [Fact]
+        public void Should_remove_default_accept_header_when_accept_is_invoked_without_quality_parameter()
+        {
+            // Given
+            var context = new BrowserContext();
+
+            // When
+            context.Accept("application/json");
+
+            // Then
+            ((IBrowserContextValues)context).Headers.Count.ShouldEqual(1);
+        }
+
+        [Fact]
+        public void Should_remove_default_accept_header_once_when_accept_is_invoked_without_quality_parameter()
+        {
+            // Given
+            var context = new BrowserContext();
+
+            // When
+            context.Accept("application/json");
+            context.Accept("*/*");
+            context.Accept("application/xml");
+
+            // Then
+            ((IBrowserContextValues)context).Headers["accept"].Count().ShouldEqual(3);
+        }
+
+        [Fact]
+        public void Should_remove_default_accept_header_when_accept_is_invoked_with_quality_parameter()
+        {
+            // Given
+            var context = new BrowserContext();
+
+            // When
+            context.Accept("application/json", 0.8m);
+
+            // Then
+            ((IBrowserContextValues)context).Headers.Count.ShouldEqual(1);
+        }
+
+        [Fact]
+        public void Should_remove_default_accept_header_once_when_accept_is_invoked_with_quality_parameter()
+        {
+            // Given
+            var context = new BrowserContext();
+
+            // When
+            context.Accept("application/json", 0.8m);
+            context.Accept("*/*", 1.0m);
+            context.Accept("application/xml", 0.5m);
+
+            // Then
+            ((IBrowserContextValues)context).Headers["accept"].Count().ShouldEqual(3);
+        }
+
+        [Fact]
+        public void Should_add_mediarange_as_accept_header_with_default_quality_when_accept_is_invoked_without_quality_parameter()
+        {
+            // Given
+            var context = new BrowserContext();
+
+            // When
+            context.Accept("application/json");
+
+            // Then
+            ((IBrowserContextValues) context).Headers["accept"].First().ShouldEqual("application/json;q=1.0");
+        }
+
+        [Fact]
+        public void Should_add_mediarange_with_supplied_quality_as_accept_header_with_default_quality_when_accept_is_invoked_with_quality_parameter()
+        {
+            // Given
+            var context = new BrowserContext();
+
+            // When
+            context.Accept("application/json", 0.8m);
+
+            // Then
+            ((IBrowserContextValues)context).Headers["accept"].First().ShouldEqual("application/json;q=0.8");
+        }
+    }
+}

--- a/src/Nancy.Testing.Tests/Nancy.Testing.Tests.csproj
+++ b/src/Nancy.Testing.Tests/Nancy.Testing.Tests.csproj
@@ -117,6 +117,7 @@
     </Compile>
     <Compile Include="AndConnectorTests.cs" />
     <Compile Include="AssertEqualityComparerFixture.cs" />
+    <Compile Include="BrowserContextExtensionsFixture.cs" />
     <Compile Include="BrowserResponseBodyWrapperExtensionsFixture.cs" />
     <Compile Include="BrowserResponseBodyWrapperFixture.cs" />
     <Compile Include="BrowserResponseExtensionsTests.cs" />

--- a/src/Nancy.Testing/Accept.cs
+++ b/src/Nancy.Testing/Accept.cs
@@ -1,0 +1,32 @@
+namespace Nancy.Testing
+{
+    /// <summary>
+    /// Constants for accept header media ranges
+    /// </summary>
+    public static class Accept
+    {
+        /// <summary>
+        /// Json media range
+        /// </summary>
+        /// <value>application/json</value>
+        public const string Json = "application/json";
+
+        /// <summary>
+        /// Html media range
+        /// </summary>
+        /// <value>text/html</value>
+        public const string Html = "text/html";
+
+        /// <summary>
+        /// Text media range
+        /// </summary>
+        /// <value>>text/plain</value>
+        public const string Text = "text/plain";
+
+        /// <summary>
+        /// Xml media range
+        /// </summary>
+        /// <value>application/xml</value>
+        public const string Xml = "application/xml";
+    }
+}

--- a/src/Nancy.Testing/BrowserContext.cs
+++ b/src/Nancy.Testing/BrowserContext.cs
@@ -144,7 +144,7 @@
             var defaultHeaders = 
                 new Dictionary<string, IEnumerable<string>>
                 {
-                    { "accept", new [] { "*/*"} }
+                    { "accept", new [] { "*/*" } }
                 };
 
             return defaultHeaders;

--- a/src/Nancy.Testing/BrowserContextExtensions.cs
+++ b/src/Nancy.Testing/BrowserContextExtensions.cs
@@ -2,6 +2,7 @@
 namespace Nancy.Testing
 {
     using System;
+    using System.Globalization;
     using System.Text;
     using System.IO;
     using System.Collections.Generic;
@@ -11,6 +12,7 @@ namespace Nancy.Testing
     using Nancy.Extensions;
     using Nancy.Helpers;
     using Nancy.Responses;
+    using Responses.Negotiation;
 
     /// <summary>
     /// Defines extensions for the <see cref="BrowserContext"/> type.
@@ -144,6 +146,33 @@ namespace Nancy.Testing
             var cookieContents = String.Format("{1}{0}", encryptedId, hmacString);
 
             Cookie(browserContext, FormsAuthentication.FormsAuthenticationCookieName, cookieContents);
+        }
+
+        public static void Accept(this BrowserContext browserContext, MediaRange mediaRange)
+        {
+            browserContext.Accept(mediaRange, 1.0m);
+        }
+
+        public static void Accept(this BrowserContext browserContext, MediaRange mediaRange, decimal quality)
+        {
+            var contextValues =
+                (IBrowserContextValues)browserContext;
+
+            if (contextValues.Headers.ContainsKey("accept"))
+            {
+                if (contextValues.Headers["accept"].Count().Equals(1))
+                {
+                    if (contextValues.Headers["accept"].Any(x => x.Equals("*/*")))
+                    {
+                        contextValues.Headers.Remove("accept");
+                    }    
+                }
+            }
+
+            var mediaTypeWithQuality =
+                string.Concat(mediaRange, ";q=", Convert.ToString(quality, CultureInfo.InvariantCulture));
+
+            browserContext.Header("accept", mediaTypeWithQuality);
         }
     }
 }

--- a/src/Nancy.Testing/Nancy.Testing.csproj
+++ b/src/Nancy.Testing/Nancy.Testing.csproj
@@ -103,6 +103,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Accept.cs" />
     <Compile Include="AndConnector.cs" />
     <Compile Include="AssertEqualityComparer.cs" />
     <Compile Include="AssertException.cs" />


### PR DESCRIPTION
Can now set accept headers, for the Browser class, using the Accept
exentions.
