### PR TITLE
Adding less extension to MimeTypes.cs

### DIFF
--- a/src/Nancy/MimeTypes.cs
+++ b/src/Nancy/MimeTypes.cs
@@ -220,7 +220,7 @@ namespace Nancy
 			mimeTypes.Add ("la", "audio/nspaudio");
 			mimeTypes.Add ("lam", "audio/x-liveaudio");
 			mimeTypes.Add ("latex", "application/x-latex");
-            mimeTypes.Add ("less", "text/css");
+			mimeTypes.Add ("less", "text/css");
 			mimeTypes.Add ("list", "text/plain");
 			mimeTypes.Add ("lma", "audio/nspaudio");
 			mimeTypes.Add ("log", "text/plain");


### PR DESCRIPTION
I want to use less.js in development of a new site and currently *.less
files are being returned as 'application/octet-stream' they should be
reutrned as 'text/css'.
