### PR TITLE
Fix XML comment

### DIFF
--- a/src/Nancy.Testing/ConfigurableBootstrapper.cs
+++ b/src/Nancy.Testing/ConfigurableBootstrapper.cs
@@ -754,7 +754,7 @@ namespace Nancy.Testing
             }
 
             /// <summary>
-            /// Disables the auto registration behavior of the bootstrapper
+            /// Enables the auto registration behavior of the bootstrapper
             /// </summary>
             /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
             public ConfigurableBootstrapperConfigurator EnableAutoRegistration()


### PR DESCRIPTION
Looks like this was missed in https://github.com/NancyFx/Nancy/pull/644 when the method was switched from `DisableAutoRegistration` to `EnableAutoRegistration`
