### PR TITLE
Exception handling in the AppDomainAssemblyTypeScanner when read an unmanaged code library

### DIFF
--- a/src/Nancy/Bootstrapper/AppDomainAssemblyTypeScanner.cs
+++ b/src/Nancy/Bootstrapper/AppDomainAssemblyTypeScanner.cs
@@ -59,15 +59,15 @@ namespace Nancy.Bootstrapper
         /// be included as a true from another delegate will take precedence.
         /// </summary>
         public static IEnumerable<Func<Assembly, bool>> AssembliesToScan
-        { 
-            private get 
+        {
+            private get
             {
                 return assembliesToScan ?? (assembliesToScan = DefaultAssembliesToScan);
-            } 
-            set 
+            }
+            set
             {
                 assembliesToScan = value;
-                UpdateTypes ();
+                UpdateTypes();
             }
         }
 
@@ -228,10 +228,17 @@ namespace Nancy.Bootstrapper
 
                 foreach (var unloadedAssembly in unloadedAssemblies)
                 {
-                    var inspectedAssembly =
-                        Assembly.ReflectionOnlyLoadFrom(unloadedAssembly);
+                    Assembly inspectedAssembly = null;
+                    try
+                    {
+                        inspectedAssembly = Assembly.ReflectionOnlyLoadFrom(unloadedAssembly);
+                    }
+                    catch (BadImageFormatException biEx)
+                    {
+                        //the assembly maybe it's not managed code
+                    }
 
-                    if (inspectedAssembly.GetReferencedAssemblies().Any(r => r.Name.StartsWith("Nancy", StringComparison.OrdinalIgnoreCase)))
+                    if (inspectedAssembly != null && inspectedAssembly.GetReferencedAssemblies().Any(r => r.Name.StartsWith("Nancy", StringComparison.OrdinalIgnoreCase)))
                     {
                         try
                         {


### PR DESCRIPTION
With the new Assembly type scanner, when nancy search for the libraries containing references to Nancy, when tries to load a assembly that is not (for example SQLite.Interop.dll or libzmq.dll) the method LoadAssembliesWithNancyReferences from the class AppDomainAssemblyTypeScanner throw a BadImageException. 

This pull request only add a try-catch to handle the BadImageException and don't provoke to shutdown the current process and pass to load the next assembly.

Thanks.
