### PR TITLE
Adding support for media range parameters

### DIFF
--- a/src/Nancy.Tests/Nancy.Tests.csproj
+++ b/src/Nancy.Tests/Nancy.Tests.csproj
@@ -190,6 +190,7 @@
     <Compile Include="Unit\RequestHeadersFixture.cs" />
     <Compile Include="Unit\ResponseExtensionsFixture.cs" />
     <Compile Include="Unit\Responses\EmbeddedFileResponseFixture.cs" />
+    <Compile Include="Unit\Responses\Negotiation\MediaRangeFixture.cs" />
     <Compile Include="Unit\Responses\RedirectResponseFixture.cs" />
     <Compile Include="Unit\Responses\StreamResponseFixture.cs" />
     <Compile Include="Unit\Responses\TextResponseFixture.cs" />

--- a/src/Nancy.Tests/Unit/RequestHeadersFixture.cs
+++ b/src/Nancy.Tests/Unit/RequestHeadersFixture.cs
@@ -27,8 +27,8 @@
             var values = headers.Values.ToList();
 
             // Then
-            values.Count().ShouldEqual(2);
-            values.First().Count().ShouldEqual(2);
+            values.ShouldHaveCount(2);
+            values.First().ShouldHaveCount(2);
             values.First().First().ShouldEqual("text/plain");
             values.First().Last().ShouldEqual("text/html");
             values.Last().First().ShouldEqual("utf-8");
@@ -51,7 +51,7 @@
             var keys = headers.Keys.ToList();
 
             // Then
-            keys.Count().ShouldEqual(2);
+            keys.ShouldHaveCount(2);
             keys.First().ShouldEqual("accept");
             keys.Last().ShouldEqual("charset");
         }
@@ -83,7 +83,7 @@
             var headers = new RequestHeaders(rawHeaders).Accept.ToList();
 
             // Then
-            headers.Count.ShouldEqual(2);
+            headers.ShouldHaveCount(2);
             headers[0].Item1.ShouldEqual("text/plain");
             headers[1].Item1.ShouldEqual("text/ninja");
         }
@@ -99,7 +99,7 @@
             var headers = new RequestHeaders(rawHeaders).Accept.ToList();
 
             // Then
-            headers.Count.ShouldEqual(2);
+            headers.ShouldHaveCount(2);
             headers[0].Item1.ShouldEqual("text/plain");
             headers[1].Item1.ShouldEqual("text/ninja");
         }
@@ -115,7 +115,7 @@
             var headers = new RequestHeaders(rawHeaders).Accept.ToList();
 
             // Then
-            headers.Count.ShouldEqual(1);
+            headers.ShouldHaveCount(1);
             headers[0].Item1.ShouldEqual("text/plain");
             headers[0].Item2.ShouldEqual(0.3m);
         }
@@ -131,7 +131,7 @@
             var headers = new RequestHeaders(rawHeaders).Accept.ToList();
 
             // Then
-            headers.Count.ShouldEqual(1);
+            headers.ShouldHaveCount(1);
             headers[0].Item1.ShouldEqual("text/plain");
             headers[0].Item2.ShouldEqual(1m);
         }
@@ -147,10 +147,26 @@
             var headers = new RequestHeaders(rawHeaders).Accept.ToList();
 
             // Then
-            headers.Count.ShouldEqual(2);
-            headers.FirstOrDefault(t => t.Item1 == "text/plain" && t.Item2 == 1.0m).ShouldNotBeNull();
-            headers.FirstOrDefault(t => t.Item1 == "text/ninja" && t.Item2 == 1.0m).ShouldNotBeNull();
+            headers.ShouldHaveCount(2);
+            headers.ShouldHave(t => t.Item1 == "text/plain" && t.Item2 == 1.0m);
+            headers.ShouldHave(t => t.Item1 == "text/ninja" && t.Item2 == 1.0m);
         }
+
+        [Fact]
+        public void Should_not_strip_additional_accept_header_parameters()
+        {
+            // Given
+            var values = new[] { "text/plain, text/ninja;q=0.3;a=1;b=2" };
+            var rawHeaders = new Dictionary<string, IEnumerable<string>> { { "Accept", values } };
+
+            // When
+            var headers = new RequestHeaders(rawHeaders).Accept.ToList();
+
+            // Then
+            headers.ShouldHaveCount(2);
+            headers.ShouldHave(t => t.Item1 == "text/plain" && t.Item2 == 1.0m);
+            headers.ShouldHave(t => t.Item1 == "text/ninja;a=1;b=2" && t.Item2 == 0.3m);
+         }
 
         [Fact]
         public void Should_sort_accept_header_values_decending_based_on_quality()
