### PR TITLE
Added method to flatten exceptions before passing them on to the OnError pipeline hook

### DIFF
--- a/src/Nancy.Tests/Unit/NancyEngineFixture.cs
+++ b/src/Nancy.Tests/Unit/NancyEngineFixture.cs
@@ -494,153 +494,153 @@ namespace Nancy.Tests.Unit
             returnedException.InnerException.ShouldBeSameAs(expectedException);
         }
 
-		[Fact]
-		public void Should_persist_and_unwrap_original_exception_in_requestexecutionexception()
-		{
-			// Given
-			var expectedException = new Exception();
-			var aggregateException = new AggregateException(expectedException);
+        [Fact]
+        public void Should_persist_and_unwrap_original_exception_in_requestexecutionexception()
+        {
+            // Given
+            var expectedException = new Exception();
+            var aggregateException = new AggregateException(expectedException);
 
-			var resolvedRoute = new ResolveResult(
-			   new FakeRoute(),
-			   DynamicDictionary.Empty,
-			   null,
-			   null,
-			   null);
+            var resolvedRoute = new ResolveResult(
+               new FakeRoute(),
+               DynamicDictionary.Empty,
+               null,
+               null,
+               null);
 
-			A.CallTo(() => resolver.Resolve(A<NancyContext>.Ignored)).Returns(resolvedRoute);
+            A.CallTo(() => resolver.Resolve(A<NancyContext>.Ignored)).Returns(resolvedRoute);
 
-			A.CallTo(() => this.requestDispatcher.Dispatch(context, A<CancellationToken>._))
-				.Returns(TaskHelpers.GetFaultedTask<Response>(aggregateException));
+            A.CallTo(() => this.requestDispatcher.Dispatch(context, A<CancellationToken>._))
+                .Returns(TaskHelpers.GetFaultedTask<Response>(aggregateException));
 
-			var pipelines = new Pipelines();
-			pipelines.OnError.AddItemToStartOfPipeline((ctx, exception) => null);
-			engine.RequestPipelinesFactory = (ctx) => pipelines;
+            var pipelines = new Pipelines();
+            pipelines.OnError.AddItemToStartOfPipeline((ctx, exception) => null);
+            engine.RequestPipelinesFactory = (ctx) => pipelines;
 
-			var request = new Request("GET", "/", "http");
+            var request = new Request("GET", "/", "http");
 
-			// When
-			var result = this.engine.HandleRequest(request);
-			var returnedException = result.Items["ERROR_EXCEPTION"] as RequestExecutionException;
+            // When
+            var result = this.engine.HandleRequest(request);
+            var returnedException = result.Items["ERROR_EXCEPTION"] as RequestExecutionException;
 
-			// Then
-			returnedException.InnerException.ShouldBeSameAs(expectedException);
-		}
+            // Then
+            returnedException.InnerException.ShouldBeSameAs(expectedException);
+        }
 
