### PR TITLE
Changed discovery of ISerializer

### DIFF
--- a/src/Nancy/Bootstrapper/NancyInternalConfiguration.cs
+++ b/src/Nancy/Bootstrapper/NancyInternalConfiguration.cs
@@ -79,7 +79,7 @@ namespace Nancy.Bootstrapper
                         StatusCodeHandlers = new List<Type>(new[] { typeof(DefaultStatusCodeHandler) }.Concat(AppDomainAssemblyTypeScanner.TypesOf<IStatusCodeHandler>(true))),
                         CsrfTokenValidator = typeof(DefaultCsrfTokenValidator),
                         ObjectSerializer = typeof(DefaultObjectSerializer),
-                        Serializers = new List<Type>(new[] { typeof(DefaultJsonSerializer), typeof(DefaultXmlSerializer) }),
+                        Serializers = AppDomainAssemblyTypeScanner.TypesOf<ISerializer>(ScanMode.ExcludeNancy).Union(new List<Type>(new[] { typeof(DefaultJsonSerializer), typeof(DefaultXmlSerializer) })).ToList(),
                         InteractiveDiagnosticProviders = new List<Type>(AppDomainAssemblyTypeScanner.TypesOf<IDiagnosticsProvider>()),
                         RequestTracing = typeof(DefaultRequestTracing),
                         RouteInvoker = typeof(DefaultRouteInvoker),


### PR DESCRIPTION
Modified the discovery so it uses the AppDomainAssemblyTypeScanner
to locate all ISerializer types, that are not Nancy-types, and
then unions that with the default json- and xml serializers
