### PR TITLE
Added support for bindings.xml in Spark

### DIFF
--- a/src/Nancy.ViewEngines.Spark/Nancy.ViewEngines.Spark.csproj
+++ b/src/Nancy.ViewEngines.Spark/Nancy.ViewEngines.Spark.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Descriptors\IDescriptorFilter.cs" />
     <Compile Include="Descriptors\IDescriptorBuilder.cs" />
     <Compile Include="Descriptors\DefaultDescriptorBuilder.cs" />
+    <Compile Include="NancyBindingProvider.cs" />
     <Compile Include="NancySparkView.cs" />
     <Compile Include="NancyViewFolder.cs" />
     <Compile Include="SparkViewEngineResult.cs" />

--- a/src/Nancy.ViewEngines.Spark/NancyBindingProvider.cs
+++ b/src/Nancy.ViewEngines.Spark/NancyBindingProvider.cs
@@ -1,0 +1,55 @@
+namespace Nancy.ViewEngines.Spark
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using global::Spark.Bindings;
+
+    /// <summary>
+    /// Loads binding files from the application path as returned by the current <see cref="IRootPathProvider"/>.
+    /// </summary>
+    /// <remarks>This will scan all sub-folders as well.</remarks>
+    public class NancyBindingProvider : BindingProvider
+    {
+        private readonly IRootPathProvider rootPathProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NancyBindingProvider"/> class, 
+        /// with the provided <paramref name="rootPathProvider"/>.
+        /// </summary>
+        /// <param name="rootPathProvider">The root path provider that defines where bindings should be looked for.</param>
+        public NancyBindingProvider(IRootPathProvider rootPathProvider)
+        {
+            this.rootPathProvider = rootPathProvider;
+        }
+
+        public override IEnumerable<Binding> GetBindings(BindingRequest bindingRequest)
+        {
+            var locatedFiles = 
+                Directory.GetFiles(this.rootPathProvider.GetRootPath(), "bindings.xml", SearchOption.AllDirectories);
+
+            return locatedFiles.Any() ? 
+                locatedFiles.SelectMany(this.LoadBindings) :
+                Enumerable.Empty<Binding>();
+        }
+
+        private IEnumerable<Binding> LoadBindings(string fileName)
+        {
+            try
+            {
+                using (var stream = new FileStream(fileName, FileMode.Open))
+                {
+                    using (var reader = new StreamReader(stream))
+                    {
+                        return this.LoadStandardMarkup(reader);
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                return Enumerable.Empty<Binding>();
+            }
+        }
+    }
+}

--- a/src/Nancy.ViewEngines.Spark/SparkViewEngine.cs
+++ b/src/Nancy.ViewEngines.Spark/SparkViewEngine.cs
@@ -1,6 +1,5 @@
 ﻿namespace Nancy.ViewEngines.Spark
 {
-    using System;
     using System.Collections.Generic;
     using System.Configuration;
     using System.Dynamic;
@@ -16,21 +15,28 @@
     public class SparkViewEngine : IViewEngine
     {
         private readonly IDescriptorBuilder descriptorBuilder;
-        private readonly ISparkViewEngine engine;
+        private readonly global::Spark.SparkViewEngine engine;
         private readonly ISparkSettings settings;
         private readonly string[] extensions = new[] { "spark", "shade" };
+
+        public SparkViewEngine()
+            : this(new DefaultRootPathProvider())
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SparkViewEngine"/> class.
         /// </summary>
-        public SparkViewEngine()
+        public SparkViewEngine(IRootPathProvider rootPathProvider)
         {
             this.settings = (ISparkSettings) ConfigurationManager.GetSection("spark") ?? new SparkSettings();
-
-            this.engine = new global::Spark.SparkViewEngine(this.settings)
-            {
-                DefaultPageBaseType = typeof(NancySparkView).FullName
-            };
+            
+            this.engine = 
+                new global::Spark.SparkViewEngine(this.settings)
+                {
+                    DefaultPageBaseType = typeof (NancySparkView).FullName,
+                    BindingProvider = new NancyBindingProvider(rootPathProvider),
+                };
 
             this.descriptorBuilder = new DefaultDescriptorBuilder(this.engine);
         }


### PR DESCRIPTION
Implemented a BindingProvider for Spark. It will look for bindings.xml files in the path (and sub-folders) that is returned by the IRootPathProvider. A BindingProvider support returning an IE<Bindings> so it's possible to have multiple bindings.xml files

Fixes #340
