### PR TITLE
Fixes Compilation Errors in DefaultRouteResolverFixture in mono

### DIFF
--- a/src/Nancy.Tests/Unit/Routing/DefaultRouteResolverFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/DefaultRouteResolverFixture.cs
@@ -1,7 +1,7 @@
 ﻿namespace Nancy.Tests.Unit.Routing
 {
     using Nancy.Testing;
-	using Nancy.Tests;
+    using Nancy.Tests;
     using Xunit;
 
     public class DefaultRouteResolverFixture


### PR DESCRIPTION
Compilation fails by default on mono because DefaultRouteResolverFixture.cs does not bring Nancy.Tests into scope.  Therefore, on this line of code:

``` csharp
result.Headers["Allow"].ShouldContain("GET");
```

the compiler assumed that the ShouldContain extension method was from Nancy.Testing.AssertExtensions instead of Nancy.Tests.ShouldExtensions
