### PR TITLE
Fix obsolete method description

### DIFF
--- a/src/Nancy.Testing/AssertExtensions.cs
+++ b/src/Nancy.Testing/AssertExtensions.cs
@@ -103,7 +103,7 @@ namespace Nancy.Testing
         /// <summary>
         /// Asserts that every node contains the specified text
         /// </summary>
-        [Obsolete("This method has a ambiguous name and will be removed. Use ShouldContainAll instead.")]
+        [Obsolete("This method has a ambiguous name and will be removed. Use AllShouldContain instead.")]
         public static AndConnector<QueryWrapper> ShouldContain(this QueryWrapper query, string contents, StringComparison comparisonType = StringComparison.InvariantCulture)
         {
             return query.AllShouldContain(contents, comparisonType);


### PR DESCRIPTION
It's James-language-nitpick time! Gather round friends!

`AllShouldContain` not `ShouldContainAll` :smiley_cat: 