-		[Fact]
-		public void Should_persist_and_unwrap_nested_original_exception_in_requestexecutionexception()
-		{
-			// Given
-			var expectedException = new Exception();
-			var expectedExceptionInner = new AggregateException(expectedException);
-			var aggregateExceptionOuter = new AggregateException(expectedExceptionInner);
+        [Fact]
+        public void Should_persist_and_unwrap_nested_original_exception_in_requestexecutionexception()
+        {
+            // Given
+            var expectedException = new Exception();
+            var expectedExceptionInner = new AggregateException(expectedException);
+            var aggregateExceptionOuter = new AggregateException(expectedExceptionInner);
 
-			var resolvedRoute = new ResolveResult(
-			   new FakeRoute(),
-			   DynamicDictionary.Empty,
-			   null,
-			   null,
-			   null);
+            var resolvedRoute = new ResolveResult(
+               new FakeRoute(),
+               DynamicDictionary.Empty,
+               null,
+               null,
+               null);
 
-			A.CallTo(() => resolver.Resolve(A<NancyContext>.Ignored)).Returns(resolvedRoute);
+            A.CallTo(() => resolver.Resolve(A<NancyContext>.Ignored)).Returns(resolvedRoute);
 
-			A.CallTo(() => this.requestDispatcher.Dispatch(context, A<CancellationToken>._))
-				.Returns(TaskHelpers.GetFaultedTask<Response>(aggregateExceptionOuter));
+            A.CallTo(() => this.requestDispatcher.Dispatch(context, A<CancellationToken>._))
+                .Returns(TaskHelpers.GetFaultedTask<Response>(aggregateExceptionOuter));
 
-			var pipelines = new Pipelines();
-			pipelines.OnError.AddItemToStartOfPipeline((ctx, exception) => null);
-			engine.RequestPipelinesFactory = (ctx) => pipelines;
+            var pipelines = new Pipelines();
+            pipelines.OnError.AddItemToStartOfPipeline((ctx, exception) => null);
+            engine.RequestPipelinesFactory = (ctx) => pipelines;
 
-			var request = new Request("GET", "/", "http");
+            var request = new Request("GET", "/", "http");
 
-			// When
-			var result = this.engine.HandleRequest(request);
-			var returnedException = result.Items["ERROR_EXCEPTION"] as RequestExecutionException;
+            // When
+            var result = this.engine.HandleRequest(request);
+            var returnedException = result.Items["ERROR_EXCEPTION"] as RequestExecutionException;
 
-			// Then
-			returnedException.InnerException.ShouldBeSameAs(expectedException);
-		}
+            // Then
+            returnedException.InnerException.ShouldBeSameAs(expectedException);
+        }
 
-		[Fact]
-		public void Should_persist_and_unwrap_multiple_nested_original_exception_in_requestexecutionexception()
-		{
-			// Given
-			var expectedException1 = new Exception();
-			var expectedException2 = new Exception();
-			var expectedException3 = new Exception();
-			var exceptionsList = new List<Exception>() { expectedException1, expectedException2, expectedException3 };
-			var aggregateExceptionInner = new AggregateException(exceptionsList);
-			var aggregateExceptionOuter = new AggregateException(aggregateExceptionInner);
+        [Fact]
+        public void Should_persist_and_unwrap_multiple_nested_original_exception_in_requestexecutionexception()
+        {
+            // Given
+            var expectedException1 = new Exception();
+            var expectedException2 = new Exception();
+            var expectedException3 = new Exception();
+            var exceptionsList = new List<Exception>() { expectedException1, expectedException2, expectedException3 };
+            var aggregateExceptionInner = new AggregateException(exceptionsList);
+            var aggregateExceptionOuter = new AggregateException(aggregateExceptionInner);
 
-			var resolvedRoute = new ResolveResult(
-			   new FakeRoute(),
-			   DynamicDictionary.Empty,
-			   null,
-			   null,
-			   null);
+            var resolvedRoute = new ResolveResult(
+               new FakeRoute(),
+               DynamicDictionary.Empty,
+               null,
+               null,
+               null);
 
-			A.CallTo(() => resolver.Resolve(A<NancyContext>.Ignored)).Returns(resolvedRoute);
+            A.CallTo(() => resolver.Resolve(A<NancyContext>.Ignored)).Returns(resolvedRoute);
 
-			A.CallTo(() => this.requestDispatcher.Dispatch(context, A<CancellationToken>._))
-				.Returns(TaskHelpers.GetFaultedTask<Response>(aggregateExceptionOuter));
+            A.CallTo(() => this.requestDispatcher.Dispatch(context, A<CancellationToken>._))
+                .Returns(TaskHelpers.GetFaultedTask<Response>(aggregateExceptionOuter));
 
-			var pipelines = new Pipelines();
-			pipelines.OnError.AddItemToStartOfPipeline((ctx, exception) => null);
-			engine.RequestPipelinesFactory = (ctx) => pipelines;
+            var pipelines = new Pipelines();
+            pipelines.OnError.AddItemToStartOfPipeline((ctx, exception) => null);
+            engine.RequestPipelinesFactory = (ctx) => pipelines;
 
-			var request = new Request("GET", "/", "http");
+            var request = new Request("GET", "/", "http");
 
-			// When
-			var result = this.engine.HandleRequest(request);
-			var returnedException = result.Items["ERROR_EXCEPTION"] as RequestExecutionException;
+            // When
+            var result = this.engine.HandleRequest(request);
+            var returnedException = result.Items["ERROR_EXCEPTION"] as RequestExecutionException;
 
-			// Then
-			var returnedInnerException = returnedException.InnerException as AggregateException;
-			returnedInnerException.ShouldBeOfType(typeof(AggregateException));
-			Assert.Equal(exceptionsList.Count, returnedInnerException.InnerExceptions.Count);
-		}
+            // Then
+            var returnedInnerException = returnedException.InnerException as AggregateException;
+            returnedInnerException.ShouldBeOfType(typeof(AggregateException));
+            Assert.Equal(exceptionsList.Count, returnedInnerException.InnerExceptions.Count);
+        }
 
