### PR TITLE
Allow overriding of JSON deserialization length for unit testing.

### DIFF
--- a/src/Nancy.Testing/BrowserResponseBodyWrapperExtensions.cs
+++ b/src/Nancy.Testing/BrowserResponseBodyWrapperExtensions.cs
@@ -58,6 +58,18 @@ namespace Nancy.Testing
             var serializer = 
                 new JavaScriptSerializer();
 
+            return bodyWrapper.DeserializeJson<TModel>(serializer);
+        }
+
+        /// <summary>
+        /// Gets the deserialized representation of the JSON in the response body.
+        /// </summary>
+        /// <typeparam name="TModel">The type that the JSON response body should be deserialized to.</typeparam>
+        /// <param name="bodyWrapper">An instance of the <see cref="BrowserResponseBodyWrapper"/> that the extension should be invoked on.</param>
+        /// <param name="serializer">An instance of <see cref="JavaScriptSerializer"/>, controlling the deserialization.</param>
+        /// <value>A <typeparamref name="TModel"/> instance representation of the HTTP response body.</value>
+        public static TModel DeserializeJson<TModel>(this BrowserResponseBodyWrapper bodyWrapper, JavaScriptSerializer serializer)
+        {
             return serializer.Deserialize<TModel>(bodyWrapper.AsString());
         }
 

--- a/src/Nancy/Json/JavaScriptSerializer.cs
+++ b/src/Nancy/Json/JavaScriptSerializer.cs
@@ -72,7 +72,7 @@ namespace Nancy.Json
         {
         }
 #endif
-        internal JavaScriptSerializer(JavaScriptTypeResolver resolver, bool registerConverters, int maxJsonLength, int recursionLimit)
+        public JavaScriptSerializer(JavaScriptTypeResolver resolver, bool registerConverters, int maxJsonLength, int recursionLimit)
         {
             _typeResolver = resolver;
 


### PR DESCRIPTION
- Made JavaScriptSerializer constructor public, allowing overriding of
  parameters.
- Allow using a different instance of JavaScriptSerializer in
  BrowserResponseBodyWrapperExtensions.DeserializeJson<TModel>().

Fixes #1147.
