### PR TITLE
Added resolved route to NancyContext

### DIFF
--- a/src/Nancy.Tests/Unit/Routing/DefaultRequestDispatcherFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/DefaultRequestDispatcherFixture.cs
@@ -285,6 +285,36 @@ namespace Nancy.Tests.Unit.Routing
         }
 
         [Fact]
+        public void Should_set_the_context_resolved_route_from_resolve_result()
+        {
+            // Given
+            const string expectedPath = "/the/path";
+
+            var context =
+                new NancyContext
+                {
+                    Request = new FakeRequest("GET", expectedPath)
+                };
+
+            var expectedRoute = new FakeRoute();
+
+            var resolveResult = new ResolveResult(
+               expectedRoute,
+               new DynamicDictionary(),
+               null,
+               null,
+               null);
+
+            A.CallTo(() => this.routeResolver.Resolve(context)).Returns(resolveResult);
+
+            // When
+            this.requestDispatcher.Dispatch(context, new CancellationToken());
+
+            // Then
+            context.ResolvedRoute.ShouldBeSameAs(expectedRoute);
+        }
+
+        [Fact]
         public void Should_invoke_route_resolver_with_context_for_current_request()
         {
             // Given

--- a/src/Nancy/NancyContext.cs
+++ b/src/Nancy/NancyContext.cs
@@ -6,6 +6,7 @@ namespace Nancy
     using System.Linq;
     using Nancy.Diagnostics;
     using Nancy.Responses.Negotiation;
+    using Nancy.Routing;
     using Nancy.Security;
     using Nancy.Validation;
     using System.Globalization;
@@ -36,6 +37,11 @@ namespace Nancy
         /// Gets the dictionary for storage of per-request items. Disposable items will be disposed when the context is.
         /// </summary>
         public IDictionary<string, object> Items { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the resolved route 
+        /// </summary>
+        public Route ResolvedRoute { get; set; }
 
         /// <summary>
         /// Gets or sets the parameters for the resolved route 

--- a/src/Nancy/Routing/DefaultRequestDispatcher.cs
+++ b/src/Nancy/Routing/DefaultRequestDispatcher.cs
@@ -46,6 +46,7 @@ namespace Nancy.Routing
             var resolveResult = this.Resolve(context);
 
             context.Parameters = resolveResult.Parameters;
+            context.ResolvedRoute = resolveResult.Route;
 
             var preReqTask = ExecuteRoutePreReq(context, cancellationToken, resolveResult.Before);
 


### PR DESCRIPTION
I need a place to do JSON Schema Validation in a REST API. This needs to know what the resolved route is, and if I want to do that elsewhere than in the route action, then I need access to the Route from where ever that is.

With this pull request, I will have access to the route in the Before Module Hook and can fail fast and early with a convention based schema validation.

With access to the route we can differentiate with different schemas for POST, PUT and PATCH.
