### PR TITLE
Sorted url decoding in the interactive diagnostics module

### DIFF
--- a/src/Nancy/Diagnostics/Modules/InfoModule.cs
+++ b/src/Nancy/Diagnostics/Modules/InfoModule.cs
@@ -14,7 +14,10 @@
         public InfoModule(IRootPathProvider rootPathProvider, NancyInternalConfiguration configuration)
             : base("/info")
         {
-            Get["/"] = _ => View["Info"];
+            Get["/"] = _ =>
+            {
+                return View["Info"];
+            };
 
             Get["/data"] = _ =>
             {
@@ -26,8 +29,8 @@
                 data.Nancy.TracesDisabled = StaticConfiguration.DisableErrorTraces;
                 data.Nancy.CaseSensitivity = StaticConfiguration.CaseSensitive ? "Sensitive" : "Insensitive";
                 data.Nancy.RootPath = rootPathProvider.GetRootPath();
-                data.Nancy.Hosting = this.GetHosting();
-                data.Nancy.BootstrapperContainer = this.GetBootstrapperContainer();
+                data.Nancy.Hosting = GetHosting();
+                data.Nancy.BootstrapperContainer = GetBootstrapperContainer();
                 data.Nancy.LocatedBootstrapper = NancyBootstrapperLocator.Bootstrapper.GetType().ToString();
                 data.Nancy.LoadedViewEngines = GetViewEngines();
 
@@ -46,39 +49,38 @@
             };
         }
 
-        private string[] GetViewEngines()
+        private static string[] GetViewEngines()
         {
-            var engines = AppDomainAssemblyTypeScanner.TypesOf<IViewEngine>();
+            var engines =
+                AppDomainAssemblyTypeScanner.TypesOf<IViewEngine>();
 
-            return engines.Select(engine => engine.Name.Split(new [] { "ViewEngine" }, StringSplitOptions.None)[0]).ToArray();
+            return engines
+                .Select(engine => engine.Name.Split(new [] { "ViewEngine" }, StringSplitOptions.None)[0])
+                .ToArray();
         }
 
-        private string GetBootstrapperContainer()
+        private static string GetBootstrapperContainer()
         {
-            var name = AppDomain.CurrentDomain.GetAssemblies()
-                                                  .Select(asm => asm.GetName())
-                                                  .FirstOrDefault(asmName => asmName.Name != null && asmName.Name.StartsWith("Nancy.Bootstrappers."));
+            var name = AppDomain.CurrentDomain
+                .GetAssemblies()
+                .Select(asm => asm.GetName())
+                .FirstOrDefault(asmName => asmName.Name != null && asmName.Name.StartsWith("Nancy.Bootstrappers."));
 
-            if (name == null)
-            {
-                return "TinyIoC";
-            }
-
-            return string.Format("{0} (v{1})", name.Name.Split('.').Last(), name.Version);
+            return (name == null) ?
+                "TinyIoC" :
+                string.Format("{0} (v{1})", name.Name.Split('.').Last(), name.Version);
         }
 
-        private string GetHosting()
+        private static string GetHosting()
         {
-            var name = AppDomain.CurrentDomain.GetAssemblies()
-                                                  .Select(asm => asm.GetName())
-                                                  .FirstOrDefault(asmName => asmName.Name != null && asmName.Name.StartsWith("Nancy.Hosting."));
+            var name = AppDomain.CurrentDomain
+                .GetAssemblies()
+                .Select(asm => asm.GetName())
+                .FirstOrDefault(asmName => asmName.Name != null && asmName.Name.StartsWith("Nancy.Hosting."));
 
-            if (name == null)
-            {
-                return "Unknown";
-            }
-
-            return string.Format("{0} (v{1})", name.Name.Split('.').Last(), name.Version);
+            return (name == null) ?
+                "Unknown" : 
+                string.Format("{0} (v{1})", name.Name.Split('.').Last(), name.Version);
         }
     }
 }

