### PR TITLE
Fixed documentation about Csrf being disabled by default.

### DIFF
--- a/src/Nancy/Security/Csrf.cs
+++ b/src/Nancy/Security/Csrf.cs
@@ -14,8 +14,7 @@
 
         /// <summary>
         /// Enables Csrf token generation.
-        /// This is disabled by default. Enabling it is just a single line in the bootstrapper app startup:
-        /// Csrf.Enable(pipelines);
+        /// This is disabled by default.
         /// </summary>
         /// <param name="pipelines">Application pipelines</param>
         public static void Enable(IPipelines pipelines)


### PR DESCRIPTION
Commit fa529c5ba1bc7dae6198a39a744aa096020f29d6 changed the way Csrf got enabled, from being enabled to default to disabled by default. The documentation didn't get updated, leading to confusion.
