### PR TITLE
Ability to set user host address when testing

### DIFF
--- a/src/Nancy.Testing.Tests/BrowserFixture.cs
+++ b/src/Nancy.Testing.Tests/BrowserFixture.cs
@@ -47,6 +47,23 @@ namespace Nancy.Testing.Tests
         }
 
         [Fact]
+        public void Should_be_able_to_set_user_host_address()
+        {
+            // Given
+            const string userHostAddress = "127.0.0.1";
+
+            // When
+            var result = browser.Get("/userHostAddress", with =>
+                                                         {
+                                                             with.HttpRequest();
+                                                             with.UserHostAddress(userHostAddress);
+                                                         });
+
+            // Then
+            result.Body.AsString().ShouldEqual(userHostAddress);
+        }
+
+        [Fact]
         public void Should_be_able_to_send_stream_in_body()
         {
             // Given
@@ -339,6 +356,8 @@ namespace Nancy.Testing.Tests
                 };
 
                 Get["/nothing"] = ctx => string.Empty;
+
+                Get["/userHostAddress"] = ctx => Request.UserHostAddress;
 
                 Get["/session"] = ctx =>
                     {

--- a/src/Nancy.Testing/Browser.cs
+++ b/src/Nancy.Testing/Browser.cs
@@ -202,7 +202,7 @@ namespace Nancy.Testing
             var requestStream =
                 RequestStream.FromStream(contextValues.Body, 0, true);
 
-            return new Request(method, path, contextValues.Headers, requestStream, contextValues.Protocol, contextValues.QueryString);
+            return new Request(method, path, contextValues.Headers, requestStream, contextValues.Protocol, contextValues.QueryString, contextValues.UserHostAddress);
         }
     }
 }

--- a/src/Nancy.Testing/BrowserContext.cs
+++ b/src/Nancy.Testing/BrowserContext.cs
@@ -39,6 +39,11 @@
         string IBrowserContextValues.QueryString { get; set; }
 
         /// <summary>
+        /// Gets or sets the user host address
+        /// </summary>
+        string IBrowserContextValues.UserHostAddress { get; set; }
+
+        /// <summary>
         /// Gets or sets the body string
         /// </summary>
         string IBrowserContextValues.BodyString { get; set; }
@@ -137,6 +142,14 @@
                 this.Values.QueryString.Length == 0 ? "?" : "&", 
                 key,
                 value);
+        }
+
+        /// <summary>
+        /// Sets the user host address.
+        /// </summary>
+        public void UserHostAddress(string userHostAddress)
+        {
+            this.Values.UserHostAddress = userHostAddress;
         }
 
         private IBrowserContextValues Values

--- a/src/Nancy.Testing/IBrowserContextValues.cs
+++ b/src/Nancy.Testing/IBrowserContextValues.cs
@@ -41,5 +41,10 @@
         /// Gets or sets the querystring
         /// </summary>
         string QueryString { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user host address
+        /// </summary>
+        string UserHostAddress { get; set; }
     }
 }


### PR DESCRIPTION
Added a UserHostAddress method to the BrowserContext for testing the Request.UserHostAddress property in an endpoint.