@@ -163,7 +179,7 @@
             var headers = new RequestHeaders(rawHeaders).Accept.ToList();
 
             // Then
-            headers.Count.ShouldEqual(3);
+            headers.ShouldHaveCount(3);
             headers[0].Item1.ShouldEqual("text/ninja");
             headers[1].Item1.ShouldEqual("text/html");
             headers[2].Item1.ShouldEqual("text/plain");
@@ -210,7 +226,7 @@
             var headers = new RequestHeaders(rawHeaders).AcceptCharset.ToList();
 
             // Then
-            headers.Count.ShouldEqual(2);
+            headers.ShouldHaveCount(2);
             headers[0].Item1.ShouldEqual("utf-8");
             headers[1].Item1.ShouldEqual("iso-8859-5");
         }
@@ -226,7 +242,7 @@
             var headers = new RequestHeaders(rawHeaders).AcceptCharset.ToList();
 
             // Then
-            headers.Count.ShouldEqual(2);
+            headers.ShouldHaveCount(2);
             headers[0].Item1.ShouldEqual("utf-8");
             headers[1].Item1.ShouldEqual("iso-8859-5");
         }
@@ -242,7 +258,7 @@
             var headers = new RequestHeaders(rawHeaders).AcceptCharset.ToList();
 
             // Then
-            headers.Count.ShouldEqual(1);
+            headers.ShouldHaveCount(1);
             headers[0].Item1.ShouldEqual("utf-8");
             headers[0].Item2.ShouldEqual(0.3m);
         }
@@ -258,7 +274,7 @@
             var headers = new RequestHeaders(rawHeaders).AcceptCharset.ToList();
 
             // Then
-            headers.Count.ShouldEqual(1);
+            headers.ShouldHaveCount(1);
             headers[0].Item1.ShouldEqual("utf-8");
             headers[0].Item2.ShouldEqual(1m);
         }
@@ -274,9 +290,9 @@
             var headers = new RequestHeaders(rawHeaders).AcceptCharset.ToList();
 
             // Then
-            headers.Count.ShouldEqual(2);
-            headers.FirstOrDefault(t => t.Item1 == "utf-8" && t.Item2 == 1.0m).ShouldNotBeNull();
-            headers.FirstOrDefault(t => t.Item1 == "iso-8859-5" && t.Item2 == 1.0m).ShouldNotBeNull();
+            headers.ShouldHaveCount(2);
+            headers.ShouldHave(t => t.Item1 == "utf-8" && t.Item2 == 1.0m);
+            headers.ShouldHave(t => t.Item1 == "iso-8859-5" && t.Item2 == 1.0m);
         }
 
         [Fact]
@@ -290,7 +306,7 @@
             var headers = new RequestHeaders(rawHeaders).AcceptCharset.ToList();
 
             // Then
-            headers.Count.ShouldEqual(3);
+            headers.ShouldHaveCount(3);
             headers[0].Item1.ShouldEqual("iso-8859-5");
             headers[1].Item1.ShouldEqual("iso-8859-15");
             headers[2].Item1.ShouldEqual("utf-8");
@@ -337,7 +353,7 @@
             var headers = new RequestHeaders(rawHeaders).AcceptEncoding.ToList();
 
             // Then
-            headers.Count.ShouldEqual(2);
+            headers.ShouldHaveCount(2);
             headers[0].ShouldEqual("compress");
             headers[1].ShouldEqual("sdch");
         }
@@ -353,7 +369,7 @@
             var headers = new RequestHeaders(rawHeaders).AcceptEncoding.ToList();
 
             // Then
-            headers.Count.ShouldEqual(2);
+            headers.ShouldHaveCount(2);
             headers[0].ShouldEqual("compress");
             headers[1].ShouldEqual("sdch");
         }
@@ -371,7 +387,7 @@
             var headers = new RequestHeaders(rawHeaders).AcceptEncoding.ToList();
 
             // Then
-            headers.Count.ShouldEqual(2);
+            headers.ShouldHaveCount(2);
             headers[0].ShouldEqual("compress");
             headers[1].ShouldEqual("sdch");
         }
