### PR TITLE
ConfigurableBootstrapper no longer disposes instance dependencies during registration

### DIFF
--- a/src/Nancy.Testing/ConfigurableBootstrapper.cs
+++ b/src/Nancy.Testing/ConfigurableBootstrapper.cs
@@ -34,6 +34,10 @@ namespace Nancy.Testing
         private readonly List<Action<TinyIoCContainer, IPipelines>> applicationStartupActions;
         private readonly List<Action<TinyIoCContainer, IPipelines, NancyContext>> requestStartupActions;
 
+        private bool configuredCollectionsRegistered;
+        private bool configuredInstancesRegistered;
+        private bool configuredTypesRegistered;
+
         /// <summary>
         /// Test project name suffixes that will be stripped from the test name project
         /// in order to try and resolve the name of the assembly that is under test so
@@ -308,7 +312,10 @@ namespace Nancy.Testing
                 container.AutoRegister();
                 this.RegisterBootstrapperTypes(container);
             }
-
+            
+            RegisterTypesInternal(this.ApplicationContainer, this.GetTypeRegistrations());
+            RegisterCollectionTypesInternal(this.ApplicationContainer, this.GetCollectionTypeRegistrations());
+            RegisterInstancesInternal(this.ApplicationContainer, this.registeredInstances);
         }
 
         /// <summary>
@@ -409,13 +416,19 @@ namespace Nancy.Testing
         /// <param name="typeRegistrations">Type registrations to register</param>
         protected override void RegisterTypes(TinyIoCContainer container, IEnumerable<TypeRegistration> typeRegistrations)
         {
-            var configuredTypes = this.GetTypeRegistrations().ToList();
+            var configuredTypes = 
+                this.GetTypeRegistrations().ToList();
 
-            typeRegistrations = configuredTypes
-                .Concat(typeRegistrations.Where(x => configuredTypes.All(y => y.RegistrationType != x.RegistrationType)))
-                .Where(x => this.registeredInstances.All(y => y.RegistrationType != x.RegistrationType));
+            var filtered = typeRegistrations
+                .Where(x => !configuredTypes.Any(y => y.RegistrationType == x.RegistrationType))
+                .Where(x => !this.registeredInstances.Any(y => y.RegistrationType == x.RegistrationType));
 
-            foreach (var typeRegistration in typeRegistrations)
+            RegisterTypesInternal(container, filtered);
+        }
+
+        private static void RegisterTypesInternal(TinyIoCContainer container, IEnumerable<TypeRegistration> filtered)
+        {
+            foreach (var typeRegistration in filtered)
             {
                 container.Register(typeRegistration.RegistrationType, typeRegistration.ImplementationType).AsSingleton();
             }
@@ -429,14 +442,21 @@ namespace Nancy.Testing
         /// <param name="collectionTypeRegistrations">Collection type registrations to register</param>
         protected override void RegisterCollectionTypes(TinyIoCContainer container, IEnumerable<CollectionTypeRegistration> collectionTypeRegistrations)
         {
-            var configuredCollectionTypes = this.GetCollectionTypeRegistrations().ToList();
+            var configuredCollectionTypes = 
+                this.GetCollectionTypeRegistrations().ToList();
 
-            collectionTypeRegistrations = configuredCollectionTypes
-                .Concat(collectionTypeRegistrations.Where(x => configuredCollectionTypes.All(y => y.RegistrationType != x.RegistrationType)));
+            var filtered = collectionTypeRegistrations
+                .Where(x => !configuredCollectionTypes.Any(y => y.RegistrationType == x.RegistrationType));
 
-            foreach (var collectionTypeRegistration in collectionTypeRegistrations)
+            RegisterCollectionTypesInternal(container, filtered);
+        }
+
+        private static void RegisterCollectionTypesInternal(TinyIoCContainer container, IEnumerable<CollectionTypeRegistration> filtered)
+        {
+            foreach (var collectionTypeRegistration in filtered)
             {
-                container.RegisterMultiple(collectionTypeRegistration.RegistrationType, collectionTypeRegistration.ImplementationTypes);
+                container.RegisterMultiple(collectionTypeRegistration.RegistrationType,
+                    collectionTypeRegistration.ImplementationTypes);
             }
         }
 
@@ -447,11 +467,19 @@ namespace Nancy.Testing
         /// <param name="instanceRegistrations">Instance registration types</param>
         protected override void RegisterInstances(TinyIoCContainer container, IEnumerable<InstanceRegistration> instanceRegistrations)
         {
-            instanceRegistrations = this.registeredInstances
-                .Concat(instanceRegistrations.Where(x => this.registeredInstances.All(y => y.RegistrationType != x.RegistrationType)))
-                .Where(x => this.GetTypeRegistrations().All(y => y.RegistrationType != x.RegistrationType));
+            var configuredInstanceRegistrations = this.GetTypeRegistrations();
 
-            foreach (var instanceRegistration in instanceRegistrations)
+            var fileteredInstanceRegistrations = instanceRegistrations
+                .Where(x => !this.registeredInstances.Any(y => y.RegistrationType == x.RegistrationType))
+                .Where(x => !configuredInstanceRegistrations.Any(y => y.RegistrationType == x.RegistrationType))
+                .ToList();
+
+            RegisterInstancesInternal(container, fileteredInstanceRegistrations);
+        }
+
+        private static void RegisterInstancesInternal(TinyIoCContainer container, IEnumerable<InstanceRegistration> fileteredInstanceRegistrations)
+        {
+            foreach (var instanceRegistration in fileteredInstanceRegistrations)
             {
                 container.Register(
                     instanceRegistration.RegistrationType,
@@ -617,7 +645,7 @@ namespace Nancy.Testing
             {
                 this.bootstrapper.registeredTypes.Add(new TypeRegistration(typeof(T), typeof(T)));
 
-                foreach (var interfaceType in typeof(T).GetInterfaces())
+                foreach (var interfaceType in GetSafeInterfaces(typeof(T)))
                 {
                     this.bootstrapper.registeredTypes.Add(new TypeRegistration(interfaceType, typeof(T)));
                 }
@@ -635,12 +663,17 @@ namespace Nancy.Testing
             {
                 this.bootstrapper.registeredInstances.Add(new InstanceRegistration(typeof(T), instance));
 
-                foreach (var interfaceType in instance.GetType().GetInterfaces())
+                foreach (var interfaceType in GetSafeInterfaces(instance.GetType()))
                 {
                     this.bootstrapper.registeredInstances.Add(new InstanceRegistration(interfaceType, instance));
                 }
 
                 return this;
+            }
+
+            private static IEnumerable<Type> GetSafeInterfaces(Type type)
+            {
+                return type.GetInterfaces().Where(x => x != typeof(IDisposable));
             }
 
             /// <summary>


### PR DESCRIPTION
Fixed #1288
