### PR TITLE
Fixed self-hosting for remote access when hosted non-admin

### DIFF
--- a/src/Nancy.Hosting.Self/NancyHost.cs
+++ b/src/Nancy.Hosting.Self/NancyHost.cs
@@ -44,7 +44,7 @@
 
             foreach (var baseUri in baseUriList)
             {
-                listener.Prefixes.Add(baseUri.ToString());
+                listener.Prefixes.Add(baseUri.ToString().Replace("localhost", "+"));
             }
 
             bootstrapper.Initialise();

--- a/src/Nancy.Hosting.Self/UriExtensions.cs
+++ b/src/Nancy.Hosting.Self/UriExtensions.cs
@@ -11,7 +11,7 @@ namespace Nancy.Hosting.Self
 	{
 		public static bool IsCaseInsensitiveBaseOf(this Uri source, Uri value)
 		{
-			if (Uri.Compare(source, value,UriComponents.Scheme | UriComponents.HostAndPort, UriFormat.Unescaped, StringComparison.InvariantCultureIgnoreCase) != 0)
+            if (Uri.Compare(source, value, UriComponents.Scheme | UriComponents.Port, UriFormat.Unescaped, StringComparison.InvariantCultureIgnoreCase) != 0)
 			{
 			    return false;
 			}


### PR DESCRIPTION
Fixed the self-hosting code to register the http/https URL prefixes using a + instead of "localhost". Together with the correct "netsh http add" command this allows for remote access to your self-hosted Nancy service.
