### PR TITLE
Removed overload of Dependencies that doesn't work

### DIFF
--- a/src/Nancy.Testing/ConfigurableBootstrapper.cs
+++ b/src/Nancy.Testing/ConfigurableBootstrapper.cs
@@ -702,23 +702,6 @@ namespace Nancy.Testing
             /// Configures the bootstrapper to use the provided types as a dependency.
             /// </summary>
             /// <param name="dependencies">The types that should be used registered as dependencies with the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
-            /// <remarks>This method will register the types for all the interfaces they implement and the types themselves.</remarks>
-            public ConfigurableBootstrapperConfigurator Dependencies(params Type[] dependencies)
-            {
-                foreach (var dependency in dependencies)
-                {
-                    // This is doesn't work
-                    this.Dependency(dependency);
-                }
-
-                return this;
-            }
-
-            /// <summary>
-            /// Configures the bootstrapper to use the provided types as a dependency.
-            /// </summary>
-            /// <param name="dependencies">The types that should be used registered as dependencies with the bootstrapper.</param>
             /// <typeparam name="T">The type that the dependencies should be registered as.</typeparam>
             /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
             public ConfigurableBootstrapperConfigurator Dependencies<T>(params Type[] dependencies)


### PR DESCRIPTION
And now is replaced by the public ConfigurableBootstrapperConfigurator MappedDependencies<T, K>(IEnumerable<Tuple<T, K>> dependencies) 

This is the commit that should be instead of #931 that I'm closing now. It's from a separate branch and things. 

Sorry about my newbie-github-workflow-confusion...
