### PR TITLE
Fix for "invalid characters in path" when using browser

### DIFF
--- a/src/Nancy.Tests.Functional/Tests/ContentNegotiationFixture.cs
+++ b/src/Nancy.Tests.Functional/Tests/ContentNegotiationFixture.cs
@@ -576,6 +576,16 @@ namespace Nancy.Tests.Functional.Tests
             Assert.Equal((HttpStatusCode)200, response.StatusCode);
         }
 
+        [Fact]
+        public void Should_not_try_and_serve_view_with_invalid_name()
+        {
+            var browser = new Browser(with => with.Module<NegotiationModule>());
+
+            var result = Record.Exception(() => browser.Get("/invalid-view-name"));
+
+            Assert.True(result.ToString().Contains("Unable to locate view"));
+        }
+
         private static Func<dynamic, NancyModule, dynamic> CreateNegotiatedResponse(Action<Negotiator> action = null)
         {
             return (parameters, module) =>
@@ -677,5 +687,23 @@ namespace Nancy.Tests.Functional.Tests
                 return (string) model;
             }
         }
+
+        private class NegotiationModule : NancyModule
+        {
+            public NegotiationModule()
+            {
+                Get["/invalid-view-name"] = _ => this.GetModel();
+            }
+
+            private IEnumerable<Foo> GetModel()
+            {
+                yield return new Foo();
+            }
+
+            private class Foo
+            {
+            }
+        }
     }
+
 }

--- a/src/Nancy/ViewEngines/DefaultViewLocator.cs
+++ b/src/Nancy/ViewEngines/DefaultViewLocator.cs
@@ -19,10 +19,14 @@
 
         private readonly ReaderWriterLockSlim padlock = new ReaderWriterLockSlim();
 
+        private readonly char[] invalidCharacters;
+
         public DefaultViewLocator(IViewLocationProvider viewLocationProvider, IEnumerable<IViewEngine> viewEngines)
         {
             this.viewLocationProvider = viewLocationProvider;
             this.viewEngines = viewEngines;
+
+            this.invalidCharacters = Path.GetInvalidFileNameChars().Where(c => c != '/').ToArray();
 
             // No need to lock here, we get constructed on app startup
             this.viewLocationResults = new List<ViewLocationResult>(this.GetInititialViewLocations());
@@ -37,6 +41,11 @@
         public ViewLocationResult LocateView(string viewName, NancyContext context)
         {
             if (string.IsNullOrEmpty(viewName))
+            {
+                return null;
+            }
+
+            if (!this.IsValidViewName(viewName))
             {
                 return null;
             }
@@ -230,6 +239,11 @@
             var extension = Path.GetExtension(viewName);
 
             return !String.IsNullOrEmpty(extension) ? extension.Substring(1) : extension;
+        }
+
+        private bool IsValidViewName(string viewName)
+        {
+            return !this.invalidCharacters.Any(viewName.Contains);
         }
     }
 }


### PR DESCRIPTION
If a route returned a model of a type who's full type name
contains characters that aren't valid path characters (e.g.
anything with generics), and the view processor was selected,
then the view locator would blow up with invalid characters in
path.
