### PR TITLE
disposed the (template) files/resources after using them

### DIFF
--- a/src/Nancy.Demo.MarkdownViewEngine/Modules/HomeModule.cs
+++ b/src/Nancy.Demo.MarkdownViewEngine/Modules/HomeModule.cs
@@ -43,8 +43,11 @@ namespace Nancy.Demo.MarkdownViewEngine.Modules
             var views = this.viewLocationProvider.GetLocatedViews(new[] { "md", "markdown" });
             var model = views.Select(x =>
             {
-                var markdown = x.Contents().ReadToEnd();
-                return new BlogModel(markdown);
+                using (var reader = x.Contents())
+                {
+                    var markdown = reader.ReadToEnd();
+                    return new BlogModel(markdown);
+                }
             })
             .Where(x => x.BlogDate.Date <= DateTime.Today) //Allow for future posts to be lined up but don't show
             .OrderByDescending(x => x.BlogDate)

--- a/src/Nancy.ViewEngines.DotLiquid/DotLiquidViewEngine.cs
+++ b/src/Nancy.ViewEngines.DotLiquid/DotLiquidViewEngine.cs
@@ -77,7 +77,11 @@
                 // Set the parsed template
                 parsed = renderContext.ViewCache.GetOrAdd(
                     viewLocationResult,
-                    x => Template.Parse(viewLocationResult.Contents.Invoke().ReadToEnd()));
+                    x =>
+                    {
+                        using (var reader = viewLocationResult.Contents.Invoke())
+                            return Template.Parse(reader.ReadToEnd());
+                    });
 
                 hashedModel = Hash.FromAnonymousObject(new
                 {

--- a/src/Nancy.ViewEngines.DotLiquid/LiquidNancyFileSystem.cs
+++ b/src/Nancy.ViewEngines.DotLiquid/LiquidNancyFileSystem.cs
@@ -67,7 +67,8 @@
                 // Or to parse here and store it in the cache before passing it back in not
                 if (viewLocation != null)
                 {
-                    return viewLocation.Contents.Invoke().ReadToEnd();
+                    using (var reader = viewLocation.Contents.Invoke())
+                        return reader.ReadToEnd();
                 }
             }
             throw new liquid.Exceptions.FileSystemException("Template file {0} not found", new[] { templateName });

--- a/src/Nancy.ViewEngines.Markdown/MarkDownViewEngine.cs
+++ b/src/Nancy.ViewEngines.Markdown/MarkDownViewEngine.cs
@@ -98,8 +98,9 @@ namespace Nancy.ViewEngines.Markdown
         /// </param>
         public string ConvertMarkdown(ViewLocationResult viewLocationResult)
         {
-            string content =
-                viewLocationResult.Contents().ReadToEnd();
+            string content;
+            using (var reader = viewLocationResult.Contents.Invoke())
+                content = reader.ReadToEnd();
 
             if (content.StartsWith("<!DOCTYPE html>"))
             {

--- a/src/Nancy.ViewEngines.Markdown/MarkdownViewEngineHost.cs
+++ b/src/Nancy.ViewEngines.Markdown/MarkdownViewEngineHost.cs
@@ -59,7 +59,9 @@
                 return "[ERR!]";
             }
 
-            var templateContent = viewLocationResult.Contents.Invoke().ReadToEnd();
+            string templateContent;
+            using (var reader = viewLocationResult.Contents.Invoke())
+                templateContent = reader.ReadToEnd();
 
             if (viewLocationResult.Name.ToLower() == "master" && validExtensions.Any(x => x.Equals(viewLocationResult.Extension, StringComparison.OrdinalIgnoreCase)))
             {
@@ -68,7 +70,8 @@
 
             if (!validExtensions.Any(x => x.Equals(viewLocationResult.Extension, StringComparison.OrdinalIgnoreCase)))
             {
-                return viewLocationResult.Contents.Invoke().ReadToEnd();
+                using (var reader = viewLocationResult.Contents.Invoke())
+                    return reader.ReadToEnd();
             }
 
             return parser.Transform(templateContent);

--- a/src/Nancy.ViewEngines.Nustache/NustacheViewEngine.cs
+++ b/src/Nancy.ViewEngines.Nustache/NustacheViewEngine.cs
@@ -33,7 +33,11 @@
         {
             var viewFactory = renderContext.ViewCache.GetOrAdd(
                 viewLocationResult,
-                x => this.GetCompiledTemplate<dynamic>(x.Contents.Invoke()));
+                x =>
+                {
+                    using (var reader = x.Contents.Invoke())
+                        return this.GetCompiledTemplate<dynamic>(reader);
+                });
 
             var view = viewFactory.Invoke();
 

--- a/src/Nancy.ViewEngines.Razor/RazorViewEngine.cs
+++ b/src/Nancy.ViewEngines.Razor/RazorViewEngine.cs
@@ -445,7 +445,10 @@
         {
             var viewFactory = renderContext.ViewCache.GetOrAdd(
                 viewLocationResult,
-                x => this.GetCompiledViewFactory(x.Extension, x.Contents.Invoke(), referencingAssembly, passedModelType, viewLocationResult));
+                x => {
+                    using(var reader = x.Contents.Invoke())
+                        return this.GetCompiledViewFactory(x.Extension, reader, referencingAssembly, passedModelType, viewLocationResult);
+                });
 
             var view = viewFactory.Invoke();
 

--- a/src/Nancy/ViewEngines/SuperSimpleViewEngine/NancyViewEngineHost.cs
+++ b/src/Nancy/ViewEngines/SuperSimpleViewEngine/NancyViewEngineHost.cs
@@ -49,7 +49,8 @@ namespace Nancy.ViewEngines.SuperSimpleViewEngine
                 return "[ERR!]";
             }
 
-            return viewLocationResult.Contents.Invoke().ReadToEnd();
+            using(var reader = viewLocationResult.Contents.Invoke())
+                return reader.ReadToEnd();
         }
 
         /// <summary>

--- a/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngineWrapper.cs
+++ b/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngineWrapper.cs
@@ -59,7 +59,11 @@
             return new HtmlResponse(contents: s =>
             {
                 var writer = new StreamWriter(s);
-                var templateContents = renderContext.ViewCache.GetOrAdd(viewLocationResult, vr => vr.Contents.Invoke().ReadToEnd());
+                var templateContents = renderContext.ViewCache.GetOrAdd(viewLocationResult, vr =>
+                {
+                    using (var reader = vr.Contents.Invoke())
+                        return reader.ReadToEnd();
+                });
 
                 writer.Write(this.viewEngine.Render(templateContents, model, new NancyViewEngineHost(renderContext)));
                 writer.Flush();


### PR DESCRIPTION
There are several places in the Nancy codebase where the filesystem/resource streams were not properly disposed of. This caused problems with accessing those files/resources.

I have wrapped all usages into a using block so they get disposed of as soon as they are not needed anymore.

Please let me know if you need more changes.
