### PR TITLE
Added support for hyphens in embedded resource folder names.

### DIFF
--- a/src/Nancy.Embedded.Tests/Nancy.Embedded.Tests.csproj
+++ b/src/Nancy.Embedded.Tests/Nancy.Embedded.Tests.csproj
@@ -74,7 +74,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\Subfolder-with-hyphen\embedded3.txt" />
+  </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\Subfolder\embedded2.txt" />
   </ItemGroup>

--- a/src/Nancy.Embedded.Tests/Resources/Subfolder-with-hyphen/embedded3.txt
+++ b/src/Nancy.Embedded.Tests/Resources/Subfolder-with-hyphen/embedded3.txt
@@ -1,0 +1,1 @@
+Embedded3 Text

--- a/src/Nancy.Embedded.Tests/Unit/EmbeddedStaticContentConventionBuilderFixture.cs
+++ b/src/Nancy.Embedded.Tests/Unit/EmbeddedStaticContentConventionBuilderFixture.cs
@@ -35,6 +35,17 @@
         }
 
         [Fact]
+        public void Should_retrieve_static_content_with_hyphens_in_subfolder()
+        {
+            // Given
+            // When
+            var result = GetEmbeddedStaticContent("Foo", "Subfolder-with-hyphen/embedded3.txt");
+
+            // Then
+            result.ShouldEqual("Embedded3 Text");
+        }
+
+        [Fact]
         public void Should_retrieve_static_content_with_relative_path()
         {
             // Given

--- a/src/Nancy.Embedded/Conventions/EmbeddedStaticContentConventionBuilder.cs
+++ b/src/Nancy.Embedded/Conventions/EmbeddedStaticContentConventionBuilder.cs
@@ -99,7 +99,7 @@
                 }
 
                 var resourceName =
-                    Path.GetDirectoryName(assembly.GetName().Name + fileName.Substring(2)).Replace('\\', '.');
+                    Path.GetDirectoryName(assembly.GetName().Name + fileName.Substring(2)).Replace('\\', '.').Replace('-', '_');
 
                 fileName =
                     Path.GetFileName(fileName);


### PR DESCRIPTION
When msbuild compiles embedded resources into assemblies, hyphens are replaced with underscores in foldernames. This causes a mismatch when the EmbeddedStaticContentConventionBuilder is used to locate a resource, as it is still expecting the folder names to contain the hyphens.
