### PR TITLE
Change IConvention detection

### DIFF
--- a/src/Nancy/Bootstrapper/AppDomainAssemblyTypeScanner.cs
+++ b/src/Nancy/Bootstrapper/AppDomainAssemblyTypeScanner.cs
@@ -162,6 +162,7 @@ namespace Nancy.Bootstrapper
         /// <typeparam name="TType">Type to search for</typeparam>
         /// <param name="excludeInternalTypes">Whether to exclude types inside the core Nancy assembly</param>
         /// <returns>IEnumerable of types</returns>
+        [Obsolete("This method has been replaced by the overload that accepts a ScanMode parameter and will be removed in a subsequent release.")]
         public static IEnumerable<Type> TypesOf<TType>(bool excludeInternalTypes = false)
         {
             var returnTypes = Types.Where(t => typeof(TType).IsAssignableFrom(t));
@@ -172,6 +173,27 @@ namespace Nancy.Bootstrapper
             }
 
             return returnTypes;
+        }
+
+        /// <summary>
+        /// Gets all types implementing a particular interface/base class
+        /// </summary>
+        /// <typeparam name="TType">Type to search for</typeparam>
+        /// <param name="mode">A <see cref="ScanMode"/> value to determin which type set to scan in.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> of types.</returns>
+        public static IEnumerable<Type> TypesOf<TType>(ScanMode mode)
+        {
+            var returnTypes = 
+                Types.Where(t => typeof(TType).IsAssignableFrom(t));
+
+            if (mode == ScanMode.All)
+            {
+                return returnTypes;
+            }
+
+            return (mode == ScanMode.OnlyNancy) ?
+                returnTypes.Where(t => t.Assembly == nancyAssembly) :
+                returnTypes.Where(t => t.Assembly != nancyAssembly);
         }
     }
 

--- a/src/Nancy/Bootstrapper/ScanMode.cs
+++ b/src/Nancy/Bootstrapper/ScanMode.cs
@@ -1,0 +1,23 @@
+﻿namespace Nancy.Bootstrapper
+{
+    /// <summary>
+    /// Determins which set of types that the <see cref="AppDomainAssemblyTypeScanner"/> should scan in.
+    /// </summary>
+    public enum ScanMode
+    {
+        /// <summary>
+        /// All available types.
+        /// </summary>
+        All,
+
+        /// <summary>
+        /// Only in types that are defined in Nancy assemblies.
+        /// </summary>
+        OnlyNancy,
+
+        /// <summary>
+        /// Only types that are defined outside Nancy assemblies.
+        /// </summary>
+        ExcludeNancy
+    }
+}

--- a/src/Nancy/Conventions/NancyConventions.cs
+++ b/src/Nancy/Conventions/NancyConventions.cs
@@ -81,8 +81,11 @@
         /// </summary>
         private void BuildDefaultConventions()
         {
-            this.conventions = AppDomainAssemblyTypeScanner
-                .TypesOf<IConvention>()
+            var defaultConventions =
+                AppDomainAssemblyTypeScanner.TypesOf<IConvention>(ScanMode.OnlyNancy);
+                
+            this.conventions = defaultConventions
+                .Union(AppDomainAssemblyTypeScanner.TypesOf<IConvention>(ScanMode.ExcludeNancy))
                 .Select(t => (IConvention)Activator.CreateInstance(t));
 
             foreach (var convention in this.conventions)

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Bootstrapper\IApplicationStartup.cs" />
     <Compile Include="Bootstrapper\NancyInternalConfiguration.cs" />
     <Compile Include="Bootstrapper\Pipelines.cs" />
+    <Compile Include="Bootstrapper\ScanMode.cs" />
     <Compile Include="Conventions\AcceptHeaderCoercionConventions.cs" />
     <Compile Include="Conventions\BuiltInAcceptHeaderCoercions.cs" />
     <Compile Include="Conventions\DefaultAcceptHeaderCoercionConventions.cs" />


### PR DESCRIPTION
The default conventions are now discovered first, followed by
user conventions. This means that user conventions will always
take precedence.
