### PR TITLE
Updated default binder to combine body with context parameters.

### DIFF
--- a/src/Nancy/ModelBinding/DefaultBinder.cs
+++ b/src/Nancy/ModelBinding/DefaultBinder.cs
@@ -63,7 +63,7 @@ namespace Nancy.ModelBinding
 
             if (bodyDeserializedModel != null)
             {
-                return bodyDeserializedModel;
+                bindingContext.Model = bodyDeserializedModel;
             }
 
             foreach (var modelProperty in bindingContext.ValidModelProperties)


### PR DESCRIPTION
Updated default binder to combine body with context parameters. Before the fix if a body were set all other parameters were ignored.

Updated tests for default binder.

Hope this pull requests gets it right.
