### PR TITLE
show error message when view cannot be rendered

### DIFF
--- a/src/Nancy.ViewEngines.Razor.Tests/RazorViewEngineFixture.cs
+++ b/src/Nancy.ViewEngines.Razor.Tests/RazorViewEngineFixture.cs
@@ -1,16 +1,16 @@
 ﻿namespace Nancy.ViewEngines.Razor.Tests
 {
+    using FakeItEasy;
+    using Nancy.Localization;
+    using Nancy.Tests;
+    using Nancy.ViewEngines.Razor.Tests.Models;
     using System;
     using System.Dynamic;
     using System.IO;
     using System.Linq;
     using System.Text;
-    using FakeItEasy;
-    using Xunit;
-    using Nancy.Tests;
-    using Nancy.ViewEngines.Razor.Tests.Models;
     using System.Threading;
-    using Nancy.Localization;
+    using Xunit;
 
     public class RazorViewEngineFixture
     {
@@ -472,6 +472,28 @@
             // Then
             var output = ReadAll(stream).Trim();
             output.ShouldEqual("<h1>Hi, Nancy!</h1>");
+        }
+
+        [Fact]
+        public void Should_tell_view_name_when_loading_missing_view()
+        {
+            bool threwException = false;
+            try
+            {
+                var result = new ViewLocationResult("MyPath", "NonExistingView", "cshtml", () => new StringReader(string.Empty));
+                var response = engine.RenderView(result, null, renderContext);
+
+                Stream stream = new MemoryStream();
+                response.Contents.Invoke(stream);
+            }
+            catch (Exception e)
+            {
+                threwException = true;
+                Assert.IsType<ViewRenderException>(e);
+                Assert.Equal("Could not render MyPath/NonExistingView.cshtml", e.Message);
+            }
+
+            Assert.True(threwException);
         }
 
         [Fact(Skip = "Multi-threading regression test")]

--- a/src/Nancy.ViewEngines.Razor/NancyRazorViewBase.cs
+++ b/src/Nancy.ViewEngines.Razor/NancyRazorViewBase.cs
@@ -1,11 +1,11 @@
 ﻿namespace Nancy.ViewEngines.Razor
 {
+    using Nancy.Helpers;
     using System;
     using System.Collections.Generic;
     using System.Globalization;
     using System.IO;
     using System.Text;
-    using Nancy.Helpers;
 
     /// <summary>
     /// Base class for nancy razor views.
@@ -240,7 +240,8 @@
             }
             catch (NullReferenceException)
             {
-                throw new ViewRenderException("Unable to render the view.  Most likely the Model, or a property on the Model, is null");
+                throw new ViewRenderException(
+                    "Unable to render the view. This may be because the Model, or a property on the Model, is null, or the path to the view is incorrect.");
             }
 
             this.Body = this.contents.ToString();

--- a/src/Nancy.ViewEngines.Razor/RazorViewEngine.cs
+++ b/src/Nancy.ViewEngines.Razor/RazorViewEngine.cs
@@ -1,5 +1,8 @@
 ﻿namespace Nancy.ViewEngines.Razor
 {
+    using Nancy.Bootstrapper;
+    using Nancy.Localization;
+    using Nancy.Responses;
     using System;
     using System.CodeDom;
     using System.CodeDom.Compiler;
@@ -9,9 +12,6 @@
     using System.Reflection;
     using System.Web.Razor;
     using System.Web.Razor.Parser.SyntaxTree;
-    using Nancy.Bootstrapper;
-    using Nancy.Responses;
-    using Nancy.Localization;
 
     /// <summary>
     /// View engine for rendering razor views.
@@ -345,8 +345,13 @@
 
             var view = viewFactory.Invoke();
 
+            if (string.IsNullOrWhiteSpace(view.Path))
+            {
+                throw new ViewRenderException(string.Format("Could not render {0}/{1}.{2}", viewLocationResult.Location, viewLocationResult.Name, viewLocationResult.Extension));
+            }
+
             view.Text = new TextResourceFinder(this.textResource, renderContext.Context);
-            
+
             view.Code = string.Empty;
 
             return view;


### PR DESCRIPTION
When View cannot be found, a message saying the model is probably null is shown.
This pull request tries to show a more friendly exception. Saying path/view.extension could not be rendered
