### PR TITLE
Disabled Csrf hook by default

### DIFF
--- a/src/Nancy.Demo.Hosting.Aspnet/DemoBootstrapper.cs
+++ b/src/Nancy.Demo.Hosting.Aspnet/DemoBootstrapper.cs
@@ -5,6 +5,7 @@
     using Conventions;
 
     using Nancy.Diagnostics;
+    using Nancy.Security;
     using Nancy.Session;
     using Nancy.TinyIoc;
     using Nancy.ViewEngines;
@@ -41,6 +42,7 @@
 
             StaticConfiguration.EnableRequestTracing = true;
             StaticConfiguration.DisableErrorTraces = false;
+            Csrf.Enable(pipelines);
 
             this.Conventions.StaticContentsConventions.Add(StaticContentConventionBuilder.AddDirectory("moo", "Content"));
 

--- a/src/Nancy.Tests/Nancy.Tests.csproj
+++ b/src/Nancy.Tests/Nancy.Tests.csproj
@@ -220,7 +220,7 @@
     <Compile Include="Unit\Routing\RouteFixture.cs" />
     <Compile Include="Unit\DynamicDictionaryFixture.cs" />
     <Compile Include="Unit\Routing\DefaultRouteResolverFixture.cs" />
-    <Compile Include="Unit\Security\CsrfStartupFixture.cs" />
+    <Compile Include="Unit\Security\CsrfFixture.cs" />
     <Compile Include="Unit\Security\DefaultCsrfTokenValidatorFixture.cs" />
     <Compile Include="Unit\Security\ModuleSecurityFixture.cs" />
     <Compile Include="Unit\Sessions\CookieBasedSessionsFixture.cs" />

--- a/src/Nancy.Tests/Unit/Security/CsrfFixture.cs
+++ b/src/Nancy.Tests/Unit/Security/CsrfFixture.cs
@@ -12,7 +12,7 @@
 
     using Xunit;
 
-    public class CsrfStartupFixture
+    public class CsrfFixture
     {
         private readonly IPipelines pipelines;
                  
@@ -24,7 +24,7 @@
 
         private readonly DefaultObjectSerializer objectSerializer;
 
-        public CsrfStartupFixture()
+        public CsrfFixture()
         {
             this.pipelines = new MockPipelines();
 
@@ -37,6 +37,7 @@
                 new DefaultCsrfTokenValidator(this.cryptographyConfiguration));
 
             csrfStartup.Initialize(this.pipelines);
+            Csrf.Enable(this.pipelines);
 
             this.request = new FakeRequest("GET", "/");
             this.response = new Response();

--- a/src/Nancy/Security/CsrfApplicationStartup.cs
+++ b/src/Nancy/Security/CsrfApplicationStartup.cs
@@ -43,7 +43,6 @@
         /// <param name="pipelines">Application pipelines</param>
         public void Initialize(IPipelines pipelines)
         {
-            Csrf.Enable(pipelines);
         }
     }
 }


### PR DESCRIPTION
As we haver a mix of people using Nancy for views and services,
and as creating the Csrf cookie is very expensive and validation
of it requires manual work anyway, having it runnign automatically
on every request is wasteful, and is especially harmful with clients
that don't store the cookie (so it gets regenerated every request)

Enabling it is just a single line in the bootstrapp app startup:

Csrf.Enable(pipelines);
