### PR TITLE
Prevent OPTIONS route clobber

### DIFF
--- a/src/Nancy/Routing/DefaultRouteResolver.cs
+++ b/src/Nancy/Routing/DefaultRouteResolver.cs
@@ -39,10 +39,10 @@
 
             if (!results.Any())
             {
-				if (this.IsOptionsRequest(context))
-				{
-					return this.BuildOptionsResult(context);
-				}
+                if (this.IsOptionsRequest(context))
+                {
+                    return this.BuildOptionsResult(context);
+                }
                 return this.GetNotFoundResult(context);
             }
 


### PR DESCRIPTION
Moved the IsOptionsRequest conditional branch to only execute if no
defined OPTIONS route for the context exists. Otherwise, even if you
define an OPTIONS route manually, the auto-OPTIONS conditional clobbers
the Response, preventing custom additions such as CORS headers.

Addresses discussion at https://github.com/NancyFx/Nancy/commit/604327a00286f39f925840c2b1678c69e2d67626#commitcomment-3148154
