### PR TITLE
Added support for Context in SSVE

### DIFF
--- a/src/Nancy.Demo.SuperSimpleViewEngine/MainModule.cs
+++ b/src/Nancy.Demo.SuperSimpleViewEngine/MainModule.cs
@@ -11,6 +11,8 @@ namespace Nancy.Demo.SuperSimpleViewEngine
         {
             Get["/"] = (x) =>
                 {
+                    
+
                     var model = new MainModel(
                         "Jimbo", 
                         new[] { new User("Bob", "Smith"), new User("Jimbo", "Jones"), new User("Bill", "Bobs"), },

--- a/src/Nancy.Demo.SuperSimpleViewEngine/Nancy.Demo.SuperSimpleViewEngine.csproj
+++ b/src/Nancy.Demo.SuperSimpleViewEngine/Nancy.Demo.SuperSimpleViewEngine.csproj
@@ -20,6 +20,10 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <OldToolsVersion>4.0</OldToolsVersion>
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Nancy.Demo.SuperSimpleViewEngine/Views/Index.sshtml
+++ b/src/Nancy.Demo.SuperSimpleViewEngine/Views/Index.sshtml
@@ -15,4 +15,8 @@
 	<h3>Encoding</h3>
 	<p>Model output can also be encoded:</p>
 	<p>@!Model.NaughtyStuff</p>
+	<p>
+		<h2>The context stuff</h2>
+		The requested path: @Context.Request.Path
+	</p>
 @EndSection

--- a/src/Nancy.Tests/Fakes/FakeViewEngineHost.cs
+++ b/src/Nancy.Tests/Fakes/FakeViewEngineHost.cs
@@ -9,6 +9,11 @@ namespace Nancy.Tests.Fakes
         public Func<string, object, string> GetTemplateCallback { get; set; }
         public Func<string, string> ExpandPathCallBack { get; set; }
 
+        public FakeViewEngineHost()
+        {
+            this.Context = new FakeContext {Name = "Frank" };
+        }
+
         /// <summary>
         /// Html "safe" encode a string
         /// </summary>
@@ -21,6 +26,29 @@ namespace Nancy.Tests.Fakes
                 Replace(">", "&gt;").
                 Replace("\"", "&quot;");
         }
+
+        private class FakeContext
+        {
+            public FakeContext()
+            {
+                this.User = new FakeUser { Username = "Frank123" };
+            }
+
+            public string Name { get; set; }
+
+            public FakeUser User { get; set; }
+
+            public class FakeUser
+            {
+                public string Username { get; set; }
+            }
+        }
+
+        /// <summary>
+        /// Context object of the host application.
+        /// </summary>
+        /// <value>An instance of the context object from the host.</value>
+        public object Context { get; set; }
 
         /// <summary>
         /// Get the contenst of a template

--- a/src/Nancy/ViewEngines/SuperSimpleViewEngine/IViewEngineHost.cs
+++ b/src/Nancy/ViewEngines/SuperSimpleViewEngine/IViewEngineHost.cs
@@ -7,6 +7,12 @@ namespace Nancy.ViewEngines.SuperSimpleViewEngine
     public interface IViewEngineHost
     {
         /// <summary>
+        /// Context object of the host application.
+        /// </summary>
+        /// <value>An instance of the context object from the host.</value>
+        object Context { get; }
+
+        /// <summary>
         /// Html "safe" encode a string
         /// </summary>
         /// <param name="input">Input string</param>

--- a/src/Nancy/ViewEngines/SuperSimpleViewEngine/NancyViewEngineHost.cs
+++ b/src/Nancy/ViewEngines/SuperSimpleViewEngine/NancyViewEngineHost.cs
@@ -15,7 +15,14 @@ namespace Nancy.ViewEngines.SuperSimpleViewEngine
         public NancyViewEngineHost(IRenderContext renderContext)
         {
             this.renderContext = renderContext;
+            this.Context = this.renderContext.Context;
         }
+
+        /// <summary>
+        /// Context object of the host application.
+        /// </summary>
+        /// <value>An instance of the context object from the host.</value>
+        public object Context { get; private set; }
 
         /// <summary>
         /// Html "safe" encode a string


### PR DESCRIPTION
You can now access the context by using @Context and it works the
same way as @Model. In addition the conditional @If and @IfNot
as well as the @Each operator now supports that you deine the
model source using

  @If.Model...
  @IfNot.Model...
  @If.Context...
  @IfNot.Context...
  @Each.Model...
  @Each.Context...

If the model source is not included it will default to use the model
as the source.
