### PR TITLE
Updated multipart form requests

### DIFF
--- a/src/Nancy/HttpMultipartBoundary.cs
+++ b/src/Nancy/HttpMultipartBoundary.cs
@@ -62,8 +62,8 @@ namespace Nancy
 
                 if (header.StartsWith("Content-Disposition", StringComparison.CurrentCultureIgnoreCase))
                 {
-                    this.Name = Regex.Match(header, @"name=""(?<name>[^\""]*)", RegexOptions.IgnoreCase).Groups["name"].Value;
-                    this.Filename = Regex.Match(header, @"filename=""(?<filename>[^\""]*)", RegexOptions.IgnoreCase).Groups["filename"].Value;
+                    this.Name = Regex.Match(header, @"name=""?(?<name>[^\""]*)", RegexOptions.IgnoreCase).Groups["name"].Value;
+                    this.Filename = Regex.Match(header, @"filename=""?(?<filename>[^\""]*)", RegexOptions.IgnoreCase).Groups["filename"].Value;
                 }
 
                 if (header.StartsWith("Content-Type", StringComparison.InvariantCultureIgnoreCase))

--- a/src/Nancy/Request.cs
+++ b/src/Nancy/Request.cs
@@ -235,7 +235,7 @@ namespace Nancy
                 return;
             }
 
-            var boundary = Regex.Match(contentType, @"boundary=(?<token>[^\n\; ]*)").Groups["token"].Value;
+            var boundary = Regex.Match(contentType, @"boundary=""?(?<token>[^\n\;\"" ]*)").Groups["token"].Value;
             var multipart = new HttpMultipart(this.Body, boundary);
 
             var formValues =


### PR DESCRIPTION
 To accept quotes or no quotes around the content-type boundary and content-disposition name/filename

I ran into needing to support this case from our Mono iPad app that is using the provided MS class MultipartFormDataContent which sends the request with quotes around the boundary and no quotes around filenames
