### PR TITLE
Prevent IIS7 from taking over error pages

### DIFF
--- a/src/Nancy.Hosting.Aspnet/NancyHandler.cs
+++ b/src/Nancy.Hosting.Aspnet/NancyHandler.cs
@@ -96,6 +96,7 @@ namespace Nancy.Hosting.Aspnet
 
             context.Response.ContentType = response.ContentType;
             context.Response.StatusCode = (int)response.StatusCode;
+            context.Response.TrySkipIisCustomErrors = true;
             response.Contents.Invoke(context.Response.OutputStream);         
         }
 


### PR DESCRIPTION
The feature/bug this PR fixes is described in detail here: http://www.west-wind.com/weblog/posts/2009/Apr/29/IIS-7-Error-Pages-taking-over-500-Errors
