### PR TITLE
Adding Domain and Path to FormsAuthenticationConfiguration

### DIFF
--- a/src/Nancy.Authentication.Forms.Tests/FormsAuthenticationFixture.cs
+++ b/src/Nancy.Authentication.Forms.Tests/FormsAuthenticationFixture.cs
@@ -681,10 +681,13 @@ namespace Nancy.Authentication.Forms.Tests
         [Fact]
         public void Should_set_Domain_when_config_provides_domain_value()
         {
+            //Given
             FormsAuthentication.Enable(A.Fake<IPipelines>(), this.domainPathConfig);
 
+            //When
             var result = FormsAuthentication.UserLoggedInRedirectResponse(context, userGuid);
 
+            //Then
             var cookie = result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName).First();
             cookie.Domain.ShouldEqual(domain);
         }
@@ -692,10 +695,13 @@ namespace Nancy.Authentication.Forms.Tests
         [Fact]
         public void Should_set_Path_when_config_provides_path_value()
         {
+            //Given
             FormsAuthentication.Enable(A.Fake<IPipelines>(), this.domainPathConfig);
 
+            //When
             var result = FormsAuthentication.UserLoggedInRedirectResponse(context, userGuid);
 
+            //Then
             var cookie = result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName).First();
             cookie.Path.ShouldEqual(path);
         }

--- a/src/Nancy.Authentication.Forms/FormsAuthentication.cs
+++ b/src/Nancy.Authentication.Forms/FormsAuthentication.cs
@@ -244,10 +244,14 @@ namespace Nancy.Authentication.Forms
             var cookie = new NancyCookie(formsAuthenticationCookieName, cookieContents, true, configuration.RequiresSSL) { Expires = cookieExpiry };
 
             if(!string.IsNullOrEmpty(configuration.Domain))
+            {
                 cookie.Domain = configuration.Domain;
+            }
 
             if(!string.IsNullOrEmpty(configuration.Path))
+            {
                 cookie.Path = configuration.Path;
+            }
 
             return cookie;
         }
@@ -262,10 +266,14 @@ namespace Nancy.Authentication.Forms
             var cookie = new NancyCookie(formsAuthenticationCookieName, String.Empty, true, configuration.RequiresSSL) { Expires = DateTime.Now.AddDays(-1) };
 
             if(!string.IsNullOrEmpty(configuration.Domain))
+            {
                 cookie.Domain = configuration.Domain;
+            }
 
             if(!string.IsNullOrEmpty(configuration.Path))
+            {
                 cookie.Path = configuration.Path;
+            }
 
             return cookie;
         }

--- a/src/Nancy.Authentication.Forms/FormsAuthenticationConfiguration.cs
+++ b/src/Nancy.Authentication.Forms/FormsAuthenticationConfiguration.cs
@@ -55,12 +55,12 @@ namespace Nancy.Authentication.Forms
         /// <summary>
         /// Gets or sets the domain of the auth cookie
         /// </summary>
-        public string Domain {get;set;}
+        public string Domain { get; set; }
 
         /// <summary>
         /// Gets or sets the path of the auth cookie
         /// </summary>
-        public string Path {get;set;}
+        public string Path { get; set; }
 
         /// <summary>
         /// Gets or sets the cryptography configuration


### PR DESCRIPTION
There is no way to modify the path or domain of the auth cookie.  Now
there is a way to provide the domain and path via the
FormsAuthenticationConfiguration.

2 Additional Tests were created.
