### PR TITLE
Added helpful error message to 500 page

### DIFF
--- a/src/Nancy.ViewEngines.Razor/NancyRazorErrorView.cs
+++ b/src/Nancy.ViewEngines.Razor/NancyRazorErrorView.cs
@@ -8,6 +8,8 @@
     /// </summary>
     public class NancyRazorErrorView : NancyRazorViewBase
     {
+        private const string DisableErrorTracesTrueMessage = "Error details are currently disabled. Please set <code>StaticConfiguration.DisableErrorTraces = true;</code> to enable.";
+        
         private static string template;
 
         /// <summary>
@@ -39,7 +41,7 @@
         /// </summary>
         public override void Execute()
         {
-            base.WriteLiteral(Template.Replace("[DETAILS]", StaticConfiguration.DisableErrorTraces ? String.Empty : this.Message));
+            base.WriteLiteral(Template.Replace("[DETAILS]", StaticConfiguration.DisableErrorTraces ? DisableErrorTracesTrueMessage : this.Message));
         }
 
         private static string LoadResource(string filename)

--- a/src/Nancy/ErrorHandling/DefaultStatusCodeHandler.cs
+++ b/src/Nancy/ErrorHandling/DefaultStatusCodeHandler.cs
@@ -13,6 +13,8 @@ namespace Nancy.ErrorHandling
     /// </summary>
     public class DefaultStatusCodeHandler : IStatusCodeHandler
     {
+        private const string DisableErrorTracesTrueMessage = "Error details are currently disabled. Please set <code>StaticConfiguration.DisableErrorTraces = true;</code> to enable.";
+
         private readonly IDictionary<HttpStatusCode, string> errorPages;
 
         private readonly IDictionary<HttpStatusCode, Func<HttpStatusCode, NancyContext, string, string>> expansionDelegates;
@@ -115,7 +117,7 @@ namespace Nancy.ErrorHandling
 
         private static string PopulateErrorInfo(HttpStatusCode httpStatusCode, NancyContext context, string templateContents)
         {
-            return templateContents.Replace("[DETAILS]", StaticConfiguration.DisableErrorTraces ? String.Empty : context.GetExceptionDetails());
+            return templateContents.Replace("[DETAILS]", StaticConfiguration.DisableErrorTraces ? DisableErrorTracesTrueMessage : context.GetExceptionDetails());
         }
     }
 }

--- a/src/Nancy/ErrorHandling/Resources/500.html
+++ b/src/Nancy/ErrorHandling/Resources/500.html
@@ -79,6 +79,14 @@
     padding: 0;
     visibility: hidden;
   }
+  
+  code {
+    margin: 0 2px;
+    padding: 0 5px;
+    border: 1px solid #ddd;
+    background-color: #f8f8f8;
+    border-radius: 3px;
+  }
   </style>
 
   <!--[if lt IE 8]>


### PR DESCRIPTION
I've added an error message to the 500 error page that will let the user know what to do if error messages have been disabled.

I've had to duplicate the message across both `NancyRazorErrorView.cs` and `DefaultStatusCodeHandler.cs` as I couldn't think of a better place to put it. If this is a problem and you rather it go somewhere else please let me know
