### PR TITLE
Added overload to BrowserContext.Body

### DIFF
--- a/src/Nancy.Testing/BrowserContext.cs
+++ b/src/Nancy.Testing/BrowserContext.cs
@@ -81,6 +81,17 @@
         /// <summary>
         /// Adds a body to the HTTP request.
         /// </summary>
+        /// <param name="body">A string that should be used as the HTTP request body.</param>
+        /// <param name="contentType">Content type of the HTTP request body.</param>
+        public void Body(string body, string contentType)
+        {
+            this.Values.BodyString = body;
+            this.Header("Content-Type", contentType);
+        }
+
+        /// <summary>
+        /// Adds a body to the HTTP request.
+        /// </summary>
         /// <param name="body">A stream that should be used as the HTTP request body.</param>
         /// <param name="contentType">Content type of the HTTP request body. Defaults to 'application/octet-stream'</param>
         public void Body(Stream body, string contentType = null)

--- a/src/Nancy.Tests.Functional/Tests/ModelBindingTests.cs
+++ b/src/Nancy.Tests.Functional/Tests/ModelBindingTests.cs
@@ -27,10 +27,7 @@
             const string body = "[{ 'key1': 'value1' , 'key2': 'value2'},{ 'key1': 'value1' , 'key2': 'value2'}, { 'key1': 'value1' , 'key2': 'value2'}]";
 
             // When
-            var result = this.browser.Post("/jsonlist", with => {
-                with.Body(body);
-                with.Header("content-type", "application/json");
-            });
+            var result = this.browser.Post("/jsonlist", with => with.Body(body, "application/json"));
 
             // Then
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
@@ -43,11 +40,7 @@
             const string body = "{ 'key1': 'body' , 'key2': 'value2'}";
 
             // When
-            var result = this.browser.Put("/foo/param", with =>
-            {
-                with.Body(body);
-                with.Header("content-type", "application/json");
-            });
+            var result = this.browser.Put("/foo/param", with => with.Body(body, "application/json"));
 
             // Then
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);


### PR DESCRIPTION
I've added an overload to Body(string) in BrowserContext in Nancy.Testing so that it's possible to write:

```
with.Body("{key: 'some value'}", "application/json")
```

To avoid having to set content-type header in each test
