### PR TITLE
Removed empty view location convention from error

### DIFF
--- a/src/Nancy/ViewEngines/DefaultViewFactory.cs
+++ b/src/Nancy/ViewEngines/DefaultViewFactory.cs
@@ -99,15 +99,26 @@
 
         private string[] GetInspectedLocations(string viewName, dynamic model, ViewLocationContext viewLocationContext)
         {
-            var strings = new List<string>();
+            var inspectedLocations = new List<string>();
+
             foreach (var convention in conventions)
             {
                 try
                 {
-                    strings.Add(convention.Invoke(viewName, model, viewLocationContext));
-                } catch{ }                
+                    var location =
+                        convention.Invoke(viewName, model, viewLocationContext);
+
+                    if (!string.IsNullOrWhiteSpace(location))
+                    {
+                        inspectedLocations.Add(location);
+                    }
+                }
+                catch
+                {
+                }                
             }
-            return strings.ToArray();
+
+            return inspectedLocations.ToArray();
         }
 
         private static object GetSafeModel(object model)


### PR DESCRIPTION
A view location convention returns empty at times and those will
never be used to try and locate the view. If a view cannot be found
then we display an error page with the conventions that was used and
it looks a bit strange with all the empty entries.

This change excludes all empty convention results from the error page
and only display those conventions that was actually used to attempt
to locate the view.
