### PR TITLE
Fixed #908

### DIFF
--- a/src/Nancy.Tests.Functional/Tests/ContentNegotiationFixture.cs
+++ b/src/Nancy.Tests.Functional/Tests/ContentNegotiationFixture.cs
@@ -335,7 +335,7 @@ namespace Nancy.Tests.Functional.Tests
         }
 
         [Fact]
-        public void Should_add_vary_accept_header_when_multiple_accept_headers_can_be_satisfied()
+        public void Should_add_vary_accept_header()
         {
             // Given
             var browser = new Browser(with =>
@@ -349,10 +349,11 @@ namespace Nancy.Tests.Functional.Tests
             });
 
             // When
-            var response = browser.Get("/");
+            var response = browser.Get("/", with => with.Header("Accept", "application/json"));
 
             // Then
             Assert.True(response.Headers.ContainsKey("Vary"));
+            Assert.True(response.Headers["Vary"].Contains("Accept"));
         }
 
         [Fact]

--- a/src/Nancy/Routing/DefaultRouteInvoker.cs
+++ b/src/Nancy/Routing/DefaultRouteInvoker.cs
@@ -21,7 +21,7 @@ namespace Nancy.Routing
         public DefaultRouteInvoker(IEnumerable<IResponseProcessor> processors, AcceptHeaderCoercionConventions coercionConventions)
         {
             this.processors = processors;
-            this.coercionConventions = coercionConventions; 
+            this.coercionConventions = coercionConventions;
         }
 
         /// <summary>
@@ -160,10 +160,7 @@ namespace Nancy.Routing
                 response = new NotAcceptableResponse();
             }
 
-            if (compatibleHeaders.Count() > 1)
-            {
-                response.WithHeader("Vary", "Accept");
-            }
+            response.WithHeader("Vary", "Accept");
 
             AddLinkHeaders(context, compatibleHeaders, response);
 
@@ -207,7 +204,7 @@ namespace Nancy.Routing
                 return;
             }
 
-            var baseUrl = 
+            var baseUrl =
                 context.Request.Url.BasePath + "/" + Path.GetFileNameWithoutExtension(context.Request.Url.Path);
 
             var links = linkProcessors


### PR DESCRIPTION
Accept header now always set if we go through negotiation. Initially
considered only setting it if the negotiator could match more than
one type (either by having a wildcard or multiple entries), but there's
still a chance that a processor may match in some weird and wonderful
way behind the scenes so seems sensible to always add it if we have
negotiated the response.
