### PR TITLE
ReadAsRequest extension method on stream

### DIFF
--- a/src/Nancy.Tests/Nancy.Tests.csproj
+++ b/src/Nancy.Tests/Nancy.Tests.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Unit\Diagnostics\DiagnosticsHookFixture.cs" />
     <Compile Include="Unit\ErrorHandling\DefaultStatusCodeHandlerFixture.cs" />
     <Compile Include="Unit\FormatterExtensionsFixture.cs" />
+    <Compile Include="Unit\HttpParser\ReadAsRequestFixture.cs" />
     <Compile Include="Unit\MimeTypesFixture.cs" />
     <Compile Include="Unit\ModelBinding\ModelBindingExceptionFixture.cs" />
     <Compile Include="Unit\ModelBinding\PropertyBindingExceptionFixture.cs" />

--- a/src/Nancy.Tests/Unit/HttpParser/ReadAsRequestFixture.cs
+++ b/src/Nancy.Tests/Unit/HttpParser/ReadAsRequestFixture.cs
@@ -1,0 +1,36 @@
+﻿namespace Nancy.Tests.Unit.HttpParser
+{
+    using System;
+    using System.IO;
+    using Nancy.HttpParser;
+    using Xunit;
+    using Xunit.Extensions;
+
+    public class ReadAsRequestFixture
+    {
+        [Fact]
+        public void When_stream_is_null_throws_argument_null_exception()
+        {
+            // given
+            Stream stream = null;
+
+            // when/then
+            var exception = Assert.Throws<ArgumentNullException>(() => stream.ReadAsRequest());
+            exception.ParamName.ShouldEqual("stream");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        public void When_scheme_is_empty_or_whitespace_throws_argument_null_exception(string scheme)
+        {
+            // Given
+            Stream stream = new MemoryStream();
+
+            // when/then
+            var exception = Assert.Throws<ArgumentNullException>(() => stream.ReadAsRequest(scheme: scheme));
+            exception.ParamName.ShouldEqual("scheme");
+        }
+    }
+}

--- a/src/Nancy.Tests/Unit/HttpParser/ReadAsRequestFixture.cs
+++ b/src/Nancy.Tests/Unit/HttpParser/ReadAsRequestFixture.cs
@@ -109,5 +109,56 @@ asdf"));
             // then
             result.UserHostAddress.ShouldEqual(ip);
         }
