### PR TITLE
Fix "Boostrapper" typos

### DIFF
--- a/src/Nancy.Hosting.Self/NancyHost.cs
+++ b/src/Nancy.Hosting.Self/NancyHost.cs
@@ -50,7 +50,7 @@
         /// the provided <paramref name="bootstrapper"/>.
         /// Uses the default configuration
         /// </summary>
-        /// <param name="bootstrapper">The boostrapper that should be used to handle the request.</param>
+        /// <param name="bootstrapper">The bootstrapper that should be used to handle the request.</param>
         /// <param name="baseUris">The <see cref="Uri"/>s that the host will listen to.</param>
         public NancyHost(INancyBootstrapper bootstrapper, params Uri[] baseUris)
             : this(bootstrapper, new HostConfiguration(), baseUris)
@@ -62,7 +62,7 @@
         /// the provided <paramref name="bootstrapper"/>.
         /// Uses the specified configuration.
         /// </summary>
-        /// <param name="bootstrapper">The boostrapper that should be used to handle the request.</param>
+        /// <param name="bootstrapper">The bootstrapper that should be used to handle the request.</param>
         /// <param name="configuration">Configuration to use</param>
         /// <param name="baseUris">The <see cref="Uri"/>s that the host will listen to.</param>
         public NancyHost(INancyBootstrapper bootstrapper, HostConfiguration configuration, params Uri[] baseUris)
@@ -81,7 +81,7 @@
         /// Uses the default configuration
         /// </summary>
         /// <param name="baseUri">The <see cref="Uri"/> that the host will listen to.</param>
