### PR TITLE
Fixing Mono Build Error

### DIFF
--- a/src/Nancy.ViewEngines.Razor.Tests/RazorViewEngineFixture.cs
+++ b/src/Nancy.ViewEngines.Razor.Tests/RazorViewEngineFixture.cs
@@ -493,7 +493,7 @@
                 "vbhtml",
                 () => new StringReader(view.ToString())
             );
-#endif
+
             var stream = new MemoryStream();
 
             A.CallTo(() => this.configuration.GetAssemblyNames()).Returns(new[] { "Nancy.ViewEngines.Razor.Tests" });
@@ -506,7 +506,7 @@
             var output = ReadAll(stream).Trim();
             output.ShouldEqual("<h1>Hi, Nancy!</h1>");
         }
-
+#endif
         [Fact(Skip = "Multi-threading regression test")]
         public void should_work_on_multiple_threads()
         {


### PR DESCRIPTION
There is a compiler directive in the middle of a Fact. I moved the end
of the directive to encompass the entire Fact.