+
+        [Fact]
+        public void RelativeUrlGetFixtureWithSchemeAndIp()
+        {
+            // given
+            var rawRequestStream = new MemoryStream(Encoding.UTF8.GetBytes(
+@"GET /search?q=nancy&oq=nancy&aqs=chrome.0.57j61l3j62l2.1586&sugexp=chrome,mod=9&sourceid=chrome&ie=UTF-8 HTTP/1.1
+Host: www.google.com
+Connection: keep-alive
+User-Agent: Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.64 Safari/537.11
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+X-Chrome-Variations: COu1yQEIjrbJAQiZtskBCKa2yQEIqLbJAQiptskBCL62yQEIuYPKAQjkg8oB
+Accept-Encoding: gzip,deflate,sdch
+Accept-Language: en-US,en;q=0.8
+Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.3
+Cookie: HSID=AcDWbTlAk2te13e6v; SSID=ADlPlPQUdYU9sYFko; APISID=CINzVUNGqU9XeH7Z/AyUAw5-o8-dHmiYXD; SAPISID=RhfYRwz0cLjNLWlx/A2d_HwfJlHpXwhoDx; PREF=ID=fbc069c5fbe31ad0:U=049c4423c184f188:FF=0:LD=en:TM=1351297728:LM=1352001209:GM=1:S=rKPgbpqXvNMVD8-E; NID=66=ARPHDECrPAihN0H5dE_ee2xU1G77IXnqNJfeze8nPTZJNJ8xkVQZIVDCctexNW3gx0Nhg0lZE9u_m4fVPvg_d4gl9vcqR1b01K1J5ypZixaYEbDXXDyanlzKB3dYxBWjV8HYWjekJ23kdYlk9EDOELe_6dveiD_sPkI4D11OyQ4Yv2fziR9s4batoDvUOg-TZwR7M-CO; SID=DQAAAIMBAADNixH7WUPsOcqiSiRiyuTPqJWF8ApoPQEyhFCgM-yS8pjY7cZKiQZ473IvCpaKLqRshKkv-UFhLsxbc5tC11G0gN4CbCHwzKv18Y2c5SbHU2hf9Tfy6GaqSu9UV4zbYhS94E7jMzQRM-zJxOerBS_RInfjZZX0b8ZKYMf6AmpdYDOCkMhWopCaVZdxIkIcJ-wkstggYx76Nzbirtf7kojGHdsNYFeIVt9nTEjVITOLDiT2Qobn7lR7-UQA0l6xL0o7A_9zAH341OO8jvcwL-7w2auxAHcjuyZJm5MtbKlvJlMA1vflNOJsnAAdLJpiDZHjAYWdiclORrxisQHdR-LbAkTDRq6gIgYOrToAfQ8wrvKaIruGEWbYzjYU2rhVcmB6lzkvk_02-zNVzxcvCFh66MiTql0bFVNl8mSqA9JBjW-jMiw2sHS9zeqWhjuhvidWUnSRLLYoUOkSCu5U6QtrFVgj7UgzugQtep7AX0xAaPnY-gvn6nflm6O90Vk8D0AlHRfSqpKPpytfKi6PuVA-
+
+"));
+
+            // when
+            var result = rawRequestStream.ReadAsRequest(scheme: "https", ip: "192.168.0.1");
+
+            // then
+            result.Url.BasePath.ShouldBeEmpty();
+            result.Url.Fragment.ShouldBeEmpty();
+            result.Url.HostName.ShouldEqual("www.google.com");
+            result.Url.Path.ShouldEqual("/search");
+            result.Url.Port.ShouldBeNull();
+            result.Url.Query.ShouldEqual("q=nancy&oq=nancy&aqs=chrome.0.57j61l3j62l2.1586&sugexp=chrome,mod=9&sourceid=chrome&ie=UTF-8");
+            result.Url.Scheme.ShouldEqual("https");
+
+            result.UserHostAddress.ShouldEqual("192.168.0.1");
+
+            result.Headers.ShouldHaveCount(9);
+            result.Headers.Host.ShouldEqual("www.google.com");
+            result.Headers.Connection.ShouldEqual("keep-alive");
+            result.Headers.UserAgent.ShouldEqual("Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.64 Safari/537.11");
+            result.Headers["Accept"].ShouldEqualSequence(new[] { "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8" });
+            result.Headers["X-Chrome-Variations"].ShouldEqualSequence(new[] { "COu1yQEIjrbJAQiZtskBCKa2yQEIqLbJAQiptskBCL62yQEIuYPKAQjkg8oB" });
+            result.Headers.AcceptEncoding.ShouldEqualSequence(new[] { "gzip", "deflate", "sdch" });
+            result.Headers["Accept-Language"].ShouldEqualSequence(new[] { "en-US,en;q=0.8" });
+            result.Headers["Accept-Charset"].ShouldEqualSequence(new[] { "ISO-8859-1,utf-8;q=0.7,*;q=0.3" });
+            result.Headers["Cookie"].ShouldEqualSequence(new[] { "HSID=AcDWbTlAk2te13e6v; SSID=ADlPlPQUdYU9sYFko; APISID=CINzVUNGqU9XeH7Z/AyUAw5-o8-dHmiYXD; SAPISID=RhfYRwz0cLjNLWlx/A2d_HwfJlHpXwhoDx; PREF=ID=fbc069c5fbe31ad0:U=049c4423c184f188:FF=0:LD=en:TM=1351297728:LM=1352001209:GM=1:S=rKPgbpqXvNMVD8-E; NID=66=ARPHDECrPAihN0H5dE_ee2xU1G77IXnqNJfeze8nPTZJNJ8xkVQZIVDCctexNW3gx0Nhg0lZE9u_m4fVPvg_d4gl9vcqR1b01K1J5ypZixaYEbDXXDyanlzKB3dYxBWjV8HYWjekJ23kdYlk9EDOELe_6dveiD_sPkI4D11OyQ4Yv2fziR9s4batoDvUOg-TZwR7M-CO; SID=DQAAAIMBAADNixH7WUPsOcqiSiRiyuTPqJWF8ApoPQEyhFCgM-yS8pjY7cZKiQZ473IvCpaKLqRshKkv-UFhLsxbc5tC11G0gN4CbCHwzKv18Y2c5SbHU2hf9Tfy6GaqSu9UV4zbYhS94E7jMzQRM-zJxOerBS_RInfjZZX0b8ZKYMf6AmpdYDOCkMhWopCaVZdxIkIcJ-wkstggYx76Nzbirtf7kojGHdsNYFeIVt9nTEjVITOLDiT2Qobn7lR7-UQA0l6xL0o7A_9zAH341OO8jvcwL-7w2auxAHcjuyZJm5MtbKlvJlMA1vflNOJsnAAdLJpiDZHjAYWdiclORrxisQHdR-LbAkTDRq6gIgYOrToAfQ8wrvKaIruGEWbYzjYU2rhVcmB6lzkvk_02-zNVzxcvCFh66MiTql0bFVNl8mSqA9JBjW-jMiw2sHS9zeqWhjuhvidWUnSRLLYoUOkSCu5U6QtrFVgj7UgzugQtep7AX0xAaPnY-gvn6nflm6O90Vk8D0AlHRfSqpKPpytfKi6PuVA-" });
+
+            result.Cookies.ShouldHaveCount(7);
+            result.Cookies["HSID"].ShouldEqual("AcDWbTlAk2te13e6v");
+            result.Cookies["SSID"].ShouldEqual("ADlPlPQUdYU9sYFko");
+
+            result.Body.ShouldNotBeNull();
+            result.Body.Length.ShouldEqual(0L);
+        }
     }
 }

