### PR TITLE
Decode the URL before checking the segments and capturing values

### DIFF
--- a/src/Nancy/Routing/DefaultRouteResolver.cs
+++ b/src/Nancy/Routing/DefaultRouteResolver.cs
@@ -4,6 +4,8 @@
     using System.Linq;
 
     using Nancy;
+    using Nancy.Helpers;
+
     using Trie;
 
     using MatchResult = Trie.MatchResult;
@@ -40,7 +42,9 @@
                 return this.BuildOptionsResult(context);
             }
 
-            var results = this.trie.GetMatches(GetMethod(context), context.Request.Path, context);
+            var pathDecoded = HttpUtility.UrlDecode(context.Request.Path);
+
+            var results = this.trie.GetMatches(GetMethod(context), pathDecoded, context);
 
             if (!results.Any())
             {


### PR DESCRIPTION
Currently if you request a URL in the browser with a space, it encodes the URL:

`http://www.mysite.com/some path`

Becomes

`http://www.mysite.com/some%20path`

This prevents routing to look for spaces, and captured routes to contain %20 rather than the space.

Change decodes the URL first then passes it in for checking, ensuring that route checking is done on an un-encoded URL and the captured values are not encoded.

Possible breaking change for some people.
