### PR TITLE
moved TinyIoc namespace to Nancy.TinyIoc

### DIFF
--- a/src/Nancy.Demo.Authentication.Basic/AuthenticationBootstrapper.cs
+++ b/src/Nancy.Demo.Authentication.Basic/AuthenticationBootstrapper.cs
@@ -7,10 +7,11 @@ using Nancy.Authentication.Basic;
 namespace Nancy.Demo.Authentication.Basic
 {
     using Bootstrapper;
+    using Nancy.TinyIoc;
 
     public class AuthenticationBootstrapper : DefaultNancyBootstrapper
 	{
-		protected override void ApplicationStartup(TinyIoC.TinyIoCContainer container, IPipelines pipelines)
+		protected override void ApplicationStartup(TinyIoCContainer container, IPipelines pipelines)
 		{
             base.ApplicationStartup(container, pipelines);
 

--- a/src/Nancy.Demo.Authentication.Forms/FormsAuthBootstrapper.cs
+++ b/src/Nancy.Demo.Authentication.Forms/FormsAuthBootstrapper.cs
@@ -3,12 +3,11 @@ namespace Nancy.Demo.Authentication.Forms
     using Nancy;
     using Nancy.Authentication.Forms;
     using Nancy.Bootstrapper;
-
-    using TinyIoC;
+    using Nancy.TinyIoc;
 
     public class FormsAuthBootstrapper : DefaultNancyBootstrapper
     {
-        protected override void ConfigureApplicationContainer(TinyIoC.TinyIoCContainer container)
+        protected override void ConfigureApplicationContainer(TinyIoCContainer container)
         {
             // We don't call "base" here to prevent auto-discovery of
             // types/dependencies

--- a/src/Nancy.Demo.Authentication.Stateless/StatelessAuthBootstrapper.cs
+++ b/src/Nancy.Demo.Authentication.Stateless/StatelessAuthBootstrapper.cs
@@ -3,7 +3,7 @@ namespace Nancy.Demo.Authentication.Stateless
     using Nancy.Authentication.Stateless;
     using Nancy.Bootstrapper;
     using Nancy.Conventions;
-    using TinyIoC;
+    using Nancy.TinyIoc;
 
     public class StatelessAuthBootstrapper : DefaultNancyBootstrapper
     {

--- a/src/Nancy.Demo.Authentication/AuthenticationBootstrapper.cs
+++ b/src/Nancy.Demo.Authentication/AuthenticationBootstrapper.cs
@@ -5,10 +5,11 @@ namespace Nancy.Demo.Authentication
     using Bootstrapper;
     using Nancy;
     using Nancy.Responses;
+    using Nancy.TinyIoc;
 
     public class AuthenticationBootstrapper : DefaultNancyBootstrapper
     {
-        protected override void ApplicationStartup(TinyIoC.TinyIoCContainer container, IPipelines pipelines)
+        protected override void ApplicationStartup(TinyIoCContainer container, IPipelines pipelines)
         {
             base.ApplicationStartup(container, pipelines);
 

--- a/src/Nancy.Demo.Bootstrapper.Aspnet/Bootstrapper.cs
+++ b/src/Nancy.Demo.Bootstrapper.Aspnet/Bootstrapper.cs
@@ -4,8 +4,7 @@ namespace Nancy.AspNetBootstrapperDemo
 
     using Nancy.Demo.Bootstrapping.Aspnet;
     using Nancy.Hosting.Aspnet;
-
-    using TinyIoC;
+    using Nancy.TinyIoc;
 
     public class Bootstrapper : DefaultNancyAspNetBootstrapper
     {

--- a/src/Nancy.Demo.Caching/CachingBootstrapper.cs
+++ b/src/Nancy.Demo.Caching/CachingBootstrapper.cs
@@ -5,6 +5,7 @@ namespace Nancy.Demo.Caching
     using Bootstrapper;
     using Nancy;
     using Nancy.Demo.Caching.CachingExtensions;
+    using Nancy.TinyIoc;
 
     public class CachingBootstrapper : DefaultNancyBootstrapper
     {
@@ -12,7 +13,7 @@ namespace Nancy.Demo.Caching
 
         private readonly Dictionary<string, Tuple<DateTime, Response, int>> cachedResponses = new Dictionary<string, Tuple<DateTime, Response, int>>();
 
-        protected override void ApplicationStartup(TinyIoC.TinyIoCContainer container, IPipelines pipelines)
+        protected override void ApplicationStartup(TinyIoCContainer container, IPipelines pipelines)
         {
             base.ApplicationStartup(container, pipelines);
 

--- a/src/Nancy.Demo.Hosting.Aspnet/DemoBootstrapper.cs
+++ b/src/Nancy.Demo.Hosting.Aspnet/DemoBootstrapper.cs
@@ -6,9 +6,8 @@
 
     using Nancy.Diagnostics;
     using Nancy.Session;
+    using Nancy.TinyIoc;
     using Nancy.ViewEngines.Razor;
-
-    using TinyIoC;
 
     public class DemoBootstrapper : DefaultNancyBootstrapper
     {
@@ -21,7 +20,7 @@
 
         // Overriding this just to show how it works, not actually necessary as autoregister
         // takes care of it all.
-        protected override void ConfigureApplicationContainer(TinyIoC.TinyIoCContainer existingContainer)
+        protected override void ConfigureApplicationContainer(TinyIoCContainer existingContainer)
         {
             // We don't call base because we don't want autoregister
             // we just register our one known dependency as an application level singleton
@@ -36,7 +35,7 @@
             existingContainer.Register<IRequestDependency, RequestDependencyClass>().AsSingleton();
         }
 
-        protected override void ApplicationStartup(TinyIoC.TinyIoCContainer container, IPipelines pipelines)
+        protected override void ApplicationStartup(TinyIoCContainer container, IPipelines pipelines)
         {
             base.ApplicationStartup(container, pipelines);
 

--- a/src/Nancy.Hosting.Aspnet/DefaultNancyAspNetBootstrapper.cs
+++ b/src/Nancy.Hosting.Aspnet/DefaultNancyAspNetBootstrapper.cs
@@ -5,8 +5,7 @@ namespace Nancy.Hosting.Aspnet
     using System.Collections.Generic;
 
     using Bootstrapper;
-
-    using TinyIoC;
+    using Nancy.TinyIoc;
 
     /// <summary>
     /// TinyIoC ASP.Net Bootstrapper

--- a/src/Nancy.Hosting.Aspnet/TinyIoCAspNetExtensions.cs
+++ b/src/Nancy.Hosting.Aspnet/TinyIoCAspNetExtensions.cs
@@ -2,8 +2,7 @@
 {
     using System;
     using System.Web;
-
-    using TinyIoC;
+    using Nancy.TinyIoc;
 
     public class HttpContextLifetimeProvider : TinyIoCContainer.ITinyIoCObjectLifetimeProvider
     {
@@ -32,7 +31,7 @@
 
     public static class TinyIoCAspNetExtensions
     {
-        public static TinyIoCContainer.RegisterOptions AsPerRequestSingleton(this TinyIoC.TinyIoCContainer.RegisterOptions registerOptions)
+        public static TinyIoCContainer.RegisterOptions AsPerRequestSingleton(this TinyIoCContainer.RegisterOptions registerOptions)
         {
             return TinyIoCContainer.RegisterOptions.ToCustomLifetimeManager(registerOptions, new HttpContextLifetimeProvider(), "per request singleton");
         }

--- a/src/Nancy.Testing/ConfigurableBootstrapper.cs
+++ b/src/Nancy.Testing/ConfigurableBootstrapper.cs
@@ -13,9 +13,9 @@ namespace Nancy.Testing
     using Nancy.ModelBinding;
     using Nancy.Routing;
     using Nancy.Security;
+    using Nancy.TinyIoc;
     using Nancy.ViewEngines;
     using Responses.Negotiation;
-    using TinyIoC;
     using Nancy.Validation;
 
     /// <summary>

--- a/src/Nancy.Tests/Fakes/FakeDefaultNancyBootstrapper.cs
+++ b/src/Nancy.Tests/Fakes/FakeDefaultNancyBootstrapper.cs
@@ -8,8 +8,7 @@
     using Bootstrapper;
 
     using Nancy.ErrorHandling;
-
-    using TinyIoC;
+    using Nancy.TinyIoc;
 
     public class FakeDefaultNancyBootstrapper : DefaultNancyBootstrapper
     {
@@ -44,7 +43,7 @@
 
         public bool ApplicationContainerConfigured { get; set; }
 
-        public TinyIoC.TinyIoCContainer Container { get { return this.ApplicationContainer; } }
+        public TinyIoCContainer Container { get { return this.ApplicationContainer; } }
 
         public Request ConfigureRequestContainerLastRequest { get; set; }
 
@@ -80,7 +79,7 @@
             this.RequestContainerInitialisations[context] = this.RequestContainerInitialisations[context] + 1;
         }
 
-        protected override void ConfigureApplicationContainer(TinyIoC.TinyIoCContainer existingContainer)
+        protected override void ConfigureApplicationContainer(TinyIoCContainer existingContainer)
         {
             ApplicationContainerConfigured = true;
             base.ConfigureApplicationContainer(existingContainer);

--- a/src/Nancy.Tests/Unit/DefaultNancyBootstrapperBootstrapperBaseFixture.cs
+++ b/src/Nancy.Tests/Unit/DefaultNancyBootstrapperBootstrapperBaseFixture.cs
@@ -3,7 +3,7 @@ namespace Nancy.Tests.Unit
 {
     using Nancy.Bootstrapper;
     using Bootstrapper.Base;
-    using TinyIoC;
+    using Nancy.TinyIoc;
 
     public class DefaultNancyBootstrapperBootstrapperBaseFixture : BootstrapperBaseFixtureBase<TinyIoCContainer>
     {

--- a/src/Nancy.Tests/Unit/DefaultNancyBootstrapperFixture.cs
+++ b/src/Nancy.Tests/Unit/DefaultNancyBootstrapperFixture.cs
@@ -5,6 +5,7 @@
     using Microsoft.CSharp;
 
     using Nancy.Tests.Fakes;
+    using Nancy.TinyIoc;
     
     using Xunit;
 
@@ -78,7 +79,7 @@
                 .CompiledAssembly;
 
             this.bootstrapper.Initialise ();
-            Assert.Throws<TinyIoC.TinyIoCResolutionException>(
+            Assert.Throws<TinyIoCResolutionException>(
                 () => this.bootstrapper.Container.Resolve(ass.GetType("IWillNotBeResolved")));
             
         }

--- a/src/Nancy/DefaultNancyBootstrapper.cs
+++ b/src/Nancy/DefaultNancyBootstrapper.cs
@@ -8,8 +8,7 @@ namespace Nancy
     using System.Reflection;
 
     using Bootstrapper;
-
-    using TinyIoC;
+    using Nancy.TinyIoc;
 
     /// <summary>
     /// TinyIoC bootstrapper - registers default route resolver and registers itself as

--- a/src/Nancy/Diagnostics/DiagnosticsModuleCatalog.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsModuleCatalog.cs
@@ -4,8 +4,8 @@ namespace Nancy.Diagnostics
     using System.Linq;
     using ModelBinding;
     using Nancy.Bootstrapper;
+    using Nancy.TinyIoc;
     using Responses;
-    using TinyIoC;
 
     internal class DiagnosticsModuleCatalog : INancyModuleCatalog
     {

--- a/src/Nancy/TinyIoc/TinyIoC.cs
+++ b/src/Nancy/TinyIoc/TinyIoC.cs
@@ -48,7 +48,7 @@
 #endif
 
 #endregion
-namespace TinyIoC
+namespace Nancy.TinyIoc
 {
     using System;
     using System.Collections.Generic;


### PR DESCRIPTION
`namespace TinyIoc` to `namespace Nancy.TinyIoc`.

If anything breaks blame resharper :)

This is a breaking change, but I hope this gets into the master branch soon. It is better to have a breaking change sooner than latter.
