### PR TITLE
Always return HttpQSCollection (fixes #1132).

### DIFF
--- a/src/Nancy/Helpers/HttpUtility.cs
+++ b/src/Nancy/Helpers/HttpUtility.cs
@@ -687,7 +687,7 @@ namespace Nancy.Helpers
             if (encoding == null)
                 throw new ArgumentNullException("encoding");
             if (query.Length == 0 || (query.Length == 1 && query[0] == '?'))
-                return new NameValueCollection();
+                return new HttpQSCollection();
             if (query[0] == '?')
                 query = query.Substring(1);
 


### PR DESCRIPTION
Sometimes `HttpUtility.ParseQueryString` is [used as a factory](http://stackoverflow.com/a/1877016/121146) for creating `NameValueCollection` instances that can be serialized back into a query string. Therefore it is valuable to get back a `HttpQSCollection` (which has the useful `ToString` overload) even when the `query` parameter is an empty string.
