### PR TITLE
Url decode provider name

### DIFF
--- a/src/Nancy/Diagnostics/Modules/InteractiveModule.cs
+++ b/src/Nancy/Diagnostics/Modules/InteractiveModule.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Linq;
+    using Helpers;
 
     public class InteractiveModule : DiagnosticModule
     {
@@ -28,7 +29,11 @@
 
             Get["/providers/{providerName}"] = ctx =>
                 {
-                    InteractiveDiagnostic diagnostic = this.interactiveDiagnostics.GetDiagnostic(ctx.providerName);
+                    var name =
+                        HttpUtility.UrlDecode((string)ctx.providerName);
+
+                    var diagnostic = 
+                        this.interactiveDiagnostics.GetDiagnostic(name);
 
                     if (diagnostic == null)
                     {


### PR DESCRIPTION
This is preventing interactive diagnostics provider methods to be displayed on the diagnostics page
