### PR TITLE
Fix to cookie parsing algorithm in RequestHeaders

### DIFF
--- a/src/Nancy.Tests/Unit/RequestHeadersFixture.cs
+++ b/src/Nancy.Tests/Unit/RequestHeadersFixture.cs
@@ -788,6 +788,22 @@
             ValidateCookie(headers.Cookie.Last(), "name", "value");
         }
 
+        [Fact]
+        public void Should_parse_cookie_headers_when_delimited_by_semicolon()
+        {
+          // Given
+          var rawValues = new[] { "foo=bar", "name=value ; third=  something=stuff  " };
+          var rawHeaders = new Dictionary<string, IEnumerable<string>> { { "Cookie", rawValues } };
+
+          // When
+          var headers = new RequestHeaders(rawHeaders);
+
+          // Then
+          ValidateCookie(headers.Cookie.ElementAt(0), "foo", "bar");
+          ValidateCookie(headers.Cookie.ElementAt(1), "name", "value");
+          ValidateCookie(headers.Cookie.ElementAt(2), "third", "  something=stuff");
+        }
+
         [Theory]
         [InlineData("cookie")]
         [InlineData("COokIE")]

--- a/src/Nancy/RequestHeaders.cs
+++ b/src/Nancy/RequestHeaders.cs
@@ -349,14 +349,14 @@ namespace Nancy
             }
 
             string[] cookieStrings;
-            string[] cookieData;
+            int equalPos;
             foreach (var cookie in cookies)
             {
                 cookieStrings = cookie.Split(';');
                 foreach (var cookieString in cookieStrings)
                 {
-                    cookieData = cookieString.Trim().Split('=');
-                    yield return new NancyCookie(cookieData[0], cookieData[1]);
+                    equalPos = cookieString.IndexOf('=');
+                    if (equalPos >= 0) yield return new NancyCookie(cookieString.Substring(0, equalPos).TrimStart(), cookieString.Substring(equalPos+1).TrimEnd());
                 }
             }
         }


### PR DESCRIPTION
The cookie parsing algorithm in the `RequestHeaders` class does not correctly handle more than one cookie.