-		[Fact]
-		public void Should_persist_and_unwrap_multiple_nested_original_exception_in_requestexecutionexception_with_exceptions_on_multiple_levels()
-		{
-			// Given
-			var expectedException1 = new Exception();
-			var expectedException2 = new Exception();
-			var expectedException3 = new Exception();
-			var expectedException4 = new Exception();
-			var expectgedInnerExceptions = 4;
-			var exceptionsListInner = new List<Exception>() { expectedException1, expectedException2, expectedException3 };
-			var expectedExceptionInner = new AggregateException(exceptionsListInner);
-			var exceptionsListOuter = new List<Exception>() { expectedExceptionInner, expectedException4 };
-			var aggregateExceptionOuter = new AggregateException(exceptionsListOuter);
+        [Fact]
+        public void Should_persist_and_unwrap_multiple_nested_original_exception_in_requestexecutionexception_with_exceptions_on_multiple_levels()
+        {
+            // Given
+            var expectedException1 = new Exception();
+            var expectedException2 = new Exception();
+            var expectedException3 = new Exception();
+            var expectedException4 = new Exception();
+            var expectgedInnerExceptions = 4;
+            var exceptionsListInner = new List<Exception>() { expectedException1, expectedException2, expectedException3 };
+            var expectedExceptionInner = new AggregateException(exceptionsListInner);
+            var exceptionsListOuter = new List<Exception>() { expectedExceptionInner, expectedException4 };
+            var aggregateExceptionOuter = new AggregateException(exceptionsListOuter);
 
-			var resolvedRoute = new ResolveResult(
-			   new FakeRoute(),
-			   DynamicDictionary.Empty,
-			   null,
-			   null,
-			   null);
+            var resolvedRoute = new ResolveResult(
+               new FakeRoute(),
+               DynamicDictionary.Empty,
+               null,
+               null,
+               null);
 
-			A.CallTo(() => resolver.Resolve(A<NancyContext>.Ignored)).Returns(resolvedRoute);
+            A.CallTo(() => resolver.Resolve(A<NancyContext>.Ignored)).Returns(resolvedRoute);
 
-			A.CallTo(() => this.requestDispatcher.Dispatch(context, A<CancellationToken>._))
-				.Returns(TaskHelpers.GetFaultedTask<Response>(aggregateExceptionOuter));
+            A.CallTo(() => this.requestDispatcher.Dispatch(context, A<CancellationToken>._))
+                .Returns(TaskHelpers.GetFaultedTask<Response>(aggregateExceptionOuter));
 
-			var pipelines = new Pipelines();
-			pipelines.OnError.AddItemToStartOfPipeline((ctx, exception) => null);
-			engine.RequestPipelinesFactory = (ctx) => pipelines;
+            var pipelines = new Pipelines();
+            pipelines.OnError.AddItemToStartOfPipeline((ctx, exception) => null);
+            engine.RequestPipelinesFactory = (ctx) => pipelines;
 
-			var request = new Request("GET", "/", "http");
+            var request = new Request("GET", "/", "http");
 
-			// When
-			var result = this.engine.HandleRequest(request);
-			var returnedException = result.Items["ERROR_EXCEPTION"] as RequestExecutionException;
+            // When
+            var result = this.engine.HandleRequest(request);
+            var returnedException = result.Items["ERROR_EXCEPTION"] as RequestExecutionException;
 
-			// Then
-			var returnedInnerException = returnedException.InnerException as AggregateException;
-			returnedInnerException.ShouldBeOfType(typeof(AggregateException));
-			Assert.Equal(expectgedInnerExceptions, returnedInnerException.InnerExceptions.Count);
-		}
+            // Then
+            var returnedInnerException = returnedException.InnerException as AggregateException;
+            returnedInnerException.ShouldBeOfType(typeof(AggregateException));
+            Assert.Equal(expectgedInnerExceptions, returnedInnerException.InnerExceptions.Count);
+        }
 
         [Fact]
         public void Should_add_requestexecutionexception_to_context_when_pipeline_is_null()

