### PR TITLE
Fixed a failing unit test that didn't have a unesacped url

### DIFF
--- a/src/Nancy/Url.cs
+++ b/src/Nancy/Url.cs
@@ -143,7 +143,8 @@ namespace Nancy
         /// <returns>An <see cref="Uri"/> representation of the <paramref name="url"/>.</returns>
         public static implicit operator Uri(Url url)
         {
-            return new Uri(url.ToString(), UriKind.Absolute);
+            var s = Uri.UnescapeDataString(url.ToString());
+            return new Uri(s, UriKind.Absolute);
         }
 
         private static string GetFragment(string fragment)


### PR DESCRIPTION
The test in question was: Should_implicitly_cast_to_absolute_uri and the problem had to do with the Uri-constructor not accepting the "%20" in the query string. 
