### PR TITLE
added overload for INancyEngine taking Func<NancyContext, NancyContext>

### DIFF
--- a/src/Nancy.Testing.Tests/ConfigurableBootstrapperFixture.cs
+++ b/src/Nancy.Testing.Tests/ConfigurableBootstrapperFixture.cs
@@ -203,6 +203,11 @@
             {
                 throw new NotImplementedException();
             }
+
+            public void HandleRequest(Request request, Func<NancyContext, NancyContext> preRequest, Action<NancyContext> onComplete, Action<Exception> onError)
+            {
+                throw new NotImplementedException();
+            }
         }
 
         private class BlowUpModule : NancyModule

--- a/src/Nancy.Tests/Unit/Bootstrapper/Base/BootstrapperBaseFixtureBase.cs
+++ b/src/Nancy.Tests/Unit/Bootstrapper/Base/BootstrapperBaseFixtureBase.cs
@@ -145,6 +145,11 @@ namespace Nancy.Tests.Unit.Bootstrapper.Base
             {
                 throw new NotImplementedException();
             }
+
+            public void HandleRequest(Request request, Func<NancyContext, NancyContext> preRequest, Action<NancyContext> onComplete, Action<Exception> onError)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/src/Nancy/INancyEngine.cs
+++ b/src/Nancy/INancyEngine.cs
@@ -28,5 +28,14 @@ namespace Nancy
         /// <param name="onComplete">Delegate to call when the request is complete</param>
         /// <param name="onError">Deletate to call when any errors occur</param>
         void HandleRequest(Request request, Action<NancyContext> onComplete, Action<Exception> onError);
+
+        /// <summary>
+        /// Handles an incoming <see cref="Request"/> async.
+        /// </summary>
+        /// <param name="request">An <see cref="Request"/> instance, containing the information about the current request.</param>
+        /// <param name="preRequest">Delegate to call before the request is processed</param>
+        /// <param name="onComplete">Delegate to call when the request is complete</param>
+        /// <param name="onError">Deletate to call when any errors occur</param>
+        void HandleRequest(Request request, Func<NancyContext, NancyContext> preRequest, Action<NancyContext> onComplete, Action<Exception> onError);
     }
 }


### PR DESCRIPTION
Added HandlRequest in INancyEngine taking preRequest Func.

``` csharp
void HandleRequest(Request request, Func<NancyContext, NancyContext> preRequest, Action<NancyContext> onComplete, Action<Exception> onError);
```

I added it as an overload as per @Grumpydev request so there would be no breaking change in Nancy https://groups.google.com/forum/?fromgroups=#!topic/nancy-web-framework/ebKfk3Gxe2k

This now allows the host to modify the NancyContext without creating a wrapper for INancyContext factory.

This can be very useful for Owin Host. Owin host can now pass the owin environment to `NancyContext.Items[NancyOwinHost.RequestEnvironmentKey]`. This means nancy apps can take advantage of owin extensions such as WebSockets extension without waiting for WebExtensions to be actually supported by Nancy. This will also allow the possibilities of using OWIN middlewares in Nancy.

I'm sending this as a separate PR. Once this is merged, I can rebase it onto my owin15 PR #730. If you would like to see the merged one you can find it in https://github.com/prabirshrestha/Nancy/tree/owin15-preRequest

Here is how one could then access the owin environment.

``` csharp
            Get["/owin"] = x =>
            {
                var owinEnvironment = (IDictionary<string, object>)Context.Items[NancyOwinHost.RequestEnvironmentKey];

                return "Method = " + (string)owinEnvironment["owin.RequestMethod"];
            };
```

/cc @loudej @Tratcher