--- a/src/Nancy/NancyEngine.cs
+++ b/src/Nancy/NancyEngine.cs
@@ -287,9 +287,9 @@
                 {
                     try
                     {
-						var flattenedException = FlattenException(t.Exception);
+                        var flattenedException = FlattenException(t.Exception);
 
-						InvokeOnErrorHook(context, pipelines.OnError, flattenedException);
+                        InvokeOnErrorHook(context, pipelines.OnError, flattenedException);
 
                         tcs.SetResult(context);
                     }
@@ -341,30 +341,30 @@
             }
         }
 
-		private static Exception FlattenException(Exception exception)
-		{
-			if (exception is AggregateException)
-			{
-				var aggregateException = exception as AggregateException;
+        private static Exception FlattenException(Exception exception)
+        {
+            if (exception is AggregateException)
+            {
+                var aggregateException = exception as AggregateException;
 
-				var flattenedAggregateException = aggregateException.Flatten();
+                var flattenedAggregateException = aggregateException.Flatten();
 
-				//If we have more than one exception in the AggregateException
-				//we have to send all exceptions back in order not to swallow any exceptions.
-				if (flattenedAggregateException.InnerExceptions.Count > 1)
-				{
-					return flattenedAggregateException;
-				}
+                //If we have more than one exception in the AggregateException
+                //we have to send all exceptions back in order not to swallow any exceptions.
+                if (flattenedAggregateException.InnerExceptions.Count > 1)
+                {
+                    return flattenedAggregateException;
+                }
 
-				return flattenedAggregateException.InnerException;
-			}
+                return flattenedAggregateException.InnerException;
+            }
 
-			if (exception != null && exception.InnerException != null)
-			{
-				return FlattenException(exception.InnerException);
-			}
+            if (exception != null && exception.InnerException != null)
+            {
+                return FlattenException(exception.InnerException);
+            }
 
-			return exception;
-		}
+            return exception;
+        }
     }
 }


### PR DESCRIPTION
This is a proposed fix for issue #1232.

As described in issue #1232 the error pipeline hook does not unwrap the AggregateExceptions thrown from Tasks in the request handler.

One comment has to be made on this pull request. More than one exception can be nested inside AggregateExceptions, but the OnError pipeline hook only expects a single exception, so unless only one exception is actually nested inside the AggregateException we cannot fully unwrap it. In the case where more than one exception exists we have to return all of them in order not to swallow up any exception.

This is mentioned in a comment in the code as well, that should perhaps be deleted if the pull request is accepted.

Jon Skeet describes this issue in a short comment on Stack Overflow:
http://stackoverflow.com/questions/13570855/aggregateexception-what-does-aggregateexception-flatten-innerexception-repre
