### PR TITLE
Fix problem with JsonBodyDeserializer and unsigned Nullable<> types

### DIFF
--- a/src/Nancy.Tests/Unit/ModelBinding/DefaultBodyDeserializers/JsonBodyDeserializerFixture.cs
+++ b/src/Nancy.Tests/Unit/ModelBinding/DefaultBodyDeserializers/JsonBodyDeserializerFixture.cs
@@ -199,6 +199,21 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
             result.ListOfComplexObjectsProperty[1].Value2.ShouldEqual("four");
         }
 
+        [Fact]
+        public void Should_Deserialize_Signed_And_Unsigned_Nullable_Numeric_Types()
+        {
+            //Given
+            const string json = "{F1: 1, F2: 2, F3: 3}";
+
+            //When
+            var model = this.serializer.Deserialize<ModelWithNullables> (json);
+
+            //Should
+            Assert.Equal (1, model.F1);
+            Assert.Equal ((uint)2, model.F2);
+            Assert.Equal ((uint)3, model.F3);
+        }
+
 #if !__MonoCS__
         [Fact]
         public void Should_Serialize_Doubles_In_Different_Cultures()
@@ -348,4 +363,12 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
 
         public double Longitude { get; set; }
     }
+
+    public class ModelWithNullables 
+    {
+        public int? F1 { get; set; } 
+        public uint F2 { get; set; } 
+        public uint? F3 { get; set; } 
+    }
+
 }

--- a/src/Nancy/Json/JavaScriptSerializer.cs
+++ b/src/Nancy/Json/JavaScriptSerializer.cs
@@ -164,16 +164,22 @@ namespace Nancy.Json
                 return c.ConvertFrom(obj);
             }
 
-            /*
-             * Take care of the special case whereas in JSON an empty string ("") really means 
-             * an empty value 
-             * (see: https://bugzilla.novell.com/show_bug.cgi?id=328836)
-             */
+
             if ((type.IsGenericType) && (type.GetGenericTypeDefinition() == typeof(Nullable<>)))
             {
+                /*
+                 * Take care of the special case whereas in JSON an empty string ("") really means 
+                 * an empty value 
+                 * (see: https://bugzilla.novell.com/show_bug.cgi?id=328836)
+                 */
                 string s = obj as String;
-                if (String.IsNullOrEmpty(s))
-                    return null;
+                if (s != null)
+                {
+                    if (s == string.Empty)
+                        return null;
+                }
+                else //It is not string at all, convert to Nullable<> type, from int to uint for example
+                    return Convert.ChangeType (obj, type.GetGenericArguments ()[0]);
             }
 
             return Convert.ChangeType(obj, type);


### PR DESCRIPTION
Now JsonBodyDeserializer is unable to deserialize uint? if it is represented as integer in the source JSON. I. e.

class Model
{
    public uint? Value {get;set;}
}

{Value: "1"} - OK
{Value: 1} - null

Here is a patch to fix this issue
