### PR TITLE
Check if 'certificate' is present before checking length

### DIFF
--- a/src/Nancy.Hosting.Aspnet/NancyHandler.cs
+++ b/src/Nancy.Hosting.Aspnet/NancyHandler.cs
@@ -61,7 +61,9 @@ namespace Nancy.Hosting.Aspnet
                                };
             byte[] certificate = null;
 
-            if (context.Request.ClientCertificate != null && context.Request.ClientCertificate.Certificate.Length != 0)
+            if (context.Request.ClientCertificate != null &&
+                context.Request.ClientCertificate.IsPresent &&
+                context.Request.ClientCertificate.Certificate.Length != 0)
             {
                 certificate = context.Request.ClientCertificate.Certificate;
             }


### PR DESCRIPTION
Attempting to access the length of a 'non-present' certificate throws a null reference exception when running Nancy as an ASP.NET app under Mono's `fastcgi-mono-server4` host

To avoid the exception, this patch first checks that the certificate `IsPresent` before accessing the certificate's `Length` property.