--- a/src/Nancy.Tests/Unit/HttpParser/ReadAsRequestFixture.cs
+++ b/src/Nancy.Tests/Unit/HttpParser/ReadAsRequestFixture.cs
@@ -1,6 +1,7 @@
 ﻿namespace Nancy.Tests.Unit.HttpParser
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Text;
     using Nancy.HttpParser;
@@ -52,6 +53,9 @@ Host: nancyfx.org
 
             result.Url.Scheme.ShouldEqual("http");
             result.Url.Path.ShouldEqual("/");
+
+            result.Headers.ShouldHaveCount(2);
+
             result.Body.Length.ShouldEqual(0L);
         }
 
@@ -74,6 +78,8 @@ asdf"));
 
             result.Url.Scheme.ShouldEqual("http");
             result.Url.Path.ShouldEqual("/");
+
+            result.Headers.ShouldHaveCount(3);
 
             using (var reader = new StreamReader(result.Body))
             {

--- a/src/Nancy/HttpParser/HeaderParser.cs
+++ b/src/Nancy/HttpParser/HeaderParser.cs
@@ -11,7 +11,7 @@
         private const int CR = '\r';
         private const int LF = '\n';
 
-        public static IDictionary<string, string[]> Parse(Stream stream)
+        public static IDictionary<string, IEnumerable<string>> Parse(Stream stream)
         {
             var headers = new NameValueCollection();
             var bytes = ReadHeaderBytes(stream);
@@ -29,7 +29,7 @@
                 headers.Add(line.Substring(0, colonIndex), line.Substring(colonIndex + 1).TrimStart());
             }
 
-            var dict = new Dictionary<string, string[]>(headers.Keys.Count);
+            var dict = new Dictionary<string, IEnumerable<string>>(headers.Keys.Count);
             foreach (var key in headers.AllKeys)
             {
                 dict.Add(key, headers.GetValues(key));

--- a/src/Nancy/HttpParser/HeaderParser.cs
+++ b/src/Nancy/HttpParser/HeaderParser.cs
@@ -1,0 +1,77 @@
+﻿namespace Nancy.HttpParser
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Specialized;
+    using System.IO;
+    using System.Text;
+
+    internal static class HeaderParser
+    {
+        private const int CR = '\r';
+        private const int LF = '\n';
+
+        public static IDictionary<string, string[]> Parse(Stream stream)
+        {
+            var headers = new NameValueCollection();
+            var bytes = ReadHeaderBytes(stream);
+
+            var text = Encoding.Default.GetString(bytes);
+            var lines = text.Split(new[] { "\r\n" }, StringSplitOptions.None);
+            foreach (var line in lines)
+            {
+                if (line == "")
+                {
+                    break;
+                }
+
+                var colonIndex = line.IndexOf(':');
+                headers.Add(line.Substring(0, colonIndex), line.Substring(colonIndex + 1).TrimStart());
+            }
+
+            var dict = new Dictionary<string, string[]>(headers.Keys.Count);
+            foreach (var key in headers.AllKeys)
+            {
+                dict.Add(key, headers.GetValues(key));
+            }
+
+            return dict;
+        }
+
+        private static byte[] ReadHeaderBytes(Stream stream)
+        {
+            var bytes = new List<byte>();
+            bool mightBeEnd = false;
+
+            while (true)
+            {
+                int b = stream.ReadByte();
+                if (b == CR)
+                {
+                    b = stream.ReadByte();
+                    if (b != LF)
+                    {
+                        bytes.Add(CR);
+                        bytes.Add((byte)b);
+                        continue;
+                    }
+
+                    if (mightBeEnd)
+                    {
+                        break;
+                    }
+
+                    mightBeEnd = true;
+                    bytes.Add(CR);
+                    bytes.Add(LF);
+                    continue;
+                }
+
+                mightBeEnd = false;
+                bytes.Add((byte)b);
+            }
+
+            return bytes.ToArray();
+        }
+    }
+}

--- a/src/Nancy/HttpParser/HttpParserStreamExtensions.cs
+++ b/src/Nancy/HttpParser/HttpParserStreamExtensions.cs
@@ -60,15 +60,6 @@
                 url.HostName = headerValues.FirstOrDefault();
             }
 
