### PR TITLE
Settings on Diagnostic page -> Settings not working

### DIFF
--- a/src/Nancy/Diagnostics/Views/Settings.sshtml
+++ b/src/Nancy/Diagnostics/Views/Settings.sshtml
@@ -30,7 +30,6 @@
 		$("input[type='checkbox']").click(function() {
 		
 			$.ajax({
-				  url: "/settings/",
 				  type: "POST",
 				  data: {Name: $(this).val(), Value:$(this).is(':checked') },
 				  dataType: "json",


### PR DESCRIPTION
Existing URL was faulty. Not specifying it, makes sure the AJAX requests
POSTs to the current window.location.