-        /// <param name="bootstrapper">The boostrapper that should be used to handle the request.</param>
+        /// <param name="bootstrapper">The bootstrapper that should be used to handle the request.</param>
         public NancyHost(Uri baseUri, INancyBootstrapper bootstrapper)
             : this(bootstrapper, new HostConfiguration(), baseUri)
         {
@@ -93,7 +93,7 @@
         /// Uses the specified configuration.
         /// </summary>
         /// <param name="baseUri">The <see cref="Uri"/> that the host will listen to.</param>
-        /// <param name="bootstrapper">The boostrapper that should be used to handle the request.</param>
+        /// <param name="bootstrapper">The bootstrapper that should be used to handle the request.</param>
         /// <param name="configuration">Configuration to use</param>
         public NancyHost(Uri baseUri, INancyBootstrapper bootstrapper, HostConfiguration configuration)
             : this (bootstrapper, configuration, baseUri)

--- a/src/Nancy.Testing.Tests/ConfigurableBootstrapperFixture.cs
+++ b/src/Nancy.Testing.Tests/ConfigurableBootstrapperFixture.cs
@@ -91,7 +91,7 @@
         {
             // Given
             var availableMembers =
-                typeof(ConfigurableBootstrapper.ConfigurableBoostrapperConfigurator)
+                typeof(ConfigurableBootstrapper.ConfigurableBootstrapperConfigurator)
                 .GetMethods(BindingFlags.Public | BindingFlags.Instance)
                 .Select(x => x.Name)
                 .Distinct();

--- a/src/Nancy.Testing/Browser.cs
+++ b/src/Nancy.Testing/Browser.cs
@@ -24,7 +24,7 @@ namespace Nancy.Testing
         /// provided <see cref="ConfigurableBootstrapper"/> configuration.
         /// </summary>
         /// <param name="action">The <see cref="ConfigurableBootstrapper"/> configuration that should be used by the bootstrapper.</param>
-        public Browser(Action<ConfigurableBootstrapper.ConfigurableBoostrapperConfigurator> action)
+        public Browser(Action<ConfigurableBootstrapper.ConfigurableBootstrapperConfigurator> action)
             : this(new ConfigurableBootstrapper(action))
         {
         }

--- a/src/Nancy.Testing/ConfigurableBootstrapper.cs
+++ b/src/Nancy.Testing/ConfigurableBootstrapper.cs
@@ -20,7 +20,7 @@ namespace Nancy.Testing
     using Nancy.Validation;
 
     /// <summary>
-    /// A Nancy boostrapper that can be configured with either Type or Instance overrides for all Nancy types.
+    /// A Nancy bootstrapper that can be configured with either Type or Instance overrides for all Nancy types.
     /// </summary>
     public class ConfigurableBootstrapper : NancyBootstrapperWithRequestContainerBase<TinyIoCContainer>, IPipelines, INancyModuleCatalog
     {
@@ -52,7 +52,7 @@ namespace Nancy.Testing
         /// Initializes a new instance of the <see cref="ConfigurableBootstrapper"/> class.
         /// </summary>
         /// <param name="configuration">The configuration that should be used by the bootstrapper.</param>
-        public ConfigurableBootstrapper(Action<ConfigurableBoostrapperConfigurator> configuration)
+        public ConfigurableBootstrapper(Action<ConfigurableBootstrapperConfigurator> configuration)
         {
             this.catalog = new ConfigurableModuleCatalog();
             this.configuration = NancyInternalConfiguration.Default;
@@ -69,7 +69,7 @@ namespace Nancy.Testing
             if (configuration != null)
             {
                 var configurator =
-                    new ConfigurableBoostrapperConfigurator(this);
+                    new ConfigurableBootstrapperConfigurator(this);
 
                 configurator.StatusCodeHandler<PassThroughStatusCodeHandler>();
                 configuration.Invoke(configurator);
@@ -527,21 +527,21 @@ namespace Nancy.Testing
         /// <summary>
         /// Provides an API for configuring a <see cref="ConfigurableBootstrapper"/> instance.
         /// </summary>
-        public class ConfigurableBoostrapperConfigurator
+        public class ConfigurableBootstrapperConfigurator
         {
             private readonly ConfigurableBootstrapper bootstrapper;
 
             /// <summary>
-            /// Initializes a new instance of the <see cref="ConfigurableBoostrapperConfigurator"/> class.
+            /// Initializes a new instance of the <see cref="ConfigurableBootstrapperConfigurator"/> class.
             /// </summary>
             /// <param name="bootstrapper">The bootstrapper that should be configured.</param>
-            public ConfigurableBoostrapperConfigurator(ConfigurableBootstrapper bootstrapper)
+            public ConfigurableBootstrapperConfigurator(ConfigurableBootstrapper bootstrapper)
             {
                 this.bootstrapper = bootstrapper;
                 this.Diagnostics<DisabledDiagnostics>();
             }
 
-            public ConfigurableBoostrapperConfigurator Binder(IBinder binder)
+            public ConfigurableBootstrapperConfigurator Binder(IBinder binder)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IBinder), binder));
@@ -549,7 +549,7 @@ namespace Nancy.Testing
                 return this;
             }
 
-            public ConfigurableBoostrapperConfigurator Assembly(string pattern)
+            public ConfigurableBootstrapperConfigurator Assembly(string pattern)
             {
                 AppDomainAssemblyTypeScanner.LoadAssemblies(AppDomain.CurrentDomain.BaseDirectory, pattern);
                 return this;
@@ -559,8 +559,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IBinder"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IBinder"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator Binder<T>() where T : IBinder
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator Binder<T>() where T : IBinder
             {
                 this.bootstrapper.configuration.Binder = typeof(T);
                 return this;
@@ -570,8 +570,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="INancyContextFactory"/>.
             /// </summary>
             /// <param name="contextFactory">The <see cref="INancyContextFactory"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ContextFactory(INancyContextFactory contextFactory)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ContextFactory(INancyContextFactory contextFactory)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(INancyContextFactory), contextFactory));
@@ -583,8 +583,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="INancyContextFactory"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="INancyContextFactory"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ContextFactory<T>() where T : INancyContextFactory
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ContextFactory<T>() where T : INancyContextFactory
             {
                 this.bootstrapper.configuration.ContextFactory = typeof(T);
                 return this;
@@ -594,8 +594,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided type as a dependency.
             /// </summary>
             /// <param name="type">The type of the dependency that should be used registered with the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator Dependency<T>(Type type)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator Dependency<T>(Type type)
             {
                 this.bootstrapper.registeredTypes.Add(new TypeRegistration(typeof(T), type));
 
@@ -606,9 +606,9 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to register the specified type as a dependency.
             /// </summary>
             /// <typeparam name="T">The type of the dependency that should be registered with the bootstrapper.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
             /// <remarks>This method will register the type for all the interfaces it implements and the type itself.</remarks>
-            public ConfigurableBoostrapperConfigurator Dependency<T>()
+            public ConfigurableBootstrapperConfigurator Dependency<T>()
             {
                 this.bootstrapper.registeredTypes.Add(new TypeRegistration(typeof(T), typeof(T)));
 
@@ -624,9 +624,9 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance as a dependency.
             /// </summary>
             /// <param name="instance">The dependency instance that should be used registered with the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
             /// <remarks>This method will register the instance for all the interfaces it implements and the type itself.</remarks>
-            public ConfigurableBoostrapperConfigurator Dependency(object instance)
+            public ConfigurableBootstrapperConfigurator Dependency(object instance)
             {
                 this.bootstrapper.registeredInstances.Add(new InstanceRegistration(instance.GetType(), instance));
 
@@ -642,8 +642,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to register the specified type as a dependency.
             /// </summary>
             /// <typeparam name="T">The type that the dependencies should be registered as.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator Dependency<T>(object instance)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator Dependency<T>(object instance)
             {
                 this.bootstrapper.registeredInstances.Add(new InstanceRegistration(typeof(T), instance));
                 return this;
@@ -653,8 +653,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to register the specified instances as a dependencies.
             /// </summary>
             /// <param name="dependencies">The instances of the dependencies that should be registered with the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator Dependencies(params object[] dependencies) 
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator Dependencies(params object[] dependencies) 
             {
                 foreach (var dependency in dependencies)
                 {
@@ -668,8 +668,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to register the specified types and instances as a dependencies.
             /// </summary>
             /// <param name="dependencies">An array of maps between the interfaces and instances that should be registered with the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator MappedDependencies<T, K>(IEnumerable<Tuple<T, K>> dependencies) 
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator MappedDependencies<T, K>(IEnumerable<Tuple<T, K>> dependencies) 
                 where T : Type
                 where K: class 
             {
@@ -687,8 +687,8 @@ namespace Nancy.Testing
             /// </summary>
             /// <param name="dependencies">The instances of the dependencies that should be registered with the bootstrapper.</param>
             /// <typeparam name="T">The type that the dependencies should be registered as.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator Dependencies<T>(params object[] dependencies)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator Dependencies<T>(params object[] dependencies)
             {
                 foreach (var dependency in dependencies)
                 {
@@ -702,9 +702,9 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided types as a dependency.
             /// </summary>
             /// <param name="dependencies">The types that should be used registered as dependencies with the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
             /// <remarks>This method will register the types for all the interfaces they implement and the types themselves.</remarks>
-            public ConfigurableBoostrapperConfigurator Dependencies(params Type[] dependencies)
+            public ConfigurableBootstrapperConfigurator Dependencies(params Type[] dependencies)
             {
                 foreach (var dependency in dependencies)
                 {
@@ -720,8 +720,8 @@ namespace Nancy.Testing
             /// </summary>
             /// <param name="dependencies">The types that should be used registered as dependencies with the bootstrapper.</param>
             /// <typeparam name="T">The type that the dependencies should be registered as.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator Dependencies<T>(params Type[] dependencies)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator Dependencies<T>(params Type[] dependencies)
             {
                 foreach (var dependency in dependencies)
                 {
@@ -734,8 +734,8 @@ namespace Nancy.Testing
             /// <summary>
             /// Disables the auto registration behavior of the bootstrapper
             /// </summary>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator EnableAutoRegistration()
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator EnableAutoRegistration()
             {
                 this.bootstrapper.enableAutoRegistration = true;
                 return this;
@@ -745,8 +745,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IStatusCodeHandler"/>.
             /// </summary>
             /// <param name="statusCodeHandlers">The <see cref="IStatusCodeHandler"/> types that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator StatusCodeHandlers(params Type[] statusCodeHandlers)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator StatusCodeHandlers(params Type[] statusCodeHandlers)
             {
                 this.bootstrapper.configuration.StatusCodeHandlers = new List<Type>(statusCodeHandlers);
 
@@ -757,8 +757,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IStatusCodeHandler"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IStatusCodeHandler"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator StatusCodeHandler<T>() where T : IStatusCodeHandler
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator StatusCodeHandler<T>() where T : IStatusCodeHandler
             {
                 this.bootstrapper.configuration.StatusCodeHandlers = new List<Type>(new[] { typeof(T) });
                 return this;
@@ -768,8 +768,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IFieldNameConverter"/>.
             /// </summary>
             /// <param name="fieldNameConverter">The <see cref="IFieldNameConverter"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator FieldNameConverter(IFieldNameConverter fieldNameConverter)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator FieldNameConverter(IFieldNameConverter fieldNameConverter)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IFieldNameConverter), fieldNameConverter));
@@ -781,8 +781,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IFieldNameConverter"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IFieldNameConverter"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator FieldNameConverter<T>() where T : IFieldNameConverter
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator FieldNameConverter<T>() where T : IFieldNameConverter
             {
                 this.bootstrapper.configuration.FieldNameConverter = typeof(T);
                 return this;
@@ -792,8 +792,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IModelBinderLocator"/>.
             /// </summary>
             /// <param name="modelBinderLocator">The <see cref="IModelBinderLocator"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ModelBinderLocator(IModelBinderLocator modelBinderLocator)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ModelBinderLocator(IModelBinderLocator modelBinderLocator)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IModelBinderLocator), modelBinderLocator));
@@ -805,8 +805,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IModelBinderLocator"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IModelBinderLocator"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ModelBinderLocator<T>() where T : IModelBinderLocator
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ModelBinderLocator<T>() where T : IModelBinderLocator
             {
                 this.bootstrapper.configuration.ModelBinderLocator = typeof(T);
                 return this;
@@ -816,30 +816,30 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create a <see cref="NancyModule"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="NancyModule"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator Module<T>() where T : INancyModule
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator Module<T>() where T : INancyModule
             {
                 return this.Modules(typeof(T));
             }
 
             /// <summary>
-            /// Configures the boostrapper to register the provided <see cref="NancyModule"/> instance.
+            /// Configures the bootstrapper to register the provided <see cref="NancyModule"/> instance.
             /// </summary>
             /// <param name="module">The <see cref="NancyModule"/> instance to register.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator Module(INancyModule module)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator Module(INancyModule module)
             {
                 this.bootstrapper.catalog.RegisterModuleInstance(module, module.GetType().FullName);
                 return this;
             }
 
             /// <summary>
-            /// Configures the boostrapper to register the provided <see cref="NancyModule"/> instance.
+            /// Configures the bootstrapper to register the provided <see cref="NancyModule"/> instance.
             /// </summary>
             /// <param name="module">The <see cref="NancyModule"/> instance to register.</param>
             /// <param name="moduleKey">The module key of the module that is being registered.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator Module(INancyModule module, string moduleKey)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator Module(INancyModule module, string moduleKey)
             {
                 this.bootstrapper.catalog.RegisterModuleInstance(module, moduleKey);
                 return this;
@@ -849,8 +849,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create <see cref="NancyModule"/> instances of the specified types.
             /// </summary>
             /// <param name="modules">The types of the <see cref="NancyModule"/> that the bootstrapper should use.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator Modules(params Type[] modules)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator Modules(params Type[] modules)
             {
                 var keyGenerator = new DefaultModuleKeyGenerator();
 
@@ -867,8 +867,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="INancyEngine"/>.
             /// </summary>
             /// <param name="engine">The <see cref="INancyEngine"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator NancyEngine(INancyEngine engine)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator NancyEngine(INancyEngine engine)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(INancyEngine), engine));
@@ -880,8 +880,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="INancyEngine"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="INancyEngine"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator NancyEngine<T>() where T : INancyEngine
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator NancyEngine<T>() where T : INancyEngine
             {
                 this.bootstrapper.configuration.NancyEngine = typeof(T);
                 return this;
@@ -891,8 +891,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="INancyModuleBuilder"/>.
             /// </summary>
             /// <param name="nancyModuleBuilder">The <see cref="INancyModuleBuilder"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator NancyModuleBuilder(INancyModuleBuilder nancyModuleBuilder)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator NancyModuleBuilder(INancyModuleBuilder nancyModuleBuilder)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(INancyModuleBuilder), nancyModuleBuilder));
@@ -904,8 +904,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="INancyModuleBuilder"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="INancyModuleBuilder"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator NancyModuleBuilder<T>() where T : INancyModuleBuilder
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator NancyModuleBuilder<T>() where T : INancyModuleBuilder
             {
                 this.bootstrapper.configuration.NancyModuleBuilder = typeof(T);
                 return this;
@@ -915,8 +915,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IRenderContextFactory"/>.
             /// </summary>
             /// <param name="renderContextFactory">The <see cref="IRenderContextFactory"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator RenderContextFactory(IRenderContextFactory renderContextFactory)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RenderContextFactory(IRenderContextFactory renderContextFactory)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IRenderContextFactory), renderContextFactory));
@@ -928,8 +928,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IRenderContextFactory"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IRenderContextFactory"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator RenderContextFactory<T>() where T : IRenderContextFactory
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RenderContextFactory<T>() where T : IRenderContextFactory
             {
                 this.bootstrapper.configuration.RenderContextFactory = typeof(T);
                 return this;
@@ -939,8 +939,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IResponseFormatterFactory"/>.
             /// </summary>
             /// <param name="responseFormatterFactory">The <see cref="IResponseFormatterFactory"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ResponseFormatterFactory(IResponseFormatterFactory responseFormatterFactory)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ResponseFormatterFactory(IResponseFormatterFactory responseFormatterFactory)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IResponseFormatterFactory), responseFormatterFactory));
@@ -952,8 +952,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IResponseFormatterFactory"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IResponseFormatterFactory"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ResponseFormatterFactory<T>() where T : IResponseFormatterFactory
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ResponseFormatterFactory<T>() where T : IResponseFormatterFactory
             {
                 this.bootstrapper.configuration.ResponseFormatterFactory = typeof(T);
                 return this;
@@ -963,8 +963,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IRouteCache"/>.
             /// </summary>
             /// <param name="routeCache">The <see cref="IRouteCache"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator RouteCache(IRouteCache routeCache)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RouteCache(IRouteCache routeCache)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IRouteCache), routeCache));
@@ -976,8 +976,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IRouteCache"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IRouteCache"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator RouteCache<T>() where T : IRouteCache
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RouteCache<T>() where T : IRouteCache
             {
                 this.bootstrapper.configuration.RouteCache = typeof(T);
                 return this;
@@ -987,8 +987,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IRouteCacheProvider"/>.
             /// </summary>
             /// <param name="routeCacheProvider">The <see cref="IRouteCacheProvider"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator RouteCacheProvider(IRouteCacheProvider routeCacheProvider)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RouteCacheProvider(IRouteCacheProvider routeCacheProvider)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IRouteCacheProvider), routeCacheProvider));
@@ -1000,8 +1000,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IRouteCacheProvider"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IRouteCacheProvider"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator RouteCacheProvider<T>() where T : IRouteCacheProvider
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RouteCacheProvider<T>() where T : IRouteCacheProvider
             {
                 this.bootstrapper.configuration.RouteCacheProvider = typeof(T);
                 return this;
@@ -1011,8 +1011,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IRootPathProvider"/>.
             /// </summary>
             /// <param name="rootPathProvider">The <see cref="IRootPathProvider"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator RootPathProvider(IRootPathProvider rootPathProvider)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RootPathProvider(IRootPathProvider rootPathProvider)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IRootPathProvider), rootPathProvider));
@@ -1024,8 +1024,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IRootPathProvider"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IRootPathProvider"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator RootPathProvider<T>() where T : IRootPathProvider
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RootPathProvider<T>() where T : IRootPathProvider
             {
                 this.bootstrapper.registeredTypes.Add(
                     new TypeRegistration(typeof(IRootPathProvider), typeof(T)));
@@ -1037,8 +1037,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IRoutePatternMatcher"/>.
             /// </summary>
             /// <param name="routePatternMatcher">The <see cref="IRoutePatternMatcher"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator RoutePatternMatcher(IRoutePatternMatcher routePatternMatcher)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RoutePatternMatcher(IRoutePatternMatcher routePatternMatcher)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IRoutePatternMatcher), routePatternMatcher));
@@ -1050,8 +1050,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IRouteInvoker"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IRouteInvoker"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator RouteInvoker<T>() where T : IRouteInvoker
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RouteInvoker<T>() where T : IRouteInvoker
             {
                 this.bootstrapper.configuration.RouteInvoker = typeof(T);
                 return this;
@@ -1061,8 +1061,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IRouteInvoker"/>.
             /// </summary>
             /// <param name="routeInvoker">The <see cref="IRouteInvoker"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator RouteInvoker(IRouteInvoker routeInvoker)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RouteInvoker(IRouteInvoker routeInvoker)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IRouteInvoker), routeInvoker));
@@ -1074,8 +1074,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IRoutePatternMatcher"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IRoutePatternMatcher"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator RoutePatternMatcher<T>() where T : IRoutePatternMatcher
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RoutePatternMatcher<T>() where T : IRoutePatternMatcher
             {
                 this.bootstrapper.configuration.RoutePatternMatcher = typeof(T);
                 return this;
@@ -1085,8 +1085,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IRouteResolver"/>.
             /// </summary>
             /// <param name="routeResolver">The <see cref="IRouteResolver"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator RouteResolver(IRouteResolver routeResolver)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RouteResolver(IRouteResolver routeResolver)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IRouteResolver), routeResolver));
@@ -1098,8 +1098,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IRouteResolver"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IRouteResolver"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator RouteResolver<T>() where T : IRouteResolver
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RouteResolver<T>() where T : IRouteResolver
             {
                 this.bootstrapper.configuration.RouteResolver = typeof(T);
                 return this;
@@ -1109,8 +1109,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IModelValidatorLocator"/>.
             /// </summary>
             /// <param name="modelValidatorLocator">The <see cref="IModelValidatorLocator"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ModelValidatorLocator(IModelValidatorLocator modelValidatorLocator)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ModelValidatorLocator(IModelValidatorLocator modelValidatorLocator)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IModelValidatorLocator), modelValidatorLocator));
@@ -1122,8 +1122,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IModelValidatorLocator"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IModelValidatorLocator"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ModelValidatorLocator<T>() where T : IModelValidatorLocator
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ModelValidatorLocator<T>() where T : IModelValidatorLocator
             {
                 this.bootstrapper.configuration.ModelValidatorLocator = typeof(T);
                 return this;
@@ -1133,8 +1133,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IRequestDispatcher"/>.
             /// </summary>
             /// <param name="requestDispatcher">The <see cref="IRequestDispatcher"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator RequestDispatcher(IRequestDispatcher requestDispatcher)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RequestDispatcher(IRequestDispatcher requestDispatcher)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IRequestDispatcher), requestDispatcher));
@@ -1146,8 +1146,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IRequestDispatcher"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IRequestDispatcher"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator RequestDispatcher<T>() where T : IRequestDispatcher
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RequestDispatcher<T>() where T : IRequestDispatcher
             {
                 this.bootstrapper.registeredTypes.Add(
                     new TypeRegistration(typeof(IRequestDispatcher), typeof(T)));
@@ -1159,8 +1159,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IResourceAssemblyProvider"/>.
             /// </summary>
             /// <param name="resourceAssemblyProvider">The <see cref="IResourceAssemblyProvider"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ResourceAssemblyProvider(IResourceAssemblyProvider resourceAssemblyProvider)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ResourceAssemblyProvider(IResourceAssemblyProvider resourceAssemblyProvider)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IResourceAssemblyProvider), resourceAssemblyProvider));
@@ -1172,8 +1172,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IResourceAssemblyProvider"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IResourceAssemblyProvider"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ResourceAssemblyProvider<T>() where T : IResourceAssemblyProvider
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ResourceAssemblyProvider<T>() where T : IResourceAssemblyProvider
             {
                 this.bootstrapper.configuration.ResourceAssemblyProvider = typeof(T);
                 return this;
@@ -1183,8 +1183,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IRouteDescriptionProvider"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IRouteDescriptionProvider"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator RouteDescriptionProvider<T>() where T : IRouteDescriptionProvider
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RouteDescriptionProvider<T>() where T : IRouteDescriptionProvider
             {
                 this.bootstrapper.registeredTypes.Add(
                     new TypeRegistration(typeof(IRouteDescriptionProvider), typeof(T)));
@@ -1196,8 +1196,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IRouteDescriptionProvider"/>.
             /// </summary>
             /// <param name="routeDescriptionProvider">The <see cref="IRouteDescriptionProvider"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator RouteDescriptionProvider(IRouteDescriptionProvider routeDescriptionProvider)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RouteDescriptionProvider(IRouteDescriptionProvider routeDescriptionProvider)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IRouteDescriptionProvider), routeDescriptionProvider));
@@ -1209,8 +1209,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IRouteSegmentExtractor"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IRouteSegmentExtractor"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator RouteSegmentExtractor<T>() where T : IRouteSegmentExtractor
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RouteSegmentExtractor<T>() where T : IRouteSegmentExtractor
             {
                 this.bootstrapper.registeredTypes.Add(
                     new TypeRegistration(typeof(IRouteSegmentExtractor), typeof(T)));
@@ -1222,8 +1222,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IRouteSegmentExtractor"/>.
             /// </summary>
             /// <param name="routeSegmentExtractor">The <see cref="IRouteSegmentExtractor"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator RouteSegmentExtractor(IRouteSegmentExtractor routeSegmentExtractor)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RouteSegmentExtractor(IRouteSegmentExtractor routeSegmentExtractor)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IRouteSegmentExtractor), routeSegmentExtractor));
@@ -1235,8 +1235,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IResponseProcessor"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IResponseProcessor"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ResponseProcessor<T>() where T : IResponseProcessor
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ResponseProcessor<T>() where T : IResponseProcessor
             {
                 this.bootstrapper.registeredTypes.Add(
                     new CollectionTypeRegistration(typeof(IResponseProcessor), new[] { typeof(T) }));
@@ -1248,8 +1248,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided <see cref="IResponseProcessor"/> types.
             /// </summary>
             /// <param name="responseProcessors">The <see cref="IResponseProcessor"/> types that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ResponseProcessors(params Type[] responseProcessors)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ResponseProcessors(params Type[] responseProcessors)
             {
                 this.bootstrapper.registeredTypes.Add(
                     new CollectionTypeRegistration(typeof(IResponseProcessor), responseProcessors));
@@ -1261,8 +1261,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="ITextResource"/>.
             /// </summary>
             /// <param name="textResource">The <see cref="ITextResource"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator TextResource(ITextResource textResource)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator TextResource(ITextResource textResource)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(ITextResource), textResource));
@@ -1274,8 +1274,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="ITextResource"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="ITextResource"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator TextResource<T>() where T : ITextResource
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator TextResource<T>() where T : ITextResource
             {
                 this.bootstrapper.configuration.TextResource = typeof(T);
                 return this;
@@ -1285,8 +1285,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IViewCache"/>.
             /// </summary>
             /// <param name="viewCache">The <see cref="IViewCache"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ViewCache(IViewCache viewCache)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ViewCache(IViewCache viewCache)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IViewCache), viewCache));
@@ -1298,8 +1298,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IViewCache"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IViewCache"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ViewCache<T>() where T : IViewCache
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ViewCache<T>() where T : IViewCache
             {
                 this.bootstrapper.configuration.ViewCache = typeof(T);
                 return this;
@@ -1309,8 +1309,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IViewEngine"/>.
             /// </summary>
             /// <param name="viewEngine">The <see cref="IViewEngine"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ViewEngine(IViewEngine viewEngine)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ViewEngine(IViewEngine viewEngine)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IViewEngine), viewEngine));
@@ -1322,8 +1322,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IViewEngine"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IViewEngine"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ViewEngine<T>() where T : IViewEngine
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ViewEngine<T>() where T : IViewEngine
             {
                 this.bootstrapper.registeredTypes.Add(
                     new CollectionTypeRegistration(typeof(IViewEngine), new[] { typeof(T) }));
@@ -1335,8 +1335,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided <see cref="IViewEngine"/> types.
             /// </summary>
             /// <param name="viewEngines">The <see cref="IViewEngine"/> types that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ViewEngines(params Type[] viewEngines)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ViewEngines(params Type[] viewEngines)
             {
                 this.bootstrapper.registeredTypes.Add(
                     new CollectionTypeRegistration(typeof(IViewEngine), viewEngines));
@@ -1348,8 +1348,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IViewFactory"/>.
             /// </summary>
             /// <param name="viewFactory">The <see cref="IViewFactory"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ViewFactory(IViewFactory viewFactory)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ViewFactory(IViewFactory viewFactory)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IViewFactory), viewFactory));
@@ -1361,8 +1361,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IViewFactory"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IViewFactory"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ViewFactory<T>() where T : IViewFactory
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ViewFactory<T>() where T : IViewFactory
             {
                 this.bootstrapper.configuration.ViewFactory = typeof(T);
                 return this;
@@ -1372,8 +1372,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IViewLocationCache"/>.
             /// </summary>
             /// <param name="viewLocationCache">The <see cref="IViewLocationCache"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ViewLocationCache(IViewLocationCache viewLocationCache)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ViewLocationCache(IViewLocationCache viewLocationCache)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IViewLocationCache), viewLocationCache));
@@ -1385,8 +1385,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IViewLocationCache"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IViewLocationCache"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ViewLocationCache<T>() where T : IViewLocationCache
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ViewLocationCache<T>() where T : IViewLocationCache
             {
                 this.bootstrapper.configuration.ViewLocationCache = typeof(T);
                 return this;
@@ -1396,8 +1396,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IViewLocationProvider"/>.
             /// </summary>
             /// <param name="viewLocationProvider">The <see cref="IViewLocationProvider"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ViewLocationProvider(IViewLocationProvider viewLocationProvider)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ViewLocationProvider(IViewLocationProvider viewLocationProvider)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IViewLocationProvider), viewLocationProvider));
@@ -1409,8 +1409,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IViewLocationProvider"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IViewLocationProvider"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ViewLocationProvider<T>() where T : IViewLocationProvider
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ViewLocationProvider<T>() where T : IViewLocationProvider
             {
                 this.bootstrapper.configuration.ViewLocationProvider = typeof(T);
                 return this;
@@ -1420,8 +1420,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IViewLocator"/>.
             /// </summary>
             /// <param name="viewLocator">The <see cref="IViewLocator"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ViewLocator(IViewLocator viewLocator)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ViewLocator(IViewLocator viewLocator)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IViewLocator), viewLocator));
@@ -1433,8 +1433,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IViewLocator"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IViewLocator"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ViewLocator<T>() where T : IViewLocator
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ViewLocator<T>() where T : IViewLocator
             {
                 this.bootstrapper.configuration.ViewLocator = typeof(T);
                 return this;
@@ -1444,8 +1444,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IViewResolver"/>.
             /// </summary>
             /// <param name="viewResolver">The <see cref="IViewResolver"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ViewResolver(IViewResolver viewResolver)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ViewResolver(IViewResolver viewResolver)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IViewResolver), viewResolver));
@@ -1457,8 +1457,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IViewResolver"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IViewResolver"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ViewResolver<T>() where T : IViewResolver
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ViewResolver<T>() where T : IViewResolver
             {
                 this.bootstrapper.configuration.ViewResolver = typeof(T);
                 return this;
@@ -1468,8 +1468,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="ICsrfTokenValidator"/>.
             /// </summary>
             /// <param name="tokenValidator">The <see cref="ICsrfTokenValidator"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator CsrfTokenValidator(ICsrfTokenValidator tokenValidator)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator CsrfTokenValidator(ICsrfTokenValidator tokenValidator)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(ICsrfTokenValidator), tokenValidator));
@@ -1481,8 +1481,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="ICsrfTokenValidator"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="ICsrfTokenValidator"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator CsrfTokenValidator<T>() where T : ICsrfTokenValidator
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator CsrfTokenValidator<T>() where T : ICsrfTokenValidator
             {
                 this.bootstrapper.configuration.CsrfTokenValidator = typeof(T);
                 return this;
@@ -1492,8 +1492,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IObjectSerializer"/>.
             /// </summary>
             /// <param name="objectSerializer">The <see cref="IObjectSerializer"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ObjectSerializer(IObjectSerializer objectSerializer)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ObjectSerializer(IObjectSerializer objectSerializer)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IObjectSerializer), objectSerializer));
@@ -1505,8 +1505,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IObjectSerializer"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IObjectSerializer"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator ObjectSerializer<T>() where T : IObjectSerializer
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator ObjectSerializer<T>() where T : IObjectSerializer
             {
                 this.bootstrapper.configuration.ObjectSerializer = typeof(T);
                 return this;
@@ -1517,8 +1517,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use a specific serializer
             /// </summary>
             /// <typeparam name="T">Serializer type</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator Serializer<T>() where T : ISerializer
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator Serializer<T>() where T : ISerializer
             {
                 this.bootstrapper.configuration.Serializers = new List<Type> { typeof(T) };
                 return this;
@@ -1528,8 +1528,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use specific serializers
             /// </summary>
             /// <param name="serializers">Collection of serializer types</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator Serializers(params Type[] serializers)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator Serializers(params Type[] serializers)
             {
                 this.bootstrapper.configuration.Serializers = new List<Type>(serializers);
                 return this;
@@ -1539,8 +1539,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use a specific diagnostics configuration
             /// </summary>
             /// <param name="diagnosticsConfiguration">Diagnostics configuration to use</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator DiagnosticsConfiguration(DiagnosticsConfiguration diagnosticsConfiguration)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator DiagnosticsConfiguration(DiagnosticsConfiguration diagnosticsConfiguration)
             {
                 this.bootstrapper.diagnosticConfiguration = diagnosticsConfiguration;
                 return this;
@@ -1550,8 +1550,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="IDiagnostics"/>.
             /// </summary>
             /// <param name="diagnostics">The <see cref="IDiagnostics"/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator Diagnostics(IDiagnostics diagnostics)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator Diagnostics(IDiagnostics diagnostics)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(IDiagnostics), diagnostics));
@@ -1563,8 +1563,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="IDiagnostics"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IDiagnostics"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator Diagnostics<T>() where T : IDiagnostics
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator Diagnostics<T>() where T : IDiagnostics
             {
                 this.bootstrapper.configuration.Diagnostics = typeof(T);
                 return this;
@@ -1574,8 +1574,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided instance of <see cref="ICultureService "/>.
             /// </summary>
             /// <param name="cultureService">The <see cref="ICultureService "/> instance that should be used by the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator CultureService(ICultureService cultureService)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator CultureService(ICultureService cultureService)
             {
                 this.bootstrapper.registeredInstances.Add(
                     new InstanceRegistration(typeof(ICultureService), cultureService));
@@ -1587,8 +1587,8 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to create an <see cref="ICultureService"/> instance of the specified type.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="ICultureService"/> that the bootstrapper should use.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator CultureService<T>() where T : ICultureService
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator CultureService<T>() where T : ICultureService
             {
                 this.bootstrapper.configuration.Diagnostics = typeof(T);
                 return this;
@@ -1599,20 +1599,20 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to add an assembly ignore predicate to the list
             /// </summary>
             /// <param name="ignoredPredicate">Ignore predicate</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBoostrapperConfigurator"/>.</returns>
-            public ConfigurableBoostrapperConfigurator IgnoredAssembly(Func<Assembly, bool> ignoredPredicate)
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator IgnoredAssembly(Func<Assembly, bool> ignoredPredicate)
             {
                 this.bootstrapper.configuration.WithIgnoredAssembly(ignoredPredicate);
                 return this;
             }
 
-            public ConfigurableBoostrapperConfigurator ApplicationStartup(Action<TinyIoCContainer, IPipelines> action)
+            public ConfigurableBootstrapperConfigurator ApplicationStartup(Action<TinyIoCContainer, IPipelines> action)
             {
                 this.bootstrapper.applicationStartupActions.Add(action);
                 return this;
             }
 
-            public ConfigurableBoostrapperConfigurator RequestStartup(Action<TinyIoCContainer, IPipelines, NancyContext> action)
+            public ConfigurableBootstrapperConfigurator RequestStartup(Action<TinyIoCContainer, IPipelines, NancyContext> action)
             {
                 this.bootstrapper.requestStartupActions.Add(action);
                 return this;


### PR DESCRIPTION
- Rename ConfigurableBoostrapperConfigurator -> ConfigurableBootstrapperConfigurator
- Update related summary tags
