### PR TITLE
Add methods for configuring startup items in ConfigurableBootstrapper

### DIFF
--- a/src/Nancy.Testing.Tests/ConfigurableBootstrapperFixture.cs
+++ b/src/Nancy.Testing.Tests/ConfigurableBootstrapperFixture.cs
@@ -127,6 +127,46 @@
             result.ToString().ShouldContain("Oh noes!");
         }
 
+        [Fact]
+        public void Should_run_application_startup_closure()
+        {
+            var date = new DateTime(2112,10,31);
+            var bootstrapper = new ConfigurableBootstrapper(with => with.ApplicationStartup((container, pipelines) =>
+                {
+                    pipelines.BeforeRequest += ctx =>
+                        {
+                            ctx.Items.Add("date", date);
+                            return null;
+                        };
+                }));
+
+            bootstrapper.Initialise();
+
+            var engine = bootstrapper.GetEngine();
+            var request = new Request("GET", "/", "http");
+            var result = engine.HandleRequest(request);
+
+            result.Items["date"].ShouldEqual(date);
+        }
+
+        [Fact]
+        public void Should_run_request_startup_closure()
+        {
+            var date = new DateTime(2112, 10, 31);
+            var bootstrapper =
+                new ConfigurableBootstrapper(
+                    with => with.RequestStartup((container, pipelines, context) => 
+                        context.Items.Add("date", date)));
+
+            bootstrapper.Initialise();
+
+            var engine = bootstrapper.GetEngine();
+            var request = new Request("GET", "/", "http");
+            var result = engine.HandleRequest(request);
+
+            result.Items["date"].ShouldEqual(date);
+        }
+
         public IEnumerable<string> GetConfigurableBootstrapperMembers()
         {
             var ignoreList = new[]

--- a/src/Nancy.Testing/ConfigurableBootstrapper.cs
+++ b/src/Nancy.Testing/ConfigurableBootstrapper.cs
@@ -28,6 +28,8 @@ namespace Nancy.Testing
         private readonly ConfigurableModuleCatalog catalog;
         private bool enableAutoRegistration;
         private DiagnosticsConfiguration diagnosticConfiguration;
+        private readonly List<Action<TinyIoCContainer, IPipelines>> applicationStartupActions;
+        private readonly List<Action<TinyIoCContainer, IPipelines, NancyContext>> requestStartupActions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigurableBootstrapper"/> class.
@@ -47,6 +49,8 @@ namespace Nancy.Testing
             this.configuration = NancyInternalConfiguration.Default;
             this.registeredTypes = new List<object>();
             this.registeredInstances = new List<InstanceRegistration>();
+            this.applicationStartupActions = new List<Action<TinyIoCContainer, IPipelines>>();
+            this.requestStartupActions = new List<Action<TinyIoCContainer, IPipelines, NancyContext>>();
 
             if (configuration != null)
             {
@@ -56,6 +60,22 @@ namespace Nancy.Testing
                 configurator.ErrorHandler<PassThroughErrorHandler>();
 
                 configuration.Invoke(configurator);
+            }
+        }
+        protected override void ApplicationStartup(TinyIoCContainer container, IPipelines pipelines)
+        {
+            base.ApplicationStartup(container, pipelines);
+            foreach (var action in this.applicationStartupActions)
+            {
+                action.Invoke(container,pipelines);
+            }
+        }
+        protected override void RequestStartup(TinyIoCContainer container, IPipelines pipelines, NancyContext context)
+        {
+            base.RequestStartup(container, pipelines, context);
+            foreach (var action in this.requestStartupActions)
+            {
+                action.Invoke(container,pipelines,context);
             }
         }
 
@@ -1377,6 +1397,18 @@ namespace Nancy.Testing
             public ConfigurableBoostrapperConfigurator IgnoredAssembly(Func<Assembly, bool> ignoredPredicate)
             {
                 this.bootstrapper.configuration.WithIgnoredAssembly(ignoredPredicate);
+                return this;
+            }
+
+            public ConfigurableBoostrapperConfigurator ApplicationStartup(Action<TinyIoCContainer, IPipelines> action)
+            {
+                this.bootstrapper.applicationStartupActions.Add(action);
+                return this;
+            }
+
+            public ConfigurableBoostrapperConfigurator RequestStartup(Action<TinyIoCContainer, IPipelines, NancyContext> action)
+            {
+                this.bootstrapper.requestStartupActions.Add(action);
                 return this;
             }
         }


### PR DESCRIPTION
In order to add ApplicationStartup and RequestStartup items, one would
have to subclass `ConfigurableBootstrapper`. The obvious case would be
adding in-memory session or fake authentication handlers. The simplest
case would be to add a user to the context on request startup.  This 
construct would allow simple cases to be added quickly and easily 
without having to subclass `ConfigurableBootstrapper`. 

```
var bootstrapper = new ConfigurableBootstrapper(
   with => {
     with.ApplicationStartup((container,pipelines) => 
       InMemorySession.Enable(pipelines));
     with.ApplicationStartup((container,pipelines) =>  
       FakeFormsAuthentication.Enable(pipelines));
     with.RequestStartup((container,pipelines,context) =>  
       context.Items["foo"]=bar);
     with.RequestStartup((container,pipelines,context) =>  
       context.CurrentUser=fakeUser);
});
```
- Add configuration method for applicationStartup
- Add configuration method for requestStartup
- Add list containers for application and request startup actions
- Execute the configured startup actions via the respective overload
- Add test to ensure the code is run
- Addresses #713
