### PR TITLE
Update to AspNet HttpRequestHandler to use Fully Qualified Type Name (include assembly name)

### DIFF
--- a/src/Nancy.Hosting.Aspnet/NancyHttpRequestHandler.cs
+++ b/src/Nancy.Hosting.Aspnet/NancyHttpRequestHandler.cs
@@ -37,7 +37,7 @@ namespace Nancy.Hosting.Aspnet
             if (configurationBootstrapperType != null)
             {
                 var bootstrapperType =
-                    Type.GetType(configurationBootstrapperType.Name + ", " + configurationBootstrapperType.Assembly);
+                    Type.GetType(string.Concat(configurationBootstrapperType.Name, ", ", configurationBootstrapperType.Assembly));
 
                 return Activator.CreateInstance(bootstrapperType) as INancyBootstrapper;
             }


### PR DESCRIPTION
GetType was returning null when configurationBootstrapperType.Name is not in the executing assembly. Assembly, which is a required attribute in the nancyFx config section, was not actually being used. More detail here: https://groups.google.com/forum/#!topic/nancy-web-framework/nxz9Pl4EUxE
