### PR TITLE
Added support for matchers in SSVE

### DIFF
--- a/src/Nancy.ViewEngines.Markdown.Tests/MarkdownViewEngineFixture.cs
+++ b/src/Nancy.ViewEngines.Markdown.Tests/MarkdownViewEngineFixture.cs
@@ -18,10 +18,10 @@
         public MarkdownViewEngineFixture()
         {
             this.renderContext = A.Fake<IRenderContext>();
-            this.viewEngine = new MarkDownViewEngine(new SuperSimpleViewEngine());
+            this.viewEngine = new MarkDownViewEngine(new SuperSimpleViewEngine(Enumerable.Empty<ISuperSimpleViewEngineMatcher>()));
 
             this.rootPathProvider = A.Fake<IRootPathProvider>();
-            
+
             A.CallTo(() => this.rootPathProvider.GetRootPath()).Returns(Path.Combine(Environment.CurrentDirectory, "Markdown"));
 
             this.fileSystemViewLocationProvider = new FileSystemViewLocationProvider(this.rootPathProvider, new DefaultFileSystemReader());

--- a/src/Nancy/Diagnostics/DiagnosticsViewRenderer.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsViewRenderer.cs
@@ -1,7 +1,7 @@
 namespace Nancy.Diagnostics
 {
     using System.IO;
-
+    using System.Linq;
     using Nancy.Localization;
 
     using Responses;
@@ -14,7 +14,7 @@ namespace Nancy.Diagnostics
         private readonly NancyContext context;
         private static readonly IViewResolver ViewResolver = new DiagnosticsViewResolver();
 
-        private static readonly IViewEngine Engine = new SuperSimpleViewEngineWrapper();
+        private static readonly IViewEngine Engine = new SuperSimpleViewEngineWrapper(Enumerable.Empty<ISuperSimpleViewEngineMatcher>());
 
         public DiagnosticsViewRenderer(NancyContext context)
         {

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -412,9 +412,11 @@
     <Compile Include="ViewEngines\IViewRenderer.cs" />
     <Compile Include="ViewEngines\IViewResolver.cs" />
     <Compile Include="ViewEngines\ResourceViewLocationProvider.cs" />
+    <Compile Include="ViewEngines\SuperSimpleViewEngine\ISuperSimpleViewEngineMatcher.cs" />
     <Compile Include="ViewEngines\SuperSimpleViewEngine\IViewEngineHost.cs" />
     <Compile Include="ViewEngines\SuperSimpleViewEngine\NancyViewEngineHost.cs" />
     <Compile Include="ViewEngines\SuperSimpleViewEngine\SuperSimpleViewEngine.cs" />
+    <Compile Include="ViewEngines\SuperSimpleViewEngine\SuperSimpleViewEngineRegistrations.cs" />
     <Compile Include="ViewEngines\SuperSimpleViewEngine\SuperSimpleViewEngineWrapper.cs" />
     <Compile Include="ViewEngines\ViewEngineApplicationStartup.cs" />
     <Compile Include="ViewEngines\ViewEngineStartupContext.cs" />

--- a/src/Nancy/ViewEngines/SuperSimpleViewEngine/ISuperSimpleViewEngineMatcher.cs
+++ b/src/Nancy/ViewEngines/SuperSimpleViewEngine/ISuperSimpleViewEngineMatcher.cs
@@ -1,0 +1,17 @@
+﻿namespace Nancy.ViewEngines.SuperSimpleViewEngine
+{
+    /// <summary>
+    /// Matches and modifes the content of a rendered SuperSimpleViewEngine view.
+    /// </summary>
+    public interface ISuperSimpleViewEngineMatcher
+    {
+        /// <summary>
+        /// Invokes the matcher on the content of the rendered view.
+        /// </summary>
+        /// <param name="content">The content of the rendered view.</param>
+        /// <param name="model">The model that was passed to the view.</param>
+        /// <param name="host">The <see cref="IViewEngineHost"/> host.</param>
+        /// <returns>The modified version of the view.</returns>
+        string Invoke(string content, dynamic model, IViewEngineHost host);
+    }
+}

--- a/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngineRegistrations.cs
+++ b/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngineRegistrations.cs
@@ -1,0 +1,40 @@
+﻿namespace Nancy.ViewEngines.SuperSimpleViewEngine
+{
+    using System.Collections.Generic;
+    using Bootstrapper;
+
+    /// <summary>
+    /// Performs application registations for the SuperSimpleViewEngine.
+    /// </summary>
+    public class SuperSimpleViewEngineRegistrations : IApplicationRegistrations
+    {
+        /// <summary>
+        /// Gets the type registrations to register for this startup task
+        /// </summary>
+        public IEnumerable<TypeRegistration> TypeRegistrations
+        {
+            get { return null; }
+        }
+
+        /// <summary>
+        /// Gets the collection registrations to register for this startup task
+        /// </summary>
+        public IEnumerable<CollectionTypeRegistration> CollectionTypeRegistrations
+        {
+            get
+            {
+                return new[] {
+                    new CollectionTypeRegistration(typeof(ISuperSimpleViewEngineMatcher), AppDomainAssemblyTypeScanner.TypesOf<ISuperSimpleViewEngineMatcher>(ScanMode.All))
+                };
+            }
+        }
+
+        /// <summary>
+        /// Gets the instance registrations to register for this startup task
+        /// </summary>
+        public IEnumerable<InstanceRegistration> InstanceRegistrations
+        {
+            get { return null; }
+        }
+    }
+}

--- a/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngineWrapper.cs
+++ b/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngineWrapper.cs
@@ -1,9 +1,7 @@
 ﻿namespace Nancy.ViewEngines.SuperSimpleViewEngine
 {
-    using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Threading;
     using Responses;
 
     /// <summary>
@@ -19,7 +17,7 @@
         /// <summary>
         /// The engine itself
         /// </summary>
-        private readonly SuperSimpleViewEngine viewEngine = new SuperSimpleViewEngine();
+        private readonly SuperSimpleViewEngine viewEngine;
 
         /// <summary>
         /// Gets the extensions file extensions that are supported by the view engine.
@@ -31,6 +29,20 @@
             get { return this.extensions; }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SuperSimpleViewEngineWrapper"/> class, using
+        /// the provided <see cref="ISuperSimpleViewEngineMatcher"/> extensions.
+        /// </summary>
+        /// <param name="matchers">The matchers to use with the engine.</param>
+        public SuperSimpleViewEngineWrapper(IEnumerable<ISuperSimpleViewEngineMatcher> matchers)
+        {
+            this.viewEngine = new SuperSimpleViewEngine(matchers);
+        }
+
+        /// <summary>
+        /// Initialise the view engine (if necessary)
+        /// </summary>
+        /// <param name="viewEngineStartupContext">Startup context</param>
         public void Initialize(ViewEngineStartupContext viewEngineStartupContext)
         {
         }
@@ -40,17 +52,18 @@
         /// </summary>
         /// <param name="viewLocationResult">A <see cref="ViewLocationResult"/> instance, containing information on how to get the view template.</param>
         /// <param name="model">The model that should be passed into the view</param>
-        /// <returns>A response.</returns>
+        /// <param name="renderContext">An <see cref="IRenderContext"/> instance.</param>
+        /// <returns>A response</returns>
         public Response RenderView(ViewLocationResult viewLocationResult, dynamic model, IRenderContext renderContext)
         {
             return new HtmlResponse(contents: s =>
-                {
-                    var writer = new StreamWriter(s);
-                    var templateContents = renderContext.ViewCache.GetOrAdd(viewLocationResult, vr => vr.Contents.Invoke().ReadToEnd());
+            {
+                var writer = new StreamWriter(s);
+                var templateContents = renderContext.ViewCache.GetOrAdd(viewLocationResult, vr => vr.Contents.Invoke().ReadToEnd());
 
-                    writer.Write(this.viewEngine.Render(templateContents, model, new NancyViewEngineHost(renderContext)));
-                    writer.Flush();
-                });
+                writer.Write(this.viewEngine.Render(templateContents, model, new NancyViewEngineHost(renderContext)));
+                writer.Flush();
+            });
         }
     }
 }


### PR DESCRIPTION
By implementing `ISuperSimpleViewEngineMatcher` you can parse the content of a rendered SSVE view and modify it, before it's sent back
