### PR TITLE
Added support for application/json-patch content type

### DIFF
--- a/src/Nancy/Json/Json.cs
+++ b/src/Nancy/Json/Json.cs
@@ -118,6 +118,7 @@ namespace Nancy.Json
             var contentMimeType = contentType.Split(';')[0];
 
             return contentMimeType.Equals("application/json", StringComparison.InvariantCultureIgnoreCase) ||
+                   contentMimeType.StartsWith("application/json-", StringComparison.InvariantCultureIgnoreCase) ||
                    contentMimeType.Equals("text/json", StringComparison.InvariantCultureIgnoreCase) ||
                   (contentMimeType.StartsWith("application/vnd", StringComparison.InvariantCultureIgnoreCase) &&
                    contentMimeType.EndsWith("+json", StringComparison.InvariantCultureIgnoreCase));

--- a/src/Nancy/Responses/DefaultJsonSerializer.cs
+++ b/src/Nancy/Responses/DefaultJsonSerializer.cs
@@ -67,6 +67,7 @@
             var contentMimeType = contentType.Split(';')[0];
 
             return contentMimeType.Equals("application/json", StringComparison.InvariantCultureIgnoreCase) ||
+                   contentMimeType.StartsWith("application/json-", StringComparison.InvariantCultureIgnoreCase) ||
                    contentMimeType.Equals("text/json", StringComparison.InvariantCultureIgnoreCase) ||
                   (contentMimeType.StartsWith("application/vnd", StringComparison.InvariantCultureIgnoreCase) &&
                    contentMimeType.EndsWith("+json", StringComparison.InvariantCultureIgnoreCase));


### PR DESCRIPTION
Added support for application/json-patch (or application/json-*) to default JSON serializer and body deserializer.
IETF draft spec is at http://tools.ietf.org/html//draft-ietf-appsawg-json-patch-07
Nancy forum discussion here: https://groups.google.com/forum/#!topic/nancy-web-framework/5q2DmaOVlc0/discussion

JSON Patch is a JSON-based format specifically designed for PATCHing JSON documents. Its media type is "application/json-patch", which Nancy does not realize it can parse.
