### PR TITLE
Added application registrations

### DIFF
--- a/src/Nancy.Validation.DataAnnotations/ApplicationRegistrations.cs
+++ b/src/Nancy.Validation.DataAnnotations/ApplicationRegistrations.cs
@@ -1,0 +1,39 @@
+namespace Nancy.Validation.DataAnnotations
+{
+    using System.Collections.Generic;
+    using Bootstrapper;
+
+    /// <summary>
+    /// Application registrations for Data Annotations validation types.
+    /// </summary>
+    public class ApplicationRegistrations : IApplicationRegistrations
+    {
+        /// <summary>
+        /// Gets the type registrations to register for this startup task
+        /// </summary>
+        public IEnumerable<TypeRegistration> TypeRegistrations
+        {
+            get
+            {
+                yield return new TypeRegistration(typeof(IModelValidator), typeof(DataAnnotationsValidator));
+                yield return new TypeRegistration(typeof(IModelValidatorFactory), typeof(DataAnnotationsValidatorFactory));
+            }
+        }
+
+        /// <summary>
+        /// Gets the collection registrations to register for this startup task
+        /// </summary>
+        public IEnumerable<CollectionTypeRegistration> CollectionTypeRegistrations
+        {
+            get { return null; }
+        }
+
+        /// <summary>
+        /// Gets the instance registrations to register for this startup task
+        /// </summary>
+        public IEnumerable<InstanceRegistration> InstanceRegistrations
+        {
+            get { return null; }
+        }
+    }
+}

--- a/src/Nancy.Validation.DataAnnotations/Nancy.Validation.DataAnnotations.csproj
+++ b/src/Nancy.Validation.DataAnnotations/Nancy.Validation.DataAnnotations.csproj
@@ -115,6 +115,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="ApplicationRegistrations.cs" />
     <Compile Include="DataAnnotationsValidatableObjectValidatorAdapter.cs" />
     <Compile Include="DataAnnotationsValidator.cs" />
     <Compile Include="DataAnnotationsValidatorAdapter.cs" />

--- a/src/Nancy.Validation.FluentValidation/ApplicationRegistrations.cs
+++ b/src/Nancy.Validation.FluentValidation/ApplicationRegistrations.cs
@@ -1,0 +1,39 @@
+namespace Nancy.Validation.FluentValidation
+{
+    using System.Collections.Generic;
+    using Bootstrapper;
+
+    /// <summary>
+    /// Application registrations for Fluent Validation types.
+    /// </summary>
+    public class ApplicationRegistrations : IApplicationRegistrations
+    {
+        /// <summary>
+        /// Gets the type registrations to register for this startup task
+        /// </summary>
+        public IEnumerable<TypeRegistration> TypeRegistrations
+        {
+            get
+            {
+                yield return new TypeRegistration(typeof(IModelValidator), typeof(FluentValidationValidator));
+                yield return new TypeRegistration(typeof(IModelValidatorFactory), typeof(FluentValidationValidatorFactory));
+            }
+        }
+
+        /// <summary>
+        /// Gets the collection registrations to register for this startup task
+        /// </summary>
+        public IEnumerable<CollectionTypeRegistration> CollectionTypeRegistrations
+        {
+            get { return null; }
+        }
+
+        /// <summary>
+        /// Gets the instance registrations to register for this startup task
+        /// </summary>
+        public IEnumerable<InstanceRegistration> InstanceRegistrations
+        {
+            get { return null; }
+        }
+    }
+}

--- a/src/Nancy.Validation.FluentValidation/Nancy.Validation.FluentValidation.csproj
+++ b/src/Nancy.Validation.FluentValidation/Nancy.Validation.FluentValidation.csproj
@@ -97,6 +97,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="AdapterBase.cs" />
+    <Compile Include="ApplicationRegistrations.cs" />
     <Compile Include="DefaultFluentAdapterFactory.cs" />
     <Compile Include="EmailAdapter.cs" />
     <Compile Include="EqualAdapter.cs" />


### PR DESCRIPTION
The validation projects for Data Annotations and Fluent Validation now
uses an IApplicationRegistrations, each, to register their implementations
of the validation interfaces. This should make them work out-of-the-box
with other bootstrappers.
