### PR TITLE
Fix issue with login request helper. Fixes #1047

### DIFF
--- a/src/Nancy/Diagnostics/DiagnosticsHook.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsHook.cs
@@ -233,7 +233,8 @@ namespace Nancy.Diagnostics
         private static bool IsLoginRequest(NancyContext context, DiagnosticsConfiguration diagnosticsConfiguration)
         {
             return context.Request.Method == "POST" &&
-                context.Request.Url.BasePath.TrimEnd(new[] { '/' }).EndsWith(diagnosticsConfiguration.Path);
+                context.Request.Url.BasePath.TrimEnd(new[] { '/' }).EndsWith(diagnosticsConfiguration.Path) &&
+                context.Request.Url.Path == "/";
         }
 
         private static void ExecuteRoutePreReq(NancyContext context, Func<NancyContext, Response> resolveResultPreReq)


### PR DESCRIPTION
Fixes #1047:

Any POST to the diagnostics app was being treated as a login request.
