### PR TITLE
Fix for resource files with the same name crash ResourceBasedTextResource

### DIFF
--- a/src/Nancy/Localization/ResourceBasedTextResource.cs
+++ b/src/Nancy/Localization/ResourceBasedTextResource.cs
@@ -76,7 +76,7 @@ namespace Nancy.Localization
 
             if (index == -1)
             {
-                throw new InvalidOperationException("The text key needs to be specified in the format resourcename.resourcekey.");
+                throw new InvalidOperationException("The text key needs to be specified in the format resourcename.resourcekey, where resourcename should at least be the name of the resource file and at most the fully qualified path.");
             }
 
             return new Tuple<string, string>(


### PR DESCRIPTION
Updated ResourceBasedTextResource logic

It will not track resources using their full name to avoid
name collisions. It will also apply a right-to-left matching
when figuring out which resource to use to look up the
provided key.

Fixes #1028
