### PR TITLE
This commit fixes issue #624

### DIFF
--- a/src/Nancy.Testing/Nancy.Testing.csproj
+++ b/src/Nancy.Testing/Nancy.Testing.csproj
@@ -125,6 +125,7 @@
     <Compile Include="PathHelper.cs" />
     <Compile Include="QueryWrapper.cs" />
     <Compile Include="AssertExtensions.cs" />
+    <Compile Include="TestingBootstrapper.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nancy.Authentication.Forms\Nancy.Authentication.Forms.csproj">

--- a/src/Nancy.Testing/TestingBootstrapper.cs
+++ b/src/Nancy.Testing/TestingBootstrapper.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Nancy.Testing
+{
+    public class TestingBootstrapper : ConfigurableBootstrapper
+    {
+        // Hotfix for issue #624
+        public TestingBootstrapper() : base(x => x.RootPathProvider(new DefaultRootPathProvider()))
+        {
+            
+        }
+    }
+}


### PR DESCRIPTION
Encapsulates the "hotfix" for #624 as a bootstrapper for testing purposes, `TestingBootstrapper`.

Basically a `ConfigurableBootstrapper` with `RootPathProvider` set to `DefaultRootPathProvider` by default.
