### PR TITLE
Return 404 instread of diag help page in release

### DIFF
--- a/src/Nancy/Diagnostics/DiagnosticsHook.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsHook.cs
@@ -84,9 +84,9 @@ namespace Nancy.Diagnostics
 
         private static Response GetDiagnosticsHelpView(NancyContext ctx)
         {
-            var renderer = new DiagnosticsViewRenderer(ctx);
-
-            return renderer["help"];
+            return (StaticConfiguration.IsRunningDebug)
+                       ? new DiagnosticsViewRenderer(ctx)["help"]
+                       : HttpStatusCode.NotFound;
         }
 
         private static Response GetDiagnosticsLoginView(NancyContext ctx)

--- a/src/Nancy/Diagnostics/Modules/SettingsModule.cs
+++ b/src/Nancy/Diagnostics/Modules/SettingsModule.cs
@@ -20,9 +20,11 @@
                 var model = from property in properties
                         orderby property.Name
                         let value = (bool) property.GetValue(null, null)
+                        let description = GetDescription(property)
+                        where !string.IsNullOrEmpty(description)
                         select new {
                             Name = property.Name,
-                            Description = GetDescription(property),
+                            Description = description,
                             DisplayName = Regex.Replace(property.Name, "[A-Z]", " $0"),
                             Value = value,
                             Checked = (value) ? "checked='checked'" : string.Empty

--- a/src/Nancy/StaticConfiguration.cs
+++ b/src/Nancy/StaticConfiguration.cs
@@ -62,7 +62,7 @@ namespace Nancy
         /// Checks the entry assembly to see whether it has been built in debug mode.
         /// If anything goes wrong it returns false.
         /// </summary>
-        private static bool IsRunningDebug
+        public static bool IsRunningDebug
         {
             get
             {


### PR DESCRIPTION
Updates so that StatisConfiguration.IsRunningDebug is public. The
DiagnosticsHook will not check that flag before returning the
diagnostics help view. If true then it will return NotFound
instead.

Also updated the diagnostics settings page so that it only lists
members, of StaticConfiguration, that has been decorated with a
DescriptionAttribute.

Fixes #625
