### PR TITLE
Changed windows directory separator to Path.DirectorySeparatorChar

### DIFF
--- a/src/Nancy/Diagnostics/DiagnosticsHook.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsHook.cs
@@ -65,7 +65,7 @@ namespace Nancy.Diagnostics
                             var path = Path.GetDirectoryName(ctx.Request.Url.Path.Replace(resourcePrefix, string.Empty)) ?? string.Empty;
                             if (!string.IsNullOrEmpty(path))
                             {
-                                resourceNamespace += string.Format(".{0}", path.Replace('\\', '.'));
+                                resourceNamespace += string.Format(".{0}", path.Replace(Path.DirectorySeparatorChar, '.'));
                             }
 
                             return new EmbeddedFileResponse(


### PR DESCRIPTION
...Char which prevented diagnostics pages from working on OSes with "/" as path separator.
