### PR TITLE
Client cert now comes in synchronous. Solving #1116.

### DIFF
--- a/src/Nancy.Hosting.Self/NancyHost.cs
+++ b/src/Nancy.Hosting.Self/NancyHost.cs
@@ -153,8 +153,6 @@
 
         private Request ConvertRequestToNancyRequest(HttpListenerRequest request)
         {
-            var asyncResult = request.BeginGetClientCertificate(null, null);
-
             var baseUri = baseUriList.FirstOrDefault(uri => uri.IsCaseInsensitiveBaseOf(request.Url));
 
             if (baseUri == null)
@@ -178,7 +176,8 @@
             };
 
             byte[] certificate = null;
-            var x509Certificate = request.EndGetClientCertificate(asyncResult);
+            
+            var x509Certificate = request.GetClientCertificate();
 
             if (x509Certificate != null)
             {


### PR DESCRIPTION
Getting the client certificate asynchronously resulted in an exception coming from somewhere deep within the bowels of the .NET framework. As far as I can see from here it shouldn't happen but this also solves it. And it's not that the server will halt for very long times on getting the client certificate.
