### PR TITLE
Fix for issue #1096 (DateTime converter on model binding)

### DIFF
--- a/src/Nancy.Tests/Unit/ModelBinding/DefaultBinderFixture.cs
+++ b/src/Nancy.Tests/Unit/ModelBinding/DefaultBinderFixture.cs
@@ -1442,6 +1442,26 @@ namespace Nancy.Tests.Unit.ModelBinding
             result.ShouldEqualSequence(new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 });
         }
 
+        [Fact]
+        public void Should_throw_ModelBindingException_if_convertion_of_a_property_fails_with_bad_date()
+        {
+            // Given
+            var binder = this.GetBinder(typeConverters: new ITypeConverter[] { new FallbackConverter(), new DateTimeConverter() });
+            var context = new NancyContext { Request = new FakeRequest("GET", "/") };
+            context.Request.Form["DateProperty"] = "baddate";
+
+            // Then
+            Assert.Throws<ModelBindingException>(() => binder.Bind(context, typeof(TestModel), null, new BindingConfig()))
+                .ShouldMatch(exception =>
+                             exception.BoundType == typeof(TestModel)
+                             && exception.PropertyBindingExceptions.Any(pe =>
+                                                                        pe.PropertyName == "DateProperty"
+                                                                        && pe.AttemptedValue == "baddate"
+                                                                        &&
+                                                                        pe.InnerException.Message ==
+                                                                        "The string was not recognized as a valid DateTime. There is an unknown word starting at index 0."));
+        }
+
         private IBinder GetBinder(IEnumerable<ITypeConverter> typeConverters = null, IEnumerable<IBodyDeserializer> bodyDeserializers = null, IFieldNameConverter nameConverter = null, BindingDefaults bindingDefaults = null)
         {
             var converters = typeConverters ?? new ITypeConverter[] { new DateTimeConverter(), new NumericConverter(), new FallbackConverter() };

--- a/src/Nancy/ModelBinding/DefaultBinder.cs
+++ b/src/Nancy/ModelBinding/DefaultBinder.cs
@@ -319,9 +319,9 @@ namespace Nancy.ModelBinding
 
         private static bool IsDefaultValue(object existingValue, Type propertyType)
         {
-            return propertyType.IsValueType
-                ? Equals(existingValue, Activator.CreateInstance(propertyType))
-                : existingValue == null;
+            return propertyType.IsValueType ? 
+                Equals(existingValue, Activator.CreateInstance(propertyType)) : 
+                existingValue == null;
         }
 
         private BindingContext CreateBindingContext(NancyContext context, Type modelType, object instance, BindingConfig configuration, IEnumerable<string> blackList, Type genericType)
@@ -342,11 +342,11 @@ namespace Nancy.ModelBinding
         private IDictionary<string, string> GetDataFields(NancyContext context)
         {
             var dictionaries = new IDictionary<string, string>[]
-                {
-                    ConvertDynamicDictionary(context.Request.Form),
-                    ConvertDynamicDictionary(context.Request.Query),
-                    ConvertDynamicDictionary(context.Parameters)
-                };
+            {
+                ConvertDynamicDictionary(context.Request.Form),
+                ConvertDynamicDictionary(context.Request.Query),
+                ConvertDynamicDictionary(context.Parameters)
+            };
 
             return dictionaries.Merge();
         }
@@ -372,8 +372,9 @@ namespace Nancy.ModelBinding
         {
             var destinationType = modelProperty.PropertyType;
 
-            var typeConverter =
-                context.TypeConverters.FirstOrDefault(c => c.CanConvertTo(destinationType, context));
+            var typeConverter = context.TypeConverters
+                                       .OrderBy(x => x.Order)
+                                       .FirstOrDefault(c => c.CanConvertTo(destinationType, context));
 
             if (typeConverter != null)
             {
@@ -392,7 +393,32 @@ namespace Nancy.ModelBinding
             }
         }
 
-        private static void SetBindingMemberValue(BindingMemberInfo modelProperty, object model, object value)
+        private static void BindProperty(PropertyInfo modelProperty, string stringValue, BindingContext context, object genericInstance)
+        {
+            var destinationType = modelProperty.PropertyType;
+
+            var typeConverter = context.TypeConverters
+                                   .OrderBy(x => x.Order)
+                                   .FirstOrDefault(c => c.CanConvertTo(destinationType, context));
+
+            if (typeConverter != null)
+            {
+                try
+                {
+                    SetPropertyValue(modelProperty, genericInstance, typeConverter.Convert(stringValue, destinationType, context));
+                }
+                catch (Exception e)
+                {
+                    throw new PropertyBindingException(modelProperty.Name, stringValue, e);
+                }
+            }
+            else if (destinationType == typeof(string))
+            {
+                SetPropertyValue(modelProperty, context.Model, stringValue);
+            }
+        }
+
+        private static void SetPropertyValue(PropertyInfo modelProperty, object model, object value)
         {
             // TODO - catch reflection exceptions?
             modelProperty.SetValue(model, value);
@@ -443,11 +469,11 @@ namespace Nancy.ModelBinding
             {
 
                 var indexindexes = context.RequestData.Keys.Select(IsMatch)
-                                           .Where(i => i != -1)
-                                           .OrderBy(i => i)
-                                           .Distinct()
-                                           .Select((k, i) => new KeyValuePair<int, int>(i, k))
-                                           .ToDictionary(k => k.Key, v => v.Value);
+                                          .Where(i => i != -1)
+                                          .OrderBy(i => i)
+                                          .Distinct()
+                                          .Select((k, i) => new KeyValuePair<int, int>(i, k))
+                                          .ToDictionary(k => k.Key, v => v.Value);
 
                 if (indexindexes.ContainsKey(index))
                 {

--- a/src/Nancy/ModelBinding/DefaultConverters/CollectionConverter.cs
+++ b/src/Nancy/ModelBinding/DefaultConverters/CollectionConverter.cs
@@ -15,6 +15,11 @@ namespace Nancy.ModelBinding.DefaultConverters
         private readonly MethodInfo enumerableToListMethod = typeof(Enumerable).GetMethod("ToList", BindingFlags.Public | BindingFlags.Static);
 
         /// <summary>
+        /// Used to ensure Converter is always called before FallbackConverter
+        /// </summary>
+        public int Order { get { return 0; } }
+
+        /// <summary>
         /// Whether the converter can convert to the destination type
         /// </summary>
         /// <param name="destinationType">Destination type</param>

--- a/src/Nancy/ModelBinding/DefaultConverters/DateTimeConverter.cs
+++ b/src/Nancy/ModelBinding/DefaultConverters/DateTimeConverter.cs
@@ -8,6 +8,11 @@
     public class DateTimeConverter : ITypeConverter
     {
         /// <summary>
+        /// Used to ensure Converter is always called before FallbackConverter
+        /// </summary>
+        public int Order { get { return 0; } }
+
+        /// <summary>
         /// Whether the converter can convert to the destination type
         /// </summary>
         /// <param name="destinationType">Destination type</param>

--- a/src/Nancy/ModelBinding/DefaultConverters/DateTimeConverter.cs
+++ b/src/Nancy/ModelBinding/DefaultConverters/DateTimeConverter.cs
@@ -1,6 +1,7 @@
 ﻿namespace Nancy.ModelBinding.DefaultConverters
 {
     using System;
+    using System.Globalization;
 
     /// <summary>
     /// Converter for datetime types
@@ -37,7 +38,15 @@
                 return null;
             }
 
-            return System.Convert.ChangeType(input, destinationType, context.Context.Culture);
+            DateTime result;
+            var culture = context.Context.Culture ?? CultureInfo.CurrentCulture;
+
+            if (DateTime.TryParse(input, culture.DateTimeFormat, DateTimeStyles.None, out result))
+            {
+                return result;
+            }
+
+            throw new FormatException("The string was not recognized as a valid DateTime. There is an unknown word starting at index 0.");
         }
     }
 }

--- a/src/Nancy/ModelBinding/DefaultConverters/FallbackConverter.cs
+++ b/src/Nancy/ModelBinding/DefaultConverters/FallbackConverter.cs
@@ -10,6 +10,11 @@ namespace Nancy.ModelBinding.DefaultConverters
     public class FallbackConverter : ITypeConverter
     {
         /// <summary>
+        /// Used to ensure the fallback converter is always called last when converting types
+        /// </summary>
+        public int Order { get { return int.MaxValue; } }
+
+        /// <summary>
         /// Whether the converter can convert to the destination type
         /// </summary>
         /// <param name="destinationType">Destination type</param>

--- a/src/Nancy/ModelBinding/DefaultConverters/NumericConverter.cs
+++ b/src/Nancy/ModelBinding/DefaultConverters/NumericConverter.cs
@@ -9,6 +9,11 @@
     public class NumericConverter : ITypeConverter
     {
         /// <summary>
+        /// Used to ensure Converter is always called before FallbackConverter
+        /// </summary>
+        public int Order { get { return 0; } }
+
+        /// <summary>
         /// Whether the converter can convert to the destination type
         /// </summary>
         /// <param name="destinationType">Destination type</param>

--- a/src/Nancy/ModelBinding/ITypeConverter.cs
+++ b/src/Nancy/ModelBinding/ITypeConverter.cs
@@ -24,5 +24,10 @@ namespace Nancy.ModelBinding
         /// <param name="context">Current context</param>
         /// <returns>Converted object of the destination type</returns>
         object Convert(string input, Type destinationType, BindingContext context);
+
+        /// <summary>
+        /// Used to ensure order of type converters is called correctly
+        /// </summary>
+        int Order { get; }
     }
 }


### PR DESCRIPTION
This PR replaces the botched #1099 PR.

Fix is for  #1096

The unit test in question is fine, the unit test didn't include the type converter, however the Fallback converter was being called before the Date so the Date Converter didn't have a chance to say he could convert it.

I added an Order property and order the collection before looking for the first matching one.

I figured this solution was fine since there's only 4-5 converters so the overhead of sorting would be almost nothing, if not nothing already.

Fixed up a few places where type converters were being used.