@@ -386,7 +402,7 @@
             var headers = new RequestHeaders(rawHeaders).AcceptLanguage.ToList();
 
             // Then
-            headers.Count.ShouldEqual(0);
+            headers.ShouldHaveCount(0);
         }
 
         [Fact]
@@ -400,7 +416,7 @@
             var headers = new RequestHeaders(rawHeaders).AcceptLanguage.ToList();
 
             // Then
-            headers.Count.ShouldEqual(2);
+            headers.ShouldHaveCount(2);
             headers[0].Item1.ShouldEqual("en-US");
             headers[1].Item1.ShouldEqual("sv-SE");
         }
@@ -416,7 +432,7 @@
             var headers = new RequestHeaders(rawHeaders).AcceptLanguage.ToList();
 
             // Then
-            headers.Count.ShouldEqual(2);
+            headers.ShouldHaveCount(2);
             headers[0].Item1.ShouldEqual("en-US");
             headers[1].Item1.ShouldEqual("sv-SE");
         }
@@ -432,7 +448,7 @@
             var headers = new RequestHeaders(rawHeaders).AcceptLanguage.ToList();
 
             // Then
-            headers.Count.ShouldEqual(1);
+            headers.ShouldHaveCount(1);
             headers[0].Item1.ShouldEqual("en-US");
             headers[0].Item2.ShouldEqual(0.3m);
         }
@@ -448,7 +464,7 @@
             var headers = new RequestHeaders(rawHeaders).AcceptLanguage.ToList();
 
             // Then
-            headers.Count.ShouldEqual(1);
+            headers.ShouldHaveCount(1);
             headers[0].Item1.ShouldEqual("en-US");
             headers[0].Item2.ShouldEqual(1m);
         }
@@ -464,9 +480,9 @@
             var headers = new RequestHeaders(rawHeaders).AcceptLanguage.ToList();
 
             // Then
-            headers.Count.ShouldEqual(2);
-            headers.FirstOrDefault(t => t.Item1 == "en-US" && t.Item2 == 1.0m).ShouldNotBeNull();
-            headers.FirstOrDefault(t => t.Item1 == "sv-SE" && t.Item2 == 1.0m).ShouldNotBeNull();
+            headers.ShouldHaveCount(2);
+            headers.ShouldHave(t => t.Item1 == "en-US" && t.Item2 == 1.0m);
+            headers.ShouldHave(t => t.Item1 == "sv-SE" && t.Item2 == 1.0m);
         }
 
         [Fact]
@@ -480,7 +496,7 @@
             var headers = new RequestHeaders(rawHeaders).AcceptLanguage.ToList();
 
             // Then
-            headers.Count.ShouldEqual(3);
+            headers.ShouldHaveCount(3);
             headers[0].Item1.ShouldEqual("da");
             headers[1].Item1.ShouldEqual("sv-SE");
             headers[2].Item1.ShouldEqual("en-US");
@@ -499,7 +515,7 @@
             var headers = new RequestHeaders(rawHeaders).AcceptLanguage.ToList();
 
             // Then
-            headers.Count.ShouldEqual(2);
+            headers.ShouldHaveCount(2);
         }
         
         [Fact]
@@ -903,7 +919,7 @@
             var headers = new RequestHeaders(rawHeaders).IfMatch.ToList();
 
             // Then
-            headers.Count.ShouldEqual(2);
+            headers.ShouldHaveCount(2);
             headers[0].ShouldEqual("xyzzy");
             headers[1].ShouldEqual("c3piozzzz");
         }
@@ -1021,7 +1037,7 @@
             var headers = new RequestHeaders(rawHeaders).IfNoneMatch.ToList();
 
             // Then
-            headers.Count.ShouldEqual(2);
+            headers.ShouldHaveCount(2);
             headers[0].ShouldEqual("xyzzy");
             headers[1].ShouldEqual("c3piozzzz");
         }
@@ -2029,9 +2045,9 @@
         [Theory]
         [InlineData("text/html;q=0.8", "text/html", 0.8)]
         [InlineData("application/javascript;q=0.9,text/html;q=0.2,text/text", "text/html", 0.2)]
