### PR TITLE
Fixed #1090

### DIFF
--- a/src/Nancy/IO/RequestStream.cs
+++ b/src/Nancy/IO/RequestStream.cs
@@ -433,7 +433,13 @@
                 return;
             }
 
-            this.stream.Position = 0;
+            // Seek to 0 if we can, although if we can't seek, and we've already written (if the size is unknown) then
+            // we are screwed anyway, and some streams that don't support seek also don't let you read hte position so
+            // there's no real way to check :-/
+            if (this.stream.CanSeek)
+            {
+                this.stream.Position = 0;
+            }
             this.stream.CopyTo(targetStream, 8196);
             if (this.stream.CanSeek)
             {


### PR DESCRIPTION
Only seek the source stream on switch if seeking is available.
Technically we could get into a position where we lose some of the body
contents, but as we can't check the current position on the self host
stream that isn't seekable there's no much we can do inside the
RequestStream class.