--- a/src/Nancy/Diagnostics/Modules/InteractiveModule.cs
+++ b/src/Nancy/Diagnostics/Modules/InteractiveModule.cs
@@ -10,114 +10,129 @@
     {
         private readonly IInteractiveDiagnostics interactiveDiagnostics;
 
-        public InteractiveModule(IRequestTracing sessionProvider, IInteractiveDiagnostics interactiveDiagnostics)
+        public InteractiveModule(IInteractiveDiagnostics interactiveDiagnostics)
             :base ("/interactive")
         {
             this.interactiveDiagnostics = interactiveDiagnostics;
 
-            Get["/"] = _ => View["InteractiveDiagnostics"];
+            Get["/"] = _ =>
+            {
+                return View["InteractiveDiagnostics"];
+            };
 
             Get["/providers"] = _ =>
-                {
-                    var providers = this.interactiveDiagnostics
-                                        .AvailableDiagnostics
-                                        .Select(p => new { p.Name, p.Description, Type = p.GetType().Name, p.GetType().Namespace, Assembly = p.GetType().Assembly.GetName().Name })
-                                        .ToArray();
+            {
+                var providers = this.interactiveDiagnostics
+                    .AvailableDiagnostics
+                    .Select(p => new
+                        {
+                            p.Name, 
+                            p.Description, 
+                            Type = p.GetType().Name, 
+                            p.GetType().Namespace, 
+                            Assembly = p.GetType().Assembly.GetName().Name
+                        })
+                    .ToArray();
 
-                    return Response.AsJson(providers);
-                };
+                return Response.AsJson(providers);
+            };
 
             Get["/providers/{providerName}"] = ctx =>
+            {
+                var providerName =
+                    HttpUtility.UrlDecode((string)ctx.providerName);
+
+                var diagnostic = 
+                    this.interactiveDiagnostics.GetDiagnostic(providerName);
+
+                if (diagnostic == null)
                 {
-                    var providerName =
-                        HttpUtility.UrlDecode((string)ctx.providerName);
+                    return HttpStatusCode.NotFound;
+                }
 
-                    var diagnostic = 
-                        this.interactiveDiagnostics.GetDiagnostic(providerName);
+                var methods = diagnostic.Methods
+                    .Select(m => new
+                        {
+                            m.MethodName, 
+                            ReturnType = m.ReturnType.ToString(), 
+                            m.Description,
+                            Arguments = m.Arguments.Select(a => new
+                            {
+                                ArgumentName = a.Item1, 
+                                ArgumentType = a.Item2.ToString()
+                            })
+                        })
+                    .ToArray();
 
-                    if (diagnostic == null)
-                    {
-                        return HttpStatusCode.NotFound;
-                    }
-
-                    var methods = diagnostic.Methods
-                                          .Select(m => new
-                                              {
-                                                  m.MethodName, 
-                                                  ReturnType = m.ReturnType.ToString(), 
-                                                  m.Description,
-                                                  Arguments = m.Arguments.Select(a => new
-                                                      {
-                                                          ArgumentName = a.Item1, 
-                                                          ArgumentType = a.Item2.ToString()
-                                                      })
-                                              })
-                                          .ToArray();
-
-                    return Response.AsJson(methods);
-                };
+                return Response.AsJson(methods);
+            };
 
             Get["/providers/{providerName}/{methodName}"] = ctx =>
+            {
+                var providerName =
+                    HttpUtility.UrlDecode((string)ctx.providerName);
+
+                var methodName =
+                    HttpUtility.UrlDecode((string)ctx.methodName);
+
+                var method = 
+                    this.interactiveDiagnostics.GetMethod(providerName, methodName);
+
+                if (method == null)
                 {
-                    var providerName =
-                        HttpUtility.UrlDecode((string)ctx.providerName);
+                    return HttpStatusCode.NotFound;
+                }
 
-                    var methodName =
-                        HttpUtility.UrlDecode((string)ctx.methodName);
+                object[] arguments = 
+                    GetArguments(method, this.Request.Query);
 
-                    InteractiveDiagnosticMethod method = this.interactiveDiagnostics.GetMethod(providerName, methodName);
-
-                    if (method == null)
-                    {
-                        return HttpStatusCode.NotFound;
-                    }
-
-                    object[] arguments = this.GetArguments(method, this.Request.Query);
-
-                    return Response.AsJson(new { Result = this.interactiveDiagnostics.ExecuteDiagnostic(method, arguments) });
-                };
+                return Response.AsJson(new { Result = this.interactiveDiagnostics.ExecuteDiagnostic(method, arguments) });
+            };
 
             Get["/templates/{providerName}/{methodName}"] = ctx =>
