### PR TITLE
Forcing MSBuild to use v10.0

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -47,7 +47,7 @@ end
 
 desc "Compile solution file"
 msbuild :compile => [:assembly_info] do |msb|
-    msb.properties :configuration => CONFIGURATION
+    msb.properties = { :configuration => CONFIGURATION, "VisualStudioVersion" => "10.0" }
     msb.targets :Clean, :Build
     msb.solution = SOLUTION_FILE
 end


### PR DESCRIPTION
http://blogs.msdn.com/b/webdev/archive/2012/08/22/visual-studio-project-compatability-and-visualstudioversion.aspx
