### PR TITLE
Fixed issue #789

### DIFF
--- a/src/Nancy.Hosting.Aspnet/NancyHandler.cs
+++ b/src/Nancy.Hosting.Aspnet/NancyHandler.cs
@@ -42,13 +42,16 @@ namespace Nancy.Hosting.Aspnet
             var expectedRequestLength =
                 GetExpectedRequestLength(context.Request.Headers.ToDictionary());
 
+            var basePath =
+                context.Request.ApplicationPath.TrimEnd('/');
+
             var nancyUrl = new Url
                                {
                                    Scheme = context.Request.Url.Scheme,
                                    HostName = context.Request.Url.Host,
                                    Port = context.Request.Url.Port,
-                                   BasePath = context.Request.ApplicationPath.TrimEnd('/'),
-                                   Path = context.Request.AppRelativeCurrentExecutionFilePath.Replace("~", string.Empty),
+                                   BasePath = basePath,
+                                   Path = context.Request.Url.AbsolutePath.Substring(basePath.Length),
                                    Query = context.Request.Url.Query,
                                    Fragment = context.Request.Url.Fragment,
                                };


### PR DESCRIPTION
There was a problem with using AppRelativeCurrentExecutionFilePath
to set the Path of the Url on a Request, because it cut of the
path if it contained a dot, because it thought it had found a
filename and extension.