+            {
+                var providerName =
+                    HttpUtility.UrlDecode((string)ctx.providerName);
+
+                var methodName =
+                    HttpUtility.UrlDecode((string)ctx.methodName);
+
+                var method = 
+                    this.interactiveDiagnostics.GetMethod(providerName, methodName);
+
+                if (method == null)
                 {
-                    var providerName =
-                        HttpUtility.UrlDecode((string)ctx.providerName);
+                    return HttpStatusCode.NotFound;
+                }
 
-                    var methodName =
-                        HttpUtility.UrlDecode((string)ctx.methodName);
+                var template = 
+                    this.interactiveDiagnostics.GetTemplate(method);
 
-                    InteractiveDiagnosticMethod method = this.interactiveDiagnostics.GetMethod(providerName, methodName);
+                if (template == null)
+                {
+                    return HttpStatusCode.NotFound;
+                }
 
-                    if (method == null)
-                    {
-                        return HttpStatusCode.NotFound;
-                    }
-
-                    var template = this.interactiveDiagnostics.GetTemplate(method);
-
-                    if (template == null)
-                    {
-                        return HttpStatusCode.NotFound;
-                    }
-
-                    return template;
-                };
+                return template;
+            };
         }
 
-        private object[] GetArguments(InteractiveDiagnosticMethod method, dynamic query)
+        private static object[] GetArguments(InteractiveDiagnosticMethod method, dynamic query)
         {
             var arguments = new List<object>();
 
             foreach (var argument in method.Arguments)
             {
-                arguments.Add(this.ConvertArgument((string)query[argument.Item1].Value, argument.Item2));
+                arguments.Add(ConvertArgument((string)query[argument.Item1].Value, argument.Item2));
             }
 
             return arguments.ToArray();
         }
 
-        private object ConvertArgument(string value, Type destinationType)
+        private static object ConvertArgument(string value, Type destinationType)
         {
-            var converter = TypeDescriptor.GetConverter(destinationType);
+            var converter = 
+                TypeDescriptor.GetConverter(destinationType);
 
             if (converter == null || !converter.CanConvertFrom(typeof(string)))
             {

--- a/src/Nancy/Diagnostics/Modules/MainModule.cs
+++ b/src/Nancy/Diagnostics/Modules/MainModule.cs
@@ -4,9 +4,15 @@
     {
         public MainModule()
         {
-            Get["/"] = _ => View["Dashboard"];
+            Get["/"] = _ =>
+            {
+                return View["Dashboard"];
+            };
 
-            Post["/"] = _ => Response.AsRedirect("~" + DiagnosticsHook.ControlPanelPrefix);
+            Post["/"] = _ =>
+            {
+                return Response.AsRedirect("~" + DiagnosticsHook.ControlPanelPrefix);
+            };
         }
     }
 }

--- a/src/Nancy/Diagnostics/Modules/SettingsModule.cs
+++ b/src/Nancy/Diagnostics/Modules/SettingsModule.cs
@@ -55,7 +55,8 @@
         {
             var attributes = property
                 .GetCustomAttributes(typeof (DescriptionAttribute), false)
-                .Cast<DescriptionAttribute>();
+                .Cast<DescriptionAttribute>()
+                .ToArray();
 
             return (!attributes.Any()) ? string.Empty : attributes.First().Description;
         }


### PR DESCRIPTION
The `providerName` and `methodName` parameters needed to be url-decoded to ensure it worked at all times
