### PR TITLE
Implementing fix to issue where Nancy can't find embedded resource views...

### DIFF
--- a/src/Nancy/ViewEngines/ResourceViewLocationProvider.cs
+++ b/src/Nancy/ViewEngines/ResourceViewLocationProvider.cs
@@ -58,6 +58,7 @@
 
             return this.resourceAssemblyProvider
                 .GetAssembliesToScan()
+                .Union(RootNamespaces.Keys)
                 .Where(x => !Ignore.Contains(x))
                 .SelectMany(x => GetViewLocations(x, supportedViewExtensions));
         }


### PR DESCRIPTION
... in other assemblies when adding them as RootNamespaces to ResourceViewLocationProvider. I rediscovered this issue but the original fix was found and suggested by Rex Witten here: http://tinyurl.com/l2n6u2g ; his fix resolves my issues of views embedded as resources in satellite assemblies not being loaded by the ResourceViewLocationProvider as expected by Nancy.
