### PR TITLE
Added WithCookie/Cookies extensions to negotiator

### DIFF
--- a/src/Nancy.Tests.Functional/Tests/ContentNegotiationFixture.cs
+++ b/src/Nancy.Tests.Functional/Tests/ContentNegotiationFixture.cs
@@ -3,7 +3,8 @@ namespace Nancy.Tests.Functional.Tests
     using System;
     using System.Collections.Generic;
     using System.IO;
-
+    using System.Linq;
+    using Cookies;
     using Nancy.ErrorHandling;
     using Nancy.IO;
     using Nancy.Responses.Negotiation;
@@ -429,6 +430,36 @@ namespace Nancy.Tests.Functional.Tests
 
             // Then
             Assert.Equal(HttpStatusCode.InsufficientStorage, response.StatusCode);
+        }
+
+        [Fact]
+        public void Should_set_negotiated_cookies_to_response()
+        {
+            // Given
+            var negotiatedCookie = 
+                new NancyCookie("test", "test");
+
+            var browser = new Browser(with =>
+            {
+                with.ResponseProcessor<TestProcessor>();
+
+                with.Module(new ConfigurableNancyModule(x =>
+                {
+                    x.Get("/", CreateNegotiatedResponse(config =>
+                    {
+                        config.WithCookie(negotiatedCookie);
+                    }));
+                }));
+            });
+
+            // When
+            var response = browser.Get("/", with =>
+            {
+                with.Accept("test/test", 0.9m);
+            });
+
+            // Then
+            Assert.Same(negotiatedCookie, response.Cookies.First());
         }
 
         [Fact]

--- a/src/Nancy/NegotiatorExtensions.cs
+++ b/src/Nancy/NegotiatorExtensions.cs
@@ -1,12 +1,41 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nancy.Responses.Negotiation;
-
-namespace Nancy
+﻿namespace Nancy
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Nancy.Responses.Negotiation;
+    using Cookies;
+
     public static class NegotiatorExtensions
     {
+        /// <summary>
+        /// Add a cookie to the response.
+        /// </summary>
+        /// <param name="negotiator">The <see cref="Negotiator"/> instance.</param>
+        /// <param name="cookie">The <see cref="INancyCookie"/> instance that should be added.</param>
+        /// <returns>The modified <see cref="Negotiator"/> instance.</returns>
+        public static Negotiator WithCookie(this Negotiator negotiator, INancyCookie cookie)
+        {
+            negotiator.NegotiationContext.Cookies.Add(cookie);
+            return negotiator;
+        }
+
+        /// <summary>
+        /// Add a collection of cookies to the response.
+        /// </summary>
+        /// <param name="negotiator">The <see cref="Negotiator"/> instance.</param>
+        /// <param name="cookies">The <see cref="INancyCookie"/> instances that should be added.</param>
+        /// <returns>The modified <see cref="Negotiator"/> instance.</returns>
+        public static Negotiator WithCookies(this Negotiator negotiator, IEnumerable<INancyCookie> cookies)
+        {
+            foreach (var cookie in cookies)
+            {
+                negotiator.WithCookie(cookie);
+            }
+            
+            return negotiator;
+        }
+
         /// <summary>
         /// Add a header to the response
         /// </summary>

--- a/src/Nancy/Responses/Negotiation/NegotiationContext.cs
+++ b/src/Nancy/Responses/Negotiation/NegotiationContext.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Cookies;
 
     /// <summary>
     /// Context for content negotiation.
@@ -14,10 +15,17 @@
         /// </summary>
         public NegotiationContext()
         {
+            this.Cookies = new List<INancyCookie>();
             this.PermissableMediaRanges = new List<MediaRange>(new[] { (MediaRange)"*/*" });
             this.MediaRangeModelMappings = new Dictionary<MediaRange, Func<dynamic>>();
             this.Headers = new Dictionary<string, string>();
         }
+
+        /// <summary>
+        /// Gets or sets additional cookies to assign to the response.
+        /// </summary>
+        /// <value>An <see cref="IList{T}"/> of <see cref="INancyCookie"/> instances.</value>
+        public IList<INancyCookie> Cookies { get; set; }
 
         /// <summary>
         /// Gets or sets the default model that will be used if a content type specific model is not specified.

--- a/src/Nancy/Routing/DefaultRouteInvoker.cs
+++ b/src/Nancy/Routing/DefaultRouteInvoker.cs
@@ -170,6 +170,11 @@ namespace Nancy.Routing
                 response.StatusCode = negotiator.NegotiationContext.StatusCode.Value;
             }
 
+            foreach (var cookie in negotiator.NegotiationContext.Cookies)
+            {
+                response.Cookies.Add(cookie);
+            }
+
             return response;
         }
 


### PR DESCRIPTION
It is now possible to add cookies to a negotiated response
with the help of the WithCookie / WithCookies extension
methods.

Fixes #806
