### PR TITLE
Corrected StaticContentConventionBuilder to respect relative Root pathes

### DIFF
--- a/src/Nancy.Tests/Unit/StaticContentConventionBuilderFixture.cs
+++ b/src/Nancy.Tests/Unit/StaticContentConventionBuilderFixture.cs
@@ -2,62 +2,60 @@
 {
     using System;
     using System.IO;
-    using System.Security;
     using System.Text;
     using Nancy.Conventions;
     using Nancy.Responses;
     using Xunit;
-    using Xunit.Extensions;
 
     public class StaticContentConventionBuilderFixture
-	{
-		private const string StylesheetContents = @"body {
+    {
+        private const string StylesheetContents = @"body {
 	background-color: white;
 }";
 
-		[Fact]
+        [Fact]
         public void Should_retrieve_static_content_when_path_has_same_name_as_extension()
-		{
+        {
             // Given
             // When
-			var result = GetStaticContent("css", "styles.css");
+            var result = GetStaticContent("css", "styles.css");
 
             // Then
             result.ShouldEqual(StylesheetContents);
-		}
+        }
 
-		[Fact]
-		public void Should_retrieve_static_content_when_virtual_directory_name_exists_in_static_route()
-		{
+        [Fact]
+        public void Should_retrieve_static_content_when_virtual_directory_name_exists_in_static_route()
+        {
             // Given
             // When
             var result = GetStaticContent("css", "strange-css-filename.css");
 
             // Then
             result.ShouldEqual(StylesheetContents);
-		}
+        }
 
-		[Fact]
-		public void Should_retrieve_static_content_when_path_is_nested()
-		{
+        [Fact]
+        public void Should_retrieve_static_content_when_path_is_nested()
+        {
             // Given
             // When
             var result = GetStaticContent("css/sub", "styles.css");
 
             // Then
             result.ShouldEqual(StylesheetContents);
-		}
+        }
 
-		[Fact]
-		public void Should_retrieve_static_content_when_path_contains_nested_folders_with_duplicate_name()
-		{
+        [Fact]
+        public void Should_retrieve_static_content_when_path_contains_nested_folders_with_duplicate_name()
+        {
             // Given
             // When
             var result = GetStaticContent("css/css", "styles.css");
 
             // Then
             result.ShouldEqual(StylesheetContents);
-		}
+        }
 
         [Fact]
         public void Should_retrieve_static_content_when_filename_contains_dot()
@@ -70,16 +68,41 @@
             result.ShouldEqual(StylesheetContents);
         }
 
-	    [Fact]
-	    public void Should_retrieve_static_content_when_path_contains_dot()
-	    {
-	        // Given
-	        // When
+        [Fact]
+        public void Should_retrieve_static_content_when_path_contains_dot()
+        {
+            // Given
+            // When
             var result = GetStaticContent("css/Sub.folder", "styles.css");
 
-	        // Then
+            // Then
             result.ShouldEqual(StylesheetContents);
-	    }
+        }
+
+        [Fact]
+        public void Should_skip_the_request_if_resource_is_outside_the_content_folder()
+        {
+            // Given
+            // When
+            var result = GetStaticContent("css", "../../outside/styles.css");
+
+            // Then
+            result.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Should_retrieve_static_content_when_root_is_relative_path()
+        {
+            // Given
+            var resources = Path.Combine(Environment.CurrentDirectory, "Resources");
+            var relativeRootFolder = Path.Combine(resources, @"../");
+
+            // When
+            var result = GetStaticContent("css", "styles.css", relativeRootFolder);
+
+            // Then
+            result.ShouldEqual(StylesheetContents);
+        }
 
         [Fact]
         public void Should_throw_security_exception_when_content_path_points_to_root()
@@ -87,7 +110,10 @@
             // Given
             var convention = StaticContentConventionBuilder.AddDirectory("/", "/");
             var request = new Request("GET", "/face.png", "http");
-            var context = new NancyContext { Request = request };
+            var context = new NancyContext
+            {
+                Request = request
+            };
 
             // When
             var exception = Record.Exception(() => convention.Invoke(context, Environment.CurrentDirectory));
@@ -102,7 +128,10 @@
             // Given
             var convention = StaticContentConventionBuilder.AddDirectory("/");
             var request = new Request("GET", "/face.png", "http");
-            var context = new NancyContext { Request = request };
+            var context = new NancyContext
+            {
+                Request = request
+            };
 
             // When
             var exception = Record.Exception(() => convention.Invoke(context, Environment.CurrentDirectory));
@@ -111,27 +140,37 @@
             exception.ShouldBeOfType<ArgumentException>();
         }
 
-		private static string GetStaticContent(string virtualDirectory, string requestedFilename)
-		{
-			var resource = 
+        private static string GetStaticContent(string virtualDirectory, string requestedFilename, string root = null)
+        {
+            var resource =
                 string.Format("/{0}/{1}", virtualDirectory, requestedFilename);
 
-			var context = 
-                new NancyContext { Request = new Request("GET", resource, "http") };
+            var context =
+                new NancyContext
+                {
+                    Request = new Request("GET", resource, "http")
+                };
 
-			var resolver =
+            var resolver =
                 StaticContentConventionBuilder.AddDirectory(virtualDirectory, "Resources/Assets/Styles");
 
-			GenericFileResponse.SafePaths.Add(Environment.CurrentDirectory);
+            var rootFolder = root ?? Environment.CurrentDirectory;
 
-			var response = 
-                resolver.Invoke(context, Environment.CurrentDirectory) as GenericFileResponse;
+            GenericFileResponse.SafePaths.Add(rootFolder);
 
-			using (var stream = new MemoryStream())
-			{
-				response.Contents(stream);
-				return Encoding.UTF8.GetString(stream.GetBuffer(), 0, (int)stream.Length);
-			}
-		}
-	}
+            var response =
+                resolver.Invoke(context, rootFolder) as GenericFileResponse;
+
+            if (response != null)
+            {
+                using (var stream = new MemoryStream())
+                {
+                    response.Contents(stream);
+                    return Encoding.UTF8.GetString(stream.GetBuffer(), 0, (int)stream.Length);
+                }
+            }
+
+            return null;
+        }
+    }
 }

--- a/src/Nancy/Conventions/StaticContentConventionBuilder.cs
+++ b/src/Nancy/Conventions/StaticContentConventionBuilder.cs
@@ -128,7 +128,7 @@ namespace Nancy.Conventions
                     Path.GetFullPath(Path.Combine(applicationRootPath, transformedRequestPath));
 
                 var contentRootPath = 
-                    Path.Combine(applicationRootPath, GetEncodedPath(contentPath));
+                    Path.GetFullPath(Path.Combine(applicationRootPath, GetEncodedPath(contentPath)));
 
                 if (!IsWithinContentFolder(contentRootPath, fileName))
                 {


### PR DESCRIPTION
In my configuration, I have relative root path, something like `D:\Project\App\Bin\..\`, my content is under /Client folder.

Changing the default conventions for view, worked fine, but for static content it failed. The reason is that `StaticContentConventionBuilder` treated the requested file as outside the content folder. I've added some test cases and added `Path.GetFullPath()` to convert relative path to absolute.

I also update Nancy assembly version, up to actual :)
