### PR TITLE
Owin keys

### DIFF
--- a/src/Nancy.Demo.Hosting.Owin/SimpleOwinAspNetHost.cs
+++ b/src/Nancy.Demo.Hosting.Owin/SimpleOwinAspNetHost.cs
@@ -609,7 +609,7 @@ namespace Nancy.Demo.Hosting.Owin
             public const string WebSocketCloseAsyncFunc = "websocket.CloseAsyncFunc";
             public const string WebSocketCallCancelled = "websocket.CallCancelled";
 
-            public const string AspNetWebSocketContext = "aspnet.AspNetWebSocketContext";
+            public const string AspNetWebSocketContext = "System.Web.WebSockets.AspNetWebSocketContext";
         }
     }
 }


### PR DESCRIPTION
updated `SimpleOwinAspNetHost` owin keys for `HttpContextBase` and `AspNetWebSocketContext`.

This is the recommended keys used by Katana too.
