### PR TITLE
Fixed unclosed input tag for AntiForgeryToken in SSVE.

### DIFF
--- a/src/Nancy/ViewEngines/SuperSimpleViewEngine/NancyViewEngineHost.cs
+++ b/src/Nancy/ViewEngines/SuperSimpleViewEngine/NancyViewEngineHost.cs
@@ -82,7 +82,7 @@ namespace Nancy.ViewEngines.SuperSimpleViewEngine
         {
             var tokenKeyValue = this.renderContext.GetCsrfToken();
 
-            return string.Format("<input type=\"hidden\" name=\"{0}\" value=\"{1}\"", tokenKeyValue.Key, tokenKeyValue.Value);
+            return string.Format("<input type=\"hidden\" name=\"{0}\" value=\"{1}\" />", tokenKeyValue.Key, tokenKeyValue.Value);
         }
     }
 }


### PR DESCRIPTION
Input tag for AntiForgeryToken was missing " />" at the end of it.
