### PR TITLE
Allow projects to specify target framework.

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -55,7 +55,7 @@ end
 desc "Compile solution file for Mono"
 xbuild :compilemono => [:assembly_info] do |xb|
     xb.solution = SOLUTION_FILE
-    xb.properties = { :configuration => CONFIGURATIONMONO, "TargetFrameworkProfile" => "", "TargetFrameworkVersion" => "v4.0" }
+    xb.properties = { :configuration => CONFIGURATIONMONO, "TargetFrameworkProfile" => "" }
 end
 
 


### PR DESCRIPTION
Under mono, the compiler fails due to it thinking the new AsyncDemo is a 4.0 project, because of the hard coded v4.0 target with xbuild.