-            if (headers.TryGetValue("Expect", out headerValues))
-            {
-
-            }
-            else
-            {
-
-            }
-
             var nestedRequestStream = new RequestStream(new HttpMultipartSubStream(stream, stream.Position, stream.Length), stream.Length - stream.Position, true);
 
             var request = new Request(requestLine.Method, url, nestedRequestStream, headers, ip);

--- a/src/Nancy/HttpParser/HttpParserStreamExtensions.cs
+++ b/src/Nancy/HttpParser/HttpParserStreamExtensions.cs
@@ -7,6 +7,16 @@
     {
         public static Request ReadAsRequest(this Stream stream, string scheme = "http")
         {
+            if (stream == null)
+            {
+                throw new ArgumentNullException("stream");
+            }
+
+            if (string.IsNullOrWhiteSpace(scheme))
+            {
+                throw new ArgumentNullException("scheme");
+            }
+
             throw new NotImplementedException();
         }
     }

--- a/src/Nancy/HttpParser/HttpParserStreamExtensions.cs
+++ b/src/Nancy/HttpParser/HttpParserStreamExtensions.cs
@@ -6,8 +6,18 @@
     using System.Linq;
     using Nancy.IO;
 
+    /// <summary>
+    /// Extensions for Http parsing.
+    /// </summary>
     public static class HttpParserStreamExtensions
     {
+        /// <summary>
+        /// Read the http stream as a <see cref="Request"/>.
+        /// </summary>
+        /// <param name="stream">The http stream.</param>
+        /// <param name="scheme">The url scheme.</param>
+        /// <param name="ip">The ip address.</param>
+        /// <returns>Returns the parse <see cref="Request"/>.</returns>
         public static Request ReadAsRequest(this Stream stream, string scheme = "http", string ip = null)
         {
             if (stream == null)

--- a/src/Nancy/HttpParser/HttpParserStreamExtensions.cs
+++ b/src/Nancy/HttpParser/HttpParserStreamExtensions.cs
@@ -8,7 +8,7 @@
 
     public static class HttpParserStreamExtensions
     {
-        public static Request ReadAsRequest(this Stream stream, string scheme = "http")
+        public static Request ReadAsRequest(this Stream stream, string scheme = "http", string ip = null)
         {
             if (stream == null)
             {
@@ -61,7 +61,7 @@
 
             var nestedRequestStream = new RequestStream(new HttpMultipartSubStream(stream, stream.Position, stream.Length), stream.Length - stream.Position, true);
 
-            var request = new Request(requestLine.Method, url, nestedRequestStream, headers);
+            var request = new Request(requestLine.Method, url, nestedRequestStream, headers, ip);
 
             return request;
         }

--- a/src/Nancy/HttpParser/HttpParserStreamExtensions.cs
+++ b/src/Nancy/HttpParser/HttpParserStreamExtensions.cs
@@ -1,0 +1,13 @@
+﻿namespace Nancy.HttpParser
+{
+    using System;
+    using System.IO;
+
+    public static class HttpParserStreamExtensions
+    {
+        public static Request ReadAsRequest(this Stream stream, string scheme = "http")
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Nancy/HttpParser/HttpParserStreamExtensions.cs
+++ b/src/Nancy/HttpParser/HttpParserStreamExtensions.cs
@@ -2,6 +2,8 @@
 {
     using System;
     using System.IO;
+    using System.Linq;
+    using Nancy.IO;
 
     public static class HttpParserStreamExtensions
     {
@@ -17,7 +19,50 @@
                 throw new ArgumentNullException("scheme");
             }
 
-            throw new NotImplementedException();
+            var requestLine = RequestLineParser.Parse(stream);
+
+            var url = new Url();
+
+            if (requestLine.Uri.StartsWith("http", StringComparison.InvariantCultureIgnoreCase))
+            {
+                Uri uri;
+                if (Uri.TryCreate(requestLine.Uri, UriKind.Absolute, out uri))
+                {
+                    url.Path = uri.AbsolutePath;
+                    url.Query = uri.Query;
+                    url.Fragment = uri.Fragment;
+                    url.Scheme = uri.Scheme;
+                }
+            }
+            else
+            {
+                var splitUri = requestLine.Uri.Split('?');
+                url.Path = splitUri[0];
+                url.Query = splitUri.Length == 2 ? splitUri[1] : string.Empty;
+                url.Scheme = scheme;
+            }
+
+            var headers = HeaderParser.Parse(stream);
+            string[] headerValues;
+            if (headers.TryGetValue("Host", out headerValues))
+            {
+                url.HostName = headerValues.FirstOrDefault();
+            }
+
+            if (headers.TryGetValue("Expect", out headerValues))
+            {
+
+            }
+            else
+            {
+
+            }
+
+            var nestedRequestStream = new RequestStream(new HttpMultipartSubStream(stream, stream.Position, stream.Length), stream.Length - stream.Position, true);
+
+            var request = new Request(requestLine.Method, url, nestedRequestStream);
+
+            return request;
         }
     }
 }

--- a/src/Nancy/HttpParser/HttpParserStreamExtensions.cs
+++ b/src/Nancy/HttpParser/HttpParserStreamExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace Nancy.HttpParser
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using Nancy.IO;
@@ -43,7 +44,7 @@
             }
 
             var headers = HeaderParser.Parse(stream);
-            string[] headerValues;
+            IEnumerable<string> headerValues;
             if (headers.TryGetValue("Host", out headerValues))
             {
                 url.HostName = headerValues.FirstOrDefault();
@@ -60,7 +61,7 @@
 
             var nestedRequestStream = new RequestStream(new HttpMultipartSubStream(stream, stream.Position, stream.Length), stream.Length - stream.Position, true);
 
-            var request = new Request(requestLine.Method, url, nestedRequestStream);
+            var request = new Request(requestLine.Method, url, nestedRequestStream, headers);
 
             return request;
         }

--- a/src/Nancy/HttpParser/RequestLine.cs
+++ b/src/Nancy/HttpParser/RequestLine.cs
@@ -1,0 +1,31 @@
+﻿namespace Nancy.HttpParser
+{
+    internal class RequestLine
+    {
+        private readonly string method;
+        private readonly string uri;
+        private readonly string httpVersion;
+
+        public RequestLine(string method, string uri, string httpVersion)
+        {
+            this.method = method;
+            this.uri = uri;
+            this.httpVersion = httpVersion;
+        }
+
+        public string HttpVersion
+        {
+            get { return httpVersion; }
+        }
+
+        public string Uri
+        {
+            get { return uri; }
+        }
+
+        public string Method
+        {
+            get { return method; }
+        }
+    }
+}

--- a/src/Nancy/HttpParser/RequestLineParser.cs
+++ b/src/Nancy/HttpParser/RequestLineParser.cs
@@ -1,0 +1,48 @@
+﻿namespace Nancy.HttpParser
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+
+    internal static class RequestLineParser
+    {
+        private const int CR = '\r';
+        private const int LF = '\n';
+
+        public static RequestLine Parse(Stream stream)
+        {
+            int b = stream.ReadByte();
+            while (b == CR || b == LF)
+            {
+                b = stream.ReadByte();
+            }
+
+            var bytes = new LinkedList<byte>();
+            bytes.AddLast((byte)b);
+
+            while (true)
+            {
+                b = stream.ReadByte();
+                if (b == CR || b < 0)
+                {
+                    stream.ReadByte();
+                    break;
+                }
+                bytes.AddLast((byte)b);
+            }
+
+            var text = Encoding.Default.GetString(bytes.ToArray());
+            var parts = text.Split(' ');
+
+            if (parts.Length == 3)
+            {
+                return new RequestLine(parts[0], parts[1], parts[2]);
+            }
+
+            throw new InvalidOperationException("Invalid Request Line.");
+            //throw new InvalidRequestException("Invalid Request Line.");
+        }
+    }
+}

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -144,6 +144,7 @@
     <Compile Include="ModelBinding\BindingConfig.cs" />
     <Compile Include="ModelBinding\PropertyBindingException.cs" />
     <Compile Include="HttpParser\HeaderParser.cs" />
+    <Compile Include="HttpParser\HttpParserStreamExtensions.cs" />
     <Compile Include="HttpParser\RequestLine.cs" />
     <Compile Include="HttpParser\RequestLineParser.cs" />
     <Compile Include="NegotiatorExtensions.cs" />

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Diagnostics\DiagnosticsViewRenderer.cs" />
     <Compile Include="ModelBinding\BindingConfig.cs" />
     <Compile Include="ModelBinding\PropertyBindingException.cs" />
+    <Compile Include="HttpParser\HeaderParser.cs" />
     <Compile Include="NegotiatorExtensions.cs" />
     <Compile Include="Responses\EmbeddedFileResponse.cs" />
     <Compile Include="Diagnostics\IDiagnosticsProvider.cs" />

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -145,6 +145,7 @@
     <Compile Include="ModelBinding\PropertyBindingException.cs" />
     <Compile Include="HttpParser\HeaderParser.cs" />
     <Compile Include="HttpParser\RequestLine.cs" />
+    <Compile Include="HttpParser\RequestLineParser.cs" />
     <Compile Include="NegotiatorExtensions.cs" />
     <Compile Include="Responses\EmbeddedFileResponse.cs" />
     <Compile Include="Diagnostics\IDiagnosticsProvider.cs" />

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -144,6 +144,7 @@
     <Compile Include="ModelBinding\BindingConfig.cs" />
     <Compile Include="ModelBinding\PropertyBindingException.cs" />
     <Compile Include="HttpParser\HeaderParser.cs" />
+    <Compile Include="HttpParser\RequestLine.cs" />
     <Compile Include="NegotiatorExtensions.cs" />
     <Compile Include="Responses\EmbeddedFileResponse.cs" />
     <Compile Include="Diagnostics\IDiagnosticsProvider.cs" />


### PR DESCRIPTION
Proof of concept for #796 (helper methods to convert raw Stream to Nancy Request)

This is just a proof of concept `ReadAsRequest` extension which uses https://github.com/markrendle/Flux http parser internally. Only `ReadAsRequest` is exposed as a public api.

Note: this is only a partial implementation.