### PR TITLE
Fixed SSVE support for conditionals on ViewBag

### DIFF
--- a/src/Nancy.Tests/Unit/ViewEngines/SuperSimpleViewEngineTests.cs
+++ b/src/Nancy.Tests/Unit/ViewEngines/SuperSimpleViewEngineTests.cs
@@ -37,6 +37,19 @@
         }
 
         [Fact]
+        public void Should_not_throw_when_viewbag_property_is_null()
+        {
+            const string input = @"<html><head></head><body>Hey@If.Context.ViewBag.HaveMessage;Yay message!@EndIf;</body></html>";
+            var context = new { ViewBag = (dynamic)new DynamicDictionary() };
+
+            ((FakeViewEngineHost)this.fakeHost).Context = context;
+
+            var output = viewEngine.Render(input, null, this.fakeHost);
+
+            Assert.Equal(@"<html><head></head><body>Hey</body></html>", output);
+        }
+
+        [Fact]
         public void Should_replace_primitive_model_with_value()
         {
             // Given

--- a/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngine.cs
+++ b/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngine.cs
@@ -269,7 +269,7 @@ namespace Nancy.ViewEngines.SuperSimpleViewEngine
                 return substitutionObject == null;
             }
 
-            if (substitutionObject.GetType().GetProperty("Value") != null)
+            if (substitutionObject != null && substitutionObject.GetType().GetProperty("Value") != null)
             {
                 object value = ((dynamic)substitutionObject).Value;
                 if (value is bool?)


### PR DESCRIPTION
This SSVE markup:

```
@Context.ViewBag.HaveMessage;<br />
@If.Context.ViewBag.HaveMessage;
    Yay Message!
@EndIf;
```

**Produced in Nancy:**

```
True
```

**Produced in SSVE test:**

```
True
Yay Message!
```

```
[Fact]
public void Should_evaluate_context_conditional()
{
    const string input = @"@Context.ViewBag.HaveMessage;! @If.Context.ViewBag.HaveMessage;Yay message!@EndIf;";
    var context = new { ViewBag = (dynamic)new DynamicDictionary() };
    context.ViewBag.HaveMessage = true;

    ((FakeViewEngineHost)this.fakeHost).Context = context;

    var output = viewEngine.Render(input, null, this.fakeHost);

    Assert.Equal(@"True! Yay message!", output);
}
```
