### PR TITLE
Allow RegEx to specify end of line

### DIFF
--- a/src/Nancy/Routing/Trie/TrieNodeFactory.cs
+++ b/src/Nancy/Routing/Trie/TrieNodeFactory.cs
@@ -30,7 +30,7 @@ namespace Nancy.Routing.Trie
                 return this.GetCaptureNode(parent, segment);
             }
 
-            if (segment.StartsWith("^(") && segment.EndsWith(")"))
+            if (segment.StartsWith("^(") && (segment.EndsWith(")") || segment.EndsWith(")$")))
             {
                 return new GreedyRegExCaptureNode(parent, segment, this);
             }


### PR DESCRIPTION
Added a check in the factory to look for `)` and `)$` so that if a regex specifies an entire string match it still picks up the node.

This fixes an issue where if you have two routes like:

`@"^(?:(?<id>videos/\d{1,10})(?:/{0,1}(?<slug>.*)))$"`

And

`@"^(?:(videos)(?:/page/?(?<page>\d*))?)$"`

Where both seem to match and return true. 

In the first case it was trying to add the 0 index match from both causing a key already exists exception. The real issue is two routes matched and added 0 index match.

Fixing the 0 index didn't fix the issue since it sometimes picks the wrong route of the two matches.

Specifying the RegEx to match the entire string filters out the invalid match and picks the right one.
