### PR TITLE
Remove NDjango from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ Compile, run and enjoy the simple, elegant design!
 * Built from the bottom up, not simply a DSL on top of an existing framework. Removing limitations and feature hacks of an underlying framework, as well as the need to reference more assemblies than you need. _keep it light_
 * Run anywhere. Nancy is not built on any specific hosting technology can be run anywhere. Out of the box, Nancy supports running on ASP.NET/IIS, WCF, Self-hosting and any [OWIN](http://owin.org)
 * Ultra lightweight action declarations for GET, HEAD, PUT, POST, DELETE, OPTIONS and PATCH requests
-* View engine integration (Razor, Spark, NDjango, dotLiquid and our own SuperSimpleViewEngine)
+* View engine integration (Razor, Spark, dotLiquid, and our own SuperSimpleViewEngine)
 * Powerful request path matching that includes advanced parameter capabilities. The path matching strategy can be replaced with custom implementations to fit your exact needs
 * Easy response syntax, enabling you to return things like int, string, HttpStatusCode and Action<Stream> elements without having to explicitly cast or wrap your response - you just return it and Nancy _will_ do the work for you
 * A powerful, light-weight, testing framework to help you verify the behavior of your application


### PR DESCRIPTION
The NDjango view engine is no longer supported as far as i know.
