### PR TITLE
Remove original port number when redirecting to HTTPS

### DIFF
--- a/src/Nancy.Tests/Unit/Security/ModuleSecurityFixture.cs
+++ b/src/Nancy.Tests/Unit/Security/ModuleSecurityFixture.cs
@@ -373,6 +373,32 @@ namespace Nancy.Tests.Unit.Security
             result.ShouldBeOfType<RedirectResponse>();
 
             url.Scheme = "https";
+            url.Port = null;
+            result.Headers["Location"].ShouldEqual(url.ToString());
+        }
+
+        [Fact]
+        public void Should_return_redirect_response_with_specific_port_number_when_request_url_is_non_secure_method_is_get_and_requires_https()
+        {
+            // Given
+            var module = new FakeHookedModule(new BeforePipeline());
+            var url = GetFakeUrl(false);
+            var context = new NancyContext
+            {
+                Request = new Request("GET", url)
+            };
+
+            module.RequiresHttps(true, 999);
+
+            // When
+            var result = module.Before.Invoke(context);
+
+            // Then
+            result.ShouldNotBeNull();
+            result.ShouldBeOfType<RedirectResponse>();
+
+            url.Scheme = "https";
+            url.Port = 999;
             result.Headers["Location"].ShouldEqual(url.ToString());
         }
 

--- a/src/Nancy/Security/ModuleSecurity.cs
+++ b/src/Nancy/Security/ModuleSecurity.cs
@@ -65,13 +65,24 @@ namespace Nancy.Security
         /// This module requires https.
         /// </summary>
         /// <param name="module">The <see cref="INancyModule"/> that requires HTTPS.</param>
-        /// <param name="redirect"><see langword="true"/> if the user should be redirected to HTTPS if the incoming request was made using HTTP, otherwise <see langword="false"/> if <see cref="HttpStatusCode.Forbidden"/> should be returned.</param>
+        /// <param name="redirect"><see langword="true"/> if the user should be redirected to HTTPS (no port number) if the incoming request was made using HTTP, otherwise <see langword="false"/> if <see cref="HttpStatusCode.Forbidden"/> should be returned.</param>
         public static void RequiresHttps(this INancyModule module, bool redirect)
         {
-            module.Before.AddItemToEndOfPipeline(RequiresHttps(redirect));
+            module.Before.AddItemToEndOfPipeline(RequiresHttps(redirect, null));
         }
 
-        private static Func<NancyContext, Response> RequiresHttps(bool redirect)
+        /// <summary>
+        /// This module requires https.
+        /// </summary>
+        /// <param name="module">The <see cref="INancyModule"/> that requires HTTPS.</param>
+        /// <param name="redirect"><see langword="true"/> if the user should be redirected to HTTPS if the incoming request was made using HTTP, otherwise <see langword="false"/> if <see cref="HttpStatusCode.Forbidden"/> should be returned.</param>
+        /// <param name="httpsPort">The HTTPS port number to use</param>
+        public static void RequiresHttps(this INancyModule module, bool redirect, int httpsPort)
+        {
+            module.Before.AddItemToEndOfPipeline(RequiresHttps(redirect, httpsPort));
+        }
+
+        private static Func<NancyContext, Response> RequiresHttps(bool redirect, int? httpsPort)
         {
             return (ctx) =>
                    {
@@ -82,6 +93,7 @@ namespace Nancy.Security
                            if (redirect && request.Method.Equals("GET", StringComparison.OrdinalIgnoreCase))
                            {
                                var redirectUrl = request.Url.Clone();
+                               redirectUrl.Port = httpsPort;
                                redirectUrl.Scheme = "https";
                                response = new RedirectResponse(redirectUrl.ToString());
                            }


### PR DESCRIPTION
INancyModule.RequiresHttps(true) should strip the port number on the original URL when building the HTTPS redirect URL by default, with an overload to specify a HTTP port number.  

You can see the current behavior on this Windows Azure Web Site:

Site: http://wawsnancyssl.azurewebsites.net/
Source code: https://github.com/timplourde/wawsnancyssl

Notice how the redirect preserves the :80 port number from the original request.  This is not an Azure thing- it happens on local IIS too.

ASP.NET's MVC doesn't have this issue its [RequireHttps] attribute drops the original URL's port number:
http://aspnetwebstack.codeplex.com/SourceControl/changeset/view/1acb241299a8#src/System.Web.Mvc/RequireHttpsAttribute.cs

In this PR, RequiresHttps(true) will strip off the port number by default and provides an overload to specify a HTTPS port number if so desired.
