### PR TITLE
Local url validation and forms auth fix to fix #893

### DIFF
--- a/src/Nancy.Authentication.Forms/FormsAuthentication.cs
+++ b/src/Nancy.Authentication.Forms/FormsAuthentication.cs
@@ -73,14 +73,30 @@ namespace Nancy.Authentication.Forms
         /// <param name="cookieExpiry">Optional expiry date for the cookie (for 'Remember me')</param>
         /// <param name="fallbackRedirectUrl">Url to redirect to if none in the querystring</param>
         /// <returns>Nancy response with redirect.</returns>
-        public static Response UserLoggedInRedirectResponse(NancyContext context, Guid userIdentifier, DateTime? cookieExpiry = null, string fallbackRedirectUrl = "/")
+        public static Response UserLoggedInRedirectResponse(NancyContext context, Guid userIdentifier, DateTime? cookieExpiry = null, string fallbackRedirectUrl = null)
         {
             var redirectUrl = fallbackRedirectUrl;
+
+            if (string.IsNullOrEmpty(redirectUrl))
+            {
+                redirectUrl = context.Request.Url.BasePath;
+            }
+
+            if (string.IsNullOrEmpty(redirectUrl))
+            {
+                redirectUrl = "/";
+            }
+
             string redirectQuerystringKey = GetRedirectQuerystringKey(currentConfiguration);
 
             if (context.Request.Query[redirectQuerystringKey].HasValue)
             {
-                redirectUrl = context.Request.Query[redirectQuerystringKey];
+                var queryUrl = (string)context.Request.Query[redirectQuerystringKey];
+
+                if (context.IsLocalUrl(queryUrl))
+                {
+                    redirectUrl = queryUrl;
+                }
             }
 
             var response = context.GetRedirect(redirectUrl);

--- a/src/Nancy.Tests/Unit/Extensions/ContextExtensionsFixture.cs
+++ b/src/Nancy.Tests/Unit/Extensions/ContextExtensionsFixture.cs
@@ -103,5 +103,53 @@
             result.ShouldEqual("/scripts/test.js");
         }
 
+        [Fact]
+        public void Should_report_simple_relative_path_as_local()
+        {
+            var context = this.CreateContext();
+
+            var result = context.IsLocalUrl("/stuff");
+
+            result.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Should_report_same_host_absolute_url_as_local()
+        {
+            var context = this.CreateContext();
+
+            var result = context.IsLocalUrl("http://test.com/someotherpath");
+
+            result.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Should_report_empty_string_as_nonlocal()
+        {
+            var context = this.CreateContext();
+
+            var result = context.IsLocalUrl("");
+
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_report_different_host_absolute_url_as_nonlocal()
+        {
+            var context = this.CreateContext();
+
+            var result = context.IsLocalUrl("http://anothertest.com/someotherpath");
+
+            result.ShouldBeFalse();
+        }
+
+        private NancyContext CreateContext(Url url = null)
+        {
+            var request = new Request(
+                "GET",
+                url ?? new Url() { Scheme = "http", BasePath = "testing", HostName = "test.com", Path = "test" });
+
+            return new NancyContext() { Request = request };
+        }
     }
 }

--- a/src/Nancy/Extensions/ContextExtensions.cs
+++ b/src/Nancy/Extensions/ContextExtensions.cs
@@ -85,5 +85,33 @@ namespace Nancy.Extensions
         {
             context.Trace.TraceLog.WriteLog(logDelegate);
         }
+
+        /// <summary>
+        /// Returns a boolean indicating whether a given url string is local or not
+        /// </summary>
+        /// <param name="context">Nancy context</param>
+        /// <param name="url">Url string (relative or absolute)</param>
+        /// <returns>True if local, false otherwise</returns>
+        public static bool IsLocalUrl(this NancyContext context, string url)
+        {
+            if (string.IsNullOrEmpty(url))
+            {
+                return false;
+            }
+
+            Uri uri;
+
+            if (Uri.TryCreate(url, UriKind.Relative, out uri))
+            {
+                return true;
+            }
+
+            if (!Uri.TryCreate(url, UriKind.Absolute, out uri))
+            {
+                return false;
+            }
+
+            return string.Equals(uri.Host, context.Request.Url.HostName, StringComparison.OrdinalIgnoreCase);
+        }
     }
 }


### PR DESCRIPTION
Added a new extension method on context to validate whether a url
path is local to the current request.

Plumbed in the new method to forms auth so it only redirects to
to a querystring url if it's local.
