### PR TITLE
Extended type check in registration classes to handle open generics

### DIFF
--- a/src/Nancy.Tests/Unit/Bootstrapper/TypeRegistrationFixture.cs
+++ b/src/Nancy.Tests/Unit/Bootstrapper/TypeRegistrationFixture.cs
@@ -1,7 +1,9 @@
 namespace Nancy.Tests.Unit.Bootstrapper
 {
     using System;
+    using System.Collections.Generic;
     using Nancy.Bootstrapper;
+    using Nancy.Diagnostics;
     using Xunit;
 
     public class TypeRegistrationFixture
@@ -41,6 +43,16 @@ namespace Nancy.Tests.Unit.Bootstrapper
         {
             // Given, When
             var result = Record.Exception(() => new TypeRegistration(typeof(INancyBootstrapper), typeof(DefaultNancyBootstrapper)));
+
+            // Then
+            result.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Should_not_throw_if_open_generic_implementation_type_is_assignable_to_open_generic_registration_type()
+        {
+            // Given, When
+            var result = Record.Exception(() => new TypeRegistration(typeof(IEnumerable<>), typeof(ConcurrentLimitedCollection<>)));
 
             // Then
             result.ShouldBeNull();

--- a/src/Nancy/Bootstrapper/ContainerRegistration.cs
+++ b/src/Nancy/Bootstrapper/ContainerRegistration.cs
@@ -2,6 +2,7 @@ namespace Nancy.Bootstrapper
 {
     using System;
     using System.Linq;
+    using Nancy.Extensions;
 
     /// <summary>
     /// Base class for container registrations
@@ -27,7 +28,7 @@ namespace Nancy.Bootstrapper
             }
 
             var incompatibleTypes =
-                types.Where(type => !this.RegistrationType.IsAssignableFrom(type)).ToArray();
+                types.Where(type => !this.RegistrationType.IsAssignableFrom(type) && !type.IsAssignableToGenericType(this.RegistrationType)).ToArray();
 
             if (incompatibleTypes.Any())
             {

--- a/src/Nancy/Extensions/TypeExtensions.cs
+++ b/src/Nancy/Extensions/TypeExtensions.cs
@@ -19,6 +19,26 @@
             return source.BaseType == typeof(Array);
         }
 
+        /// <summary>
+        /// Determines whether the <paramref name="genericType"/> is assignable from
+        /// <paramref name="givenType"/> taking into account generic definitions
+        /// </summary>
+        /// <remarks>
+        /// Borrowed from: http://tmont.com/blargh/2011/3/determining-if-an-open-generic-type-isassignablefrom-a-type
+        /// </remarks>
+        public static bool IsAssignableToGenericType(this Type givenType, Type genericType)
+        {
+            if (givenType == null || genericType == null)
+            {
+                return false;
+            }
+
+            return givenType == genericType
+                || givenType.MapsToGenericTypeDefinition(genericType)
+                || givenType.HasInterfaceThatMapsToGenericTypeDefinition(genericType)
+                || givenType.BaseType.IsAssignableToGenericType(genericType);
+        }
+
         public static bool IsCollection(this Type source)
         {
             var collectionType = typeof(ICollection<>);
@@ -70,6 +90,21 @@
                     return false;
             }
             return false;
+        }
+
+        private static bool HasInterfaceThatMapsToGenericTypeDefinition(this Type givenType, Type genericType)
+        {
+            return givenType
+                .GetInterfaces()
+                .Where(it => it.IsGenericType)
+                .Any(it => it.GetGenericTypeDefinition() == genericType);
+        }
+
+        private static bool MapsToGenericTypeDefinition(this Type givenType, Type genericType)
+        {
+            return genericType.IsGenericTypeDefinition
+                && givenType.IsGenericType
+                && givenType.GetGenericTypeDefinition() == genericType;
         }
     }
 }


### PR DESCRIPTION
A call to `IsAssignableFrom` always returns false when checking open generics, e.g.: `typeof(IEnumerable<>).IsAssignableFrom(typeof(IList<>))`
