### PR TITLE
Update src/Nancy/IRootPathProvider.cs

### DIFF
--- a/src/Nancy/IRootPathProvider.cs
+++ b/src/Nancy/IRootPathProvider.cs
@@ -18,7 +18,7 @@
     {
         public string GetRootPath()
         {
-            return Environment.CurrentDirectory;
+            return AppDomain.CurrentDomain.BaseDirectory;
         }
     }
 }


### PR DESCRIPTION
When using multiple nancy instances in the same application in seperate appdomains you should use the app domain base path by default.

http://stackoverflow.com/questions/674857/should-i-use-appdomain-currentdomain-basedirectory-or-system-environment-current
