### PR TITLE
Moved default namespace init code into constructor of RazorViewEngine.

### DIFF
--- a/src/Nancy.ViewEngines.Razor/RazorViewEngine.cs
+++ b/src/Nancy.ViewEngines.Razor/RazorViewEngine.cs
@@ -162,7 +162,10 @@
                 {
                     foreach (var n in namespaces)
                     {
-                        engineHost.NamespaceImports.Add(n);
+                        if (!string.IsNullOrWhiteSpace(n))
+                        {
+                            engineHost.NamespaceImports.Add(n);
+                        }
                     }
                 }
             }
@@ -415,6 +418,11 @@
 
         private static void AddModelNamespace(GeneratorResults razorResult, Type modelType)
         {
+            if (string.IsNullOrWhiteSpace(modelType.Namespace))
+            {
+                return;
+            }
+
             if (razorResult.GeneratedCode.Namespaces[0].Imports.OfType<CodeNamespaceImport>().Any(x => x.Namespace == modelType.Namespace))
             {
                 return;


### PR DESCRIPTION
fixes #1173

This is a fix for a threading related issue using the RazorViewEngine - whereby multiple threads manipulating RazorEngineHost.NamespaceImports can result in empty using statements in generated Razor ("using ;"). This resulted from the fact that RazorEngineHost.NamespaceImports is an instance of HashSet - which is not thread safe. Moving the init code into the constructor avoids this.