-        [InlineData("application/xhtml+xml; profile=\"http://www.wapforum. org/xhtml\"", "application/xhtml+xml", 1.0)]
-        [InlineData("application/xhtml+xml; q=0.2; profile=\"http://www.wapforum. org/xhtml\"", "application/xhtml+xml", 0.2)]
-        [InlineData("application/xhtml+xml; q=.7; profile=\"http://www.wapforum. org/xhtml\"", "application/xhtml+xml", 0.7)]
+        [InlineData("application/xhtml+xml; profile=\"http://www.wapforum. org/xhtml\"", "application/xhtml+xml;profile=\"http://www.wapforum. org/xhtml\"", 1.0)]
+        [InlineData("application/xhtml+xml; q=0.2; profile=\"http://www.wapforum. org/xhtml\"", "application/xhtml+xml;profile=\"http://www.wapforum. org/xhtml\"", 0.2)]
+        [InlineData("application/xhtml+xml; q=.7; profile=\"http://www.wapforum. org/xhtml\"", "application/xhtml+xml;profile=\"http://www.wapforum. org/xhtml\"", 0.7)]
         public void Should_retrieve_weighting_for_accept_headers(string header, string typeToCheck, double weighting)
         {
             var rawHeaders = new Dictionary<string, IEnumerable<string>> { { "Accept", new[] { header } } };

--- a/src/Nancy.Tests/Unit/Responses/Negotiation/MediaRangeFixture.cs
+++ b/src/Nancy.Tests/Unit/Responses/Negotiation/MediaRangeFixture.cs
@@ -1,0 +1,87 @@
+﻿namespace Nancy.Tests.Unit.Responses.Negotiation
+{
+    using System.Linq;
+
+    using Nancy.Responses.Negotiation;
+
+    using Xunit;
+
+    public class MediaRangeFixture
+    {
+        [Fact]
+        public void Should_parse_media_range_parameters()
+        {
+            // When
+            var range = MediaRange.FromString("application/vnd.nancy;a=1;b=2");
+
+            // Then
+            range.Parameters.Keys.ElementAt(0).ShouldEqual("a");
+            range.Parameters.Keys.ElementAt(1).ShouldEqual("b");
+            range.Parameters.Values.ElementAt(0).ShouldEqual("1");
+            range.Parameters.Values.ElementAt(1).ShouldEqual("2");
+        }
+
+        [Fact]
+        public void Should_match_with_parameters_if_parameters_match()
+        {
+            // Given
+            var range1 = MediaRange.FromString("application/vnd.nancy;a=1;b=2");
+            var range2 = MediaRange.FromString("application/vnd.nancy;a=1;b=2");
+
+            // Then
+            range1.MatchesWithParameters(range2).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Should_not_match_with_parameters_if_parameters_do_not_match()
+        {
+            // Given
+            var range1 = MediaRange.FromString("application/vnd.nancy;a=1;b=2");
+            var range2 = MediaRange.FromString("application/vnd.nancy;a=1;b=2;c=3");
+
+            // Then
+            range1.MatchesWithParameters(range2).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_match_with_parameters_if_parameters_match_in_any_order()
+        {
+            // Given
+            var range1 = MediaRange.FromString("application/vnd.nancy;a=1;b=2");
+            var range2 = MediaRange.FromString("application/vnd.nancy;b=2;a=1");
+
+            // Then
+            range1.MatchesWithParameters(range2).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Should_handle_no_parameters_when_calling_tostring()
+        {
+            // Given
+            var range = MediaRange.FromString("application/vnd.nancy");
+
+            // Then
+            range.ToString().ShouldEqual("application/vnd.nancy");
+        }
+
+        [Fact]
+        public void Should_include_parameters_when_calling_tostring()
+        {
+            // Given
+            var range = MediaRange.FromString("application/vnd.nancy;a=1;b=2");
+
+            // Then
+            range.ToString().ShouldEqual("application/vnd.nancy;a=1;b=2");
+        }
+
+        [Fact]
+        public void Should_strip_whitespace_when_calling_tostring()
+        {
+            // Given
+            var range = MediaRange.FromString("application/vnd.nancy ; a=1; b=2");
+
+            // Then
+            range.ToString().ShouldEqual("application/vnd.nancy;a=1;b=2");
+        }
+    }
+}

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -195,6 +195,7 @@
     <Compile Include="Responses\Negotiation\JsonProcessor.cs" />
     <Compile Include="Responses\Negotiation\MatchResult.cs" />
     <Compile Include="Responses\Negotiation\MediaRange.cs" />
+    <Compile Include="Responses\Negotiation\MediaRangeParameters.cs" />
     <Compile Include="Responses\Negotiation\MediaType.cs" />
     <Compile Include="Responses\Negotiation\NegotiationContext.cs" />
     <Compile Include="Responses\Negotiation\Negotiator.cs" />

--- a/src/Nancy/RequestHeaders.cs
+++ b/src/Nancy/RequestHeaders.cs
@@ -310,8 +310,11 @@ namespace Nancy
                         if (decimal.TryParse(stringValue, NumberStyles.Number, CultureInfo.InvariantCulture, out temp))
                         {
                             quality = temp;
-                            break;
                         }
+                    }
+                    else
+                    {
+                        mediaRange += ";" + trimmedValue;
                     }
                 }
 

--- a/src/Nancy/Responses/Negotiation/MediaRange.cs
+++ b/src/Nancy/Responses/Negotiation/MediaRange.cs
@@ -1,12 +1,21 @@
 namespace Nancy.Responses.Negotiation
 {
     using System;
+    using System.Linq;
 
     /// <summary>
     /// Represents a media range from an accept header
     /// </summary>
     public class MediaRange
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MediaRange"/> class.
+        /// </summary>
+        public MediaRange()
+        {
+            this.Parameters = new MediaRangeParameters();
+        }
+
         /// <summary>
         /// Media range type
         /// </summary>
@@ -16,6 +25,11 @@ namespace Nancy.Responses.Negotiation
         /// Media range subtype
         /// </summary>
         public MediaType Subtype { get; set; }
+
+        /// <summary>
+        /// Media range parameters
+        /// </summary>
+        public MediaRangeParameters Parameters { get; set; }
 
         /// <summary>
         /// Gets a value indicating if the media range is the */* wildcard
@@ -39,6 +53,16 @@ namespace Nancy.Responses.Negotiation
         }
 
         /// <summary>
+        /// Whether or not a media range matches another, taking into account wildcards and parameters
+        /// </summary>
+        /// <param name="other">Other media range</param>
+        /// <returns>True if matching, false if not</returns>
+        public bool MatchesWithParameters(MediaRange other)
+        {
+            return this.Matches(other) && this.Parameters.Matches(other.Parameters);
+        }
+
+        /// <summary>
         /// Creates a MediaRange from a "Type/SubType" string
         /// </summary>
         /// <param name="contentType"></param>
@@ -55,16 +79,24 @@ namespace Nancy.Responses.Negotiation
                 contentType = "*/*";
             }
 
-            var parts = contentType.Split('/');
+            var parts = contentType.Split('/', ';');
 
-            if (parts.Length != 2)
+            if (parts.Length < 2)
             {
                 {
                     throw new ArgumentException("inputString not in correct Type/SubType format", contentType);
                 }
             }
 
-            return new MediaRange { Type = parts[0], Subtype = parts[1] };
+            var range = new MediaRange { Type = parts[0], Subtype = parts[1].TrimEnd() };
+
+            if (parts.Length > 2)
+            {
+                var separator = contentType.IndexOf(';');
+                range.Parameters = MediaRangeParameters.FromString(contentType.Substring(separator));
+            }
+
+            return range;
         }
 
         public static implicit operator MediaRange(string contentType)
