### PR TITLE
Adds WriteAttributeTo method for razor helpers

### DIFF
--- a/src/Nancy.ViewEngines.Razor.Tests/Nancy.ViewEngines.Razor.Tests.csproj
+++ b/src/Nancy.ViewEngines.Razor.Tests/Nancy.ViewEngines.Razor.Tests.csproj
@@ -136,6 +136,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="TestViews\ViewThatUsesHelper.cshtml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestViews\ViewThatUsesAttributeWithCodeInside.cshtml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/Nancy.ViewEngines.Razor.Tests/RazorViewEngineFixture.cs
+++ b/src/Nancy.ViewEngines.Razor.Tests/RazorViewEngineFixture.cs
@@ -434,6 +434,23 @@
         }
 
         [Fact]
+        public void Should_be_able_to_render_view_with_helper_to_steam()
+        {
+            // Given
+            var location = FindView("ViewThatUsesHelper");
+
+            var stream = new MemoryStream();
+
+            // When
+            var response = this.engine.RenderView(location, null, this.renderContext);
+            response.Contents.Invoke(stream);
+
+            // Then
+            var output = ReadAll(stream);
+            output.ShouldContainInOrder("<h1>SimplyLayout</h1>", "<div>ViewThatUsesHelper</div>", "<p class=\"className\"></p>");
+        }
+
+        [Fact]
         public void Should_use_custom_view_base_with_csharp_views()
         {
             // Given

--- a/src/Nancy.ViewEngines.Razor.Tests/TestViews/ViewThatUsesHelper.cshtml
+++ b/src/Nancy.ViewEngines.Razor.Tests/TestViews/ViewThatUsesHelper.cshtml
@@ -1,0 +1,12 @@
+﻿@{
+    Layout = "SimplyLayout";
+}
+
+<div>ViewThatUsesHelper</div>
+
+@test("className")
+
+@helper test(string className)
+{
+    <p class="@className"></p>
+}

--- a/src/Nancy.ViewEngines.Razor/NancyRazorViewBase.cs
+++ b/src/Nancy.ViewEngines.Razor/NancyRazorViewBase.cs
@@ -162,6 +162,19 @@
 
         public virtual void WriteAttribute(string name, Tuple<string, int> prefix, Tuple<string, int> suffix, params AttributeValue[] values)
         {
+            var attributeValue = this.BuildAttribute(name, prefix, suffix, values);
+            this.WriteLiteral(attributeValue);
+        }
+
+        public virtual void WriteAttributeTo(TextWriter writer, string name, Tuple<string, int> prefix, Tuple<string, int> suffix, params AttributeValue[] values)
+        {
+            var attributeValue = this.BuildAttribute(name, prefix, suffix, values);
+            this.WriteLiteralTo(writer, attributeValue);
+        }
+
+        private string BuildAttribute(string name, Tuple<string, int> prefix, Tuple<string, int> suffix,
+                                      params AttributeValue[] values)
+        {
             var writtenAttribute = false;
             var attributeBuilder = new StringBuilder(prefix.Item1);
 
@@ -188,8 +201,10 @@
 
             if (renderAttribute)
             {
-                this.WriteLiteral(attributeBuilder);
+                return attributeBuilder.ToString();
             }
+
+            return string.Empty;
         }
 
         private string GetStringValue(AttributeValue value)


### PR DESCRIPTION
The following was throwing an exception that WriteAttributeTo did not exist

``` csharp
@helper test(string className)
{
    <p class="@className"></p>
}
```

The `WriteAttributeTo` method was missing from the `NancyRazorViewBase`

Fixes #1010
