### PR TITLE
changed ModulePath setter from private to protected.

### DIFF
--- a/src/Nancy/NancyModule.cs
+++ b/src/Nancy/NancyModule.cs
@@ -116,7 +116,7 @@ namespace Nancy
         /// A <see cref="T:System.String" /> containing the root path of the module or <see langword="null" /> 
         /// if no root path should be used.</value><remarks>All routes will be relative to this root path.
         /// </remarks>
-        public string ModulePath { get; private set; }
+        public string ModulePath { get; protected set; }
 
         /// <summary>
         /// Gets all declared routes by the module.


### PR DESCRIPTION
This allows a derived type to set it to GetType().Name or do some other automagic thing.