@@ -74,7 +106,12 @@ namespace Nancy.Responses.Negotiation
 
         public static implicit operator string(MediaRange mediaRange)
         {
-            return string.Concat(mediaRange.Type, "/", mediaRange.Subtype);
+            if (mediaRange.Parameters.Any())
+            {
+                return string.Format("{0}/{1};{2}", mediaRange.Type, mediaRange.Subtype, mediaRange.Parameters);
+            }
+
+            return string.Format("{0}/{1}", mediaRange.Type, mediaRange.Subtype);
         }
 
         public override string ToString()

--- a/src/Nancy/Responses/Negotiation/MediaRangeParameters.cs
+++ b/src/Nancy/Responses/Negotiation/MediaRangeParameters.cs
@@ -1,0 +1,115 @@
+﻿namespace Nancy.Responses.Negotiation
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Provides strongly-typed access to media range parameters.
+    /// </summary>
+    public class MediaRangeParameters : IEnumerable<KeyValuePair<string, string>>
+    {
+        private readonly IDictionary<string, string> parameters;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MediaRangeParameters"/> class.
+        /// </summary>
+        public MediaRangeParameters()
+        {
+            this.parameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MediaRangeParameters"/> class.
+        /// </summary>
+        /// <param name="parameters">The parameters.</param>
+        public MediaRangeParameters(IDictionary<string, string> parameters)
+        {
+            this.parameters = new Dictionary<string, string>(parameters, StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Gets the names of the available parameters.
+        /// </summary>
+        /// <value>An <see cref="IEnumerable{T}"/> containing the names of the parameters.</value>
+        public IEnumerable<string> Keys
+        {
+            get { return this.parameters.Keys; }
+        }
+
+        /// <summary>
+        /// Gets all the parameters values.
+        /// </summary>
+        /// <value>An <see cref="IEnumerable{T}"/> that contains all the parameters values.</value>
+        public IEnumerable<string> Values
+        {
+            get { return this.parameters.Values; }
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>A <see cref="IEnumerator{T}"/> that can be used to iterate through the collection.</returns>
+        public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+        {
+            return this.parameters.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Whether or not a set of media range parameters matches another, regardless of order
+        /// </summary>
+        /// <param name="other">Other media range parameters</param>
+        /// <returns>True if matching, false if not</returns>
+        public bool Matches(MediaRangeParameters other)
+        {
+            return this.parameters.OrderBy(p => p.Key).SequenceEqual(other.parameters.OrderBy(p => p.Key));
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through a collection.
+        /// </summary>
+        /// <returns>An <see cref="IEnumerator"/> object that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Gets the value for the parameter identified by the <paramref name="name"/> parameter.
+        /// </summary>
+        /// <param name="name">The name of the parameter to return the value for.</param>
+        /// <returns>The value for the parameter. If the parameter is not defined then null is returned.</returns>
+        public string this[string name]
+        {
+            get
+            {
+                return (this.parameters.ContainsKey(name)) ? this.parameters[name] : null;
+            }
+        }
+
+        public static implicit operator string(MediaRangeParameters mediaRangeParameters)
+        {
+            return string.Join(";", mediaRangeParameters.parameters.Select(p => p.Key + "=" + p.Value));
+        }
+
+        /// <summary>
+        /// Creates a MediaRangeParameters collection from a "a=1,b=2" string
+        /// </summary>
+        /// <param name="parameters"></param>
+        /// <returns></returns>
+        public static MediaRangeParameters FromString(string parameters)
+        {
+            var dictionary = parameters.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+               .Select(part => part.Split('='))
+               .ToDictionary(split => split[0].Trim(), split => split[1].Trim());
+
+            return new MediaRangeParameters(dictionary);
+        }
+
+        public override string ToString()
+        {
+            return this;
+        }
+    }
+}

--- a/src/Nancy/Responses/Negotiation/NegotiationContext.cs
+++ b/src/Nancy/Responses/Negotiation/NegotiationContext.cs
@@ -88,12 +88,10 @@
         /// <returns>The model for the provided <paramref name="mediaRange"/> if it has been mapped, otherwise the <see cref="DefaultModel"/> will be returned.</returns>
         public dynamic GetModelForMediaRange(MediaRange mediaRange)
         {
-            var matching =
-                this.MediaRangeModelMappings.Any(
-                    m => mediaRange.Type.Matches(m.Key.Type) && mediaRange.Subtype.Matches(m.Key.Subtype));
+            var matching = this.MediaRangeModelMappings.Any(m => mediaRange.Matches(m.Key));
 
             return matching ?
-                this.MediaRangeModelMappings.First(m => mediaRange.Type.Matches(m.Key.Type) && mediaRange.Subtype.Matches(m.Key.Subtype)).Value.Invoke() :
+                this.MediaRangeModelMappings.First(m => mediaRange.Matches(m.Key)).Value.Invoke() :
                 this.DefaultModel;
         }
     }


### PR DESCRIPTION
Fix for https://github.com/NancyFx/Nancy/issues/1211.
- [x] Added a new class called `MediaParameters` which implements `IEnumerable<KeyValuePair<string, string>>`
- [x] Added a `Parameters` property to `MediaRange`, of the above type.
- [x] Altered `MediaRange.FromString` to parse the parameters into the new property.
- [x] Added `MediaRange.MatchesWithParameters` to take parameters into account (if parameters exist, they must exist in both, but ordering doesn't matter).
- [x] Modify `RequestHeaders.GetWeightedValues` so that media range parameters are not stripped.
