### PR TITLE
updated exception message to include types that were duplicated

### DIFF
--- a/src/Nancy/TinyIoc/TinyIoC.cs
+++ b/src/Nancy/TinyIoc/TinyIoC.cs
@@ -1164,7 +1164,7 @@ namespace Nancy.TinyIoc
                                              where j.Count() > 1
                                              select j.Key.FullName;
 
-                var fullNamesOfDuplicatedTypes = string.Join(",\n", queryForDuplicatedTypes);
+                var fullNamesOfDuplicatedTypes = string.Join(",\n", queryForDuplicatedTypes.ToArray());
 
                 throw new ArgumentException("types: The same implementation type cannot be specificed multiple times\n\n" + fullNamesOfDuplicatedTypes);
             }


### PR DESCRIPTION
Apparently Phil Jones had this error also, but if a type is duplicated when it shouldn't be then the exception:

> types: The same implementation type cannot be specificed multiple times

Is thrown, and it's impossible to know what the problem is. 

I updated the error to include the types:

![tinyioc](https://f.cloud.github.com/assets/895629/80849/14ecd33c-62b7-11e2-97f0-47eb476a2e30.png)

So it will show you all types that have been duplicated so you can fix them. 
