### PR TITLE
Allow arbitrary cast of DynamicDictionaryValue

### DIFF
--- a/src/Nancy.Tests/Unit/DynamicDictionaryValueFixture.cs
+++ b/src/Nancy.Tests/Unit/DynamicDictionaryValueFixture.cs
@@ -968,5 +968,19 @@
             //Then
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public void Should_be_able_to_cast_to_arbitrary_object()
+        {
+            //Given
+            dynamic value = new DynamicDictionaryValue(new EventArgs());
+
+            //When
+            //Then
+            Assert.DoesNotThrow(() =>
+            {
+                EventArgs e = (EventArgs)value;
+            });
+        }
     }
 }

--- a/src/Nancy/DynamicDictionaryValue.cs
+++ b/src/Nancy/DynamicDictionaryValue.cs
@@ -255,9 +255,17 @@
 
                 var typeCode = Type.GetTypeCode(binderType);
 
-                if (typeCode == TypeCode.Object) // something went wrong here
+                if (typeCode == TypeCode.Object)
                 {
-                    return false;
+                    if (binderType.IsAssignableFrom(value.GetType()))
+                    {
+                        result = value;
+                        return true;
+                    }
+                    else
+                    {
+                        return false;
+                    }
                 }
 
                 result = Convert.ChangeType(value, typeCode);


### PR DESCRIPTION
Casting of DynamicDictionaryValue was coded to fail when casting to a
reference type. This is fixed.
