### PR TITLE
Sped up runtime view discovery

### DIFF
--- a/src/Nancy/ViewEngines/FileSystemViewLocationProvider.cs
+++ b/src/Nancy/ViewEngines/FileSystemViewLocationProvider.cs
@@ -76,11 +76,24 @@
                 return Enumerable.Empty<ViewLocationResult>();
             }
 
-            var results = this.GetViewsFromPath(path, supportedViewExtensions);
+            var results = this.GetViewsFromPath(path, viewName, supportedViewExtensions);
 
-            return results.Where(vlr => vlr.Location.Equals(location, StringComparison.OrdinalIgnoreCase) &&
-                                        vlr.Name.Equals(viewName, StringComparison.OrdinalIgnoreCase));
+            return results;
+        }
 
+        private IEnumerable<ViewLocationResult> GetViewsFromPath(string path, string viewName, IEnumerable<string> supportedViewExtensions)
+        {
+            var matches = this.fileSystemReader.GetViewsWithSupportedExtensions(path, viewName, supportedViewExtensions);
+
+            return from match in matches
+                   select
+                       new FileSystemViewLocationResult(
+                       GetViewLocation(match.Item1, this.rootPath),
+                       Path.GetFileNameWithoutExtension(match.Item1),
+                       Path.GetExtension(match.Item1).Substring(1),
+                       match.Item2,
+                       match.Item1,
+                       this.fileSystemReader);
         }
 
         private IEnumerable<ViewLocationResult> GetViewsFromPath(string path, IEnumerable<string> supportedViewExtensions)

--- a/src/Nancy/ViewEngines/IFileSystemReader.cs
+++ b/src/Nancy/ViewEngines/IFileSystemReader.cs
@@ -23,5 +23,14 @@ namespace Nancy.ViewEngines
         /// <param name="filename">Filename</param>
         /// <returns>Time the file was last modified</returns>
         DateTime GetLastModified(string filename);
+
+        /// <summary>
+        /// Gets information about specific views that are stored in folders below the applications root path.
+        /// </summary>
+        /// <param name="path">The path of the folder where the views should be looked for.</param>
+        /// <param name="viewName">Name of the view to search for</param>
+        /// <param name="supportedViewExtensions">A list of view extensions to look for.</param>
+        /// <returns>An <see cref="IEnumerable{T}"/> containing view locations and contents readers.</returns>
+        IEnumerable<Tuple<string, Func<StreamReader>>> GetViewsWithSupportedExtensions(string path, string viewName, IEnumerable<string> supportedViewExtensions);
     }
 }


### PR DESCRIPTION
Switched the runtime view discovery to look for specific files in
specific folders, rather than the previously inefficient approach
of finding everythign in a folder and whittling it down afterwards.

Phil Jones says it is much faster now, so if it's still slow,
blame him at https://twitter.com/philjones88 ;-)
