### PR TITLE
Updated version of Spark dependency

### DIFF
--- a/src/Nancy.ViewEngines.Spark/nancy.viewengines.spark.nuspec
+++ b/src/Nancy.ViewEngines.Spark/nancy.viewengines.spark.nuspec
@@ -14,7 +14,7 @@
     <projectUrl>http://nancyfx.org</projectUrl>
     <dependencies>
       <dependency id="Nancy" />
-      <dependency id="Spark" version="1.5.1" />
+      <dependency id="Spark" version="1.7.0.0" />
     </dependencies> 
     <tags>Nancy Viewengine Spark</tags>
   </metadata>


### PR DESCRIPTION
There is a version issue with Spark. It expects 1.7.0.0 but the nuget version is 1.5.1.6. Hopefully this resolves it
