### PR TITLE
Increase buffer for send files up to 4Mb

### DIFF
--- a/src/Nancy/Responses/GenericFileResponse.cs
+++ b/src/Nancy/Responses/GenericFileResponse.cs
@@ -21,6 +21,11 @@ namespace Nancy.Responses
         /// will fail with a 404.
         /// </summary>
         public static IList<string> SafePaths { get; set; }
+
+        /// <summary>
+        ///  Size of buffer for transmitting file. Default size 4 Mb
+        /// </summary>
+        public static int BufferSize = 4 * 1024 * 1024;
                 
         static GenericFileResponse()
         {
@@ -72,10 +77,9 @@ namespace Nancy.Responses
         {
             return stream =>
             {
-                const int bufferSize = 4096 * 1024;
                 using (var file = File.OpenRead(filePath))
                 {
-                    file.CopyTo(stream, (int)(length < bufferSize ? length : bufferSize));
+                    file.CopyTo(stream, (int)(length < BufferSize ? length : BufferSize));
                 }
             };
         }


### PR DESCRIPTION
We had a problem with speed of transmitting static files in self hosted app under Windows 2008 R2.  We have checked it with several VMs with same result. For Win2012 it worked well. During investigation we found solution - increase buffer in CopyTo.

For example before patching 2MB file transfers  5 min 29 sec , after patching 354 ms.
