### PR TITLE
Updated and added PathCulture convention

### DIFF
--- a/src/Nancy.Tests/Unit/Culture/BuiltInCultureConventionFixture.cs
+++ b/src/Nancy.Tests/Unit/Culture/BuiltInCultureConventionFixture.cs
@@ -86,6 +86,21 @@
             culture.Name.ShouldEqual(expected);
         }
 
+        [Theory]
+        [InlineData("/en-GB", "/")]
+        [InlineData("/en-GB/product", "/product")]
+        public void Should_culture_of_request_path_if_first_path_parameter_valid_culture(string path, string expectedPath)
+        {
+            //Given
+            var context = CreateContextRequest(path);
+
+            //When
+            var culture = BuiltInCultureConventions.PathCulture(context);
+
+            //Then
+            context.Request.Url.Path.ShouldEqual(expectedPath);
+        }
+
         [Fact]
         public void Should_return_null_if_headers_not_populated()
         {

--- a/src/Nancy/Conventions/BuiltInCultureConventions.cs
+++ b/src/Nancy/Conventions/BuiltInCultureConventions.cs
@@ -41,11 +41,18 @@
         /// <returns>CultureInfo if found in Path otherwise null</returns>
         public static CultureInfo PathCulture(NancyContext context)
         {
-            var firstParameter = context.Request.Url.Path.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+            var segments = 
+                context.Request.Url.Path.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
 
-            if (firstParameter != null && IsValidCultureInfoName(firstParameter))
+            var firstSegment =
+                segments.FirstOrDefault();
+
+            if (firstSegment != null && IsValidCultureInfoName(firstSegment))
             {
-                return new CultureInfo(firstParameter);
+                context.Request.Url.Path = 
+                    string.Concat("/", string.Join("/", segments.Skip(1)));
+
+                return new CultureInfo(firstSegment);
             }
 
             return null;

--- a/src/Nancy/Conventions/DefaultCultureConventions.cs
+++ b/src/Nancy/Conventions/DefaultCultureConventions.cs
@@ -45,6 +45,7 @@
             conventions.CultureConventions = new List<Func<NancyContext, CultureInfo>>(6)
             {
                 BuiltInCultureConventions.FormCulture,
+                BuiltInCultureConventions.PathCulture,
                 BuiltInCultureConventions.HeaderCulture,
                 BuiltInCultureConventions.SessionCulture,
                 BuiltInCultureConventions.CookieCulture,


### PR DESCRIPTION
The convention will now strip the culture from the URL, if it
was a valid culture, before passing it along for route matching
