### PR TITLE
Added static content convention extensions

### DIFF
--- a/src/Nancy/Conventions/NancyConventions.cs
+++ b/src/Nancy/Conventions/NancyConventions.cs
@@ -5,7 +5,6 @@
     using System.Linq;
     using System.Text;
     using System.Globalization;
-
     using Nancy.Bootstrapper;
     using ViewEngines;
 

--- a/src/Nancy/Conventions/StaticContentHelper.cs
+++ b/src/Nancy/Conventions/StaticContentHelper.cs
@@ -16,6 +16,7 @@
         ///     Directory["/images"] = "images";
         /// });
         /// </summary>
+        /// <param name="conventions">The conventions to add to.</param>
         /// <param name="staticConventions">The callback method allows you to describe the static content</param>
         public static void MapStaticContent(this NancyConventions conventions, Action<StaticFileContent, StaticDirectoryContent> staticConventions)
         {

--- a/src/Nancy/Conventions/StaticContentsConventionsExtensions.cs
+++ b/src/Nancy/Conventions/StaticContentsConventionsExtensions.cs
@@ -1,0 +1,34 @@
+﻿namespace Nancy.Conventions
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Extension methods to adding static content conventions.
+    /// </summary>
+    public static class StaticContentsConventionsExtensions
+    {
+        /// <summary>
+        /// Adds a directory-based convention for static convention.
+        /// </summary>
+        /// <param name="conventions">The conventions to add to.</param>
+        /// <param name="requestedPath">The path that should be matched with the request.</param>
+        /// <param name="contentPath">The path to where the content is stored in your application, relative to the root. If this is <see langword="null" /> then it will be the same as <paramref name="requestedPath"/>.</param>
+        /// <param name="allowedExtensions">A list of extensions that is valid for the conventions. If not supplied, all extensions are valid.</param>
+        public static void AddDirectory(this IList<Func<NancyContext, string, Response>> conventions, string requestedPath, string contentPath = null, params string[] allowedExtensions)
+        {
+            conventions.Add(StaticContentConventionBuilder.AddDirectory(requestedPath, contentPath, allowedExtensions));
+        }
+
+        /// <summary>
+        /// Adds a directory-based convention for static convention.
+        /// </summary>
+        /// <param name="conventions">The conventions to add to.</param>
+        /// <param name="requestedFile">The file that should be matched with the request.</param>
+        /// <param name="contentFile">The file that should be served when the requested path is matched.</param>
+        public static void AddFile(this IList<Func<NancyContext, string, Response>> conventions, string requestedFile, string contentFile)
+        {
+            conventions.Add(StaticContentConventionBuilder.AddFile(requestedFile, contentFile));
+        }
+    }
+}

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Conventions\StaticContentConventionBuilder.cs" />
     <Compile Include="Conventions\StaticContentHelper.cs" />
     <Compile Include="Conventions\StaticContentsConventions.cs" />
+    <Compile Include="Conventions\StaticContentsConventionsExtensions.cs" />
     <Compile Include="Conventions\StaticDirectoryContent.cs" />
     <Compile Include="Conventions\StaticFileContent.cs" />
     <Compile Include="Culture\DefaultCultureService.cs" />


### PR DESCRIPTION
A couple of extension methods that adds the functionality of `StaticContentConventionsBuilder` onto the static conventions

Helps shorting the syntax by enabling

``` c#
conventions.StaticContentsConventions.Add(
   StaticContentConventionBuilder.AddDirectory("assets", @"contentFolder/subFolder")
);
```

to be converted to

``` c#
conventions.StaticContentsConventions.AddDirectory("assets", @"contentFolder/subFolder");
```

and the same for `AddFile`
