### PR TITLE
Body populated with error when XML/JSON serialization takes place

### DIFF
--- a/src/Nancy.Testing.Tests/BrowserFixture.cs
+++ b/src/Nancy.Testing.Tests/BrowserFixture.cs
@@ -353,6 +353,19 @@ namespace Nancy.Testing.Tests
             result.Body.AsString().ShouldNotBeEmpty();
         }
 
+        [Theory]
+        [InlineData("application/json")]
+        [InlineData("application/xml")]
+        public void Should_return_no_error_message_on_cyclical_exception_when_disabled_error_trace(string accept)
+        {
+            //Given/When
+            StaticConfiguration.DisableErrorTraces = true;
+            var result = browser.Get("/cyclical", with => with.Accept(accept));
+
+            //Then
+            result.Body.AsString().ShouldBeEmpty();
+        }
+
         public class EchoModel
         {
             public string SomeString { get; set; }

--- a/src/Nancy.Testing.Tests/BrowserFixture.cs
+++ b/src/Nancy.Testing.Tests/BrowserFixture.cs
@@ -346,8 +346,10 @@ namespace Nancy.Testing.Tests
         [InlineData("application/xml")]
         public void Should_return_error_message_on_cyclical_exception(string accept)
         {
+            //Given/When
             var result = browser.Get("/cyclical", with => with.Accept(accept));
 
+            //Then
             result.Body.AsString().ShouldNotBeEmpty();
         }
 

--- a/src/Nancy.Testing.Tests/BrowserFixture.cs
+++ b/src/Nancy.Testing.Tests/BrowserFixture.cs
@@ -16,6 +16,8 @@ namespace Nancy.Testing.Tests
     using FakeItEasy;
     using Nancy.Authentication.Forms;
 
+    using Xunit.Extensions;
+
     public class BrowserFixture
     {
         private readonly Browser browser;
@@ -339,12 +341,14 @@ namespace Nancy.Testing.Tests
             cookieValue.ShouldEqual(cookieContents);
         }
 
-        [Fact]
-        public void Should_return_error_message_on_cyclical_exception()
+        [Theory]
+        [InlineData("application/json")]
+        [InlineData("application/xml")]
+        public void Should_return_error_message_on_cyclical_exception(string accept)
         {
-            var result = browser.Get("/cyclical", with => with.Accept("application/json"));
+            var result = browser.Get("/cyclical", with => with.Accept(accept));
 
-            result.Body.AsString().ShouldEqual("Circular reference detected.");
+            result.Body.AsString().ShouldNotBeEmpty();
         }
 
         public class EchoModel

--- a/src/Nancy/Responses/DefaultJsonSerializer.cs
+++ b/src/Nancy/Responses/DefaultJsonSerializer.cs
@@ -46,9 +46,9 @@
                 {
                     serializer.Serialize(model, writer);
                 }
-                catch (InvalidOperationException iox)
+                catch (Exception exception)
                 {
-                    writer.Write(iox.Message);
+                    writer.Write(exception.Message);
                 }                
             }
         }

--- a/src/Nancy/Responses/DefaultJsonSerializer.cs
+++ b/src/Nancy/Responses/DefaultJsonSerializer.cs
@@ -42,8 +42,14 @@
                 var serializer = new JavaScriptSerializer(null, false, JsonSettings.MaxJsonLength, JsonSettings.MaxRecursions);
             
                 serializer.RegisterConverters(JsonSettings.Converters);
-
-                serializer.Serialize(model, writer);
+                try
+                {
+                    serializer.Serialize(model, writer);
+                }
+                catch (InvalidOperationException iox)
+                {
+                    writer.Write(iox.Message);
+                }                
             }
         }
 

--- a/src/Nancy/Responses/DefaultJsonSerializer.cs
+++ b/src/Nancy/Responses/DefaultJsonSerializer.cs
@@ -48,7 +48,10 @@
                 }
                 catch (Exception exception)
                 {
-                    writer.Write(exception.Message);
+                    if (!StaticConfiguration.DisableErrorTraces)
+                    {
+                        writer.Write(exception.Message);
+                    }
                 }                
             }
         }

--- a/src/Nancy/Responses/DefaultXmlSerializer.cs
+++ b/src/Nancy/Responses/DefaultXmlSerializer.cs
@@ -36,9 +36,9 @@
         /// <returns>Serialised object</returns>
         public void Serialize<TModel>(string contentType, TModel model, Stream outputStream)
         {
-            var serializer = new XmlSerializer(typeof(TModel));
             try
             {
+                var serializer = new XmlSerializer(typeof(TModel));
                 serializer.Serialize(outputStream, model);
             }
             catch (Exception exception)

--- a/src/Nancy/Responses/DefaultXmlSerializer.cs
+++ b/src/Nancy/Responses/DefaultXmlSerializer.cs
@@ -43,8 +43,11 @@
             }
             catch (Exception exception)
             {
-                var bytes = Encoding.UTF8.GetBytes(exception.Message);
-                outputStream.Write(bytes, 0, exception.Message.Length);
+                if (!StaticConfiguration.DisableErrorTraces)
+                {
+                    var bytes = Encoding.UTF8.GetBytes(exception.Message);
+                    outputStream.Write(bytes, 0, exception.Message.Length);
+                }
             }
 
         }

--- a/src/Nancy/Responses/DefaultXmlSerializer.cs
+++ b/src/Nancy/Responses/DefaultXmlSerializer.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Text;
     using System.Xml.Serialization;
 
     public class DefaultXmlSerializer : ISerializer
@@ -36,7 +37,16 @@
         public void Serialize<TModel>(string contentType, TModel model, Stream outputStream)
         {
             var serializer = new XmlSerializer(typeof(TModel));
-            serializer.Serialize(outputStream, model);
+            try
+            {
+                serializer.Serialize(outputStream, model);
+            }
+            catch (Exception exception)
+            {
+                var bytes = Encoding.UTF8.GetBytes(exception.Message);
+                outputStream.Write(bytes, 0, exception.Message.Length);
+            }
+
         }
 
         private static bool IsXmlType(string contentType)


### PR DESCRIPTION
I had a cyclical POCO reference that was marked with XmlIgnore attributes and when a request came in and I used application/xml this returned my data however when using application/json I got a blank response.

This puts a try/catch around the call to Serialize and writes the exception message to the stream.