### PR TITLE
DataAnnodations no longer requires IValidatableObject

### DIFF
--- a/src/Nancy.Validation.DataAnnotatioins.Tests/DefaultValidatableObjectAdapterFixture.cs
+++ b/src/Nancy.Validation.DataAnnotatioins.Tests/DefaultValidatableObjectAdapterFixture.cs
@@ -63,6 +63,19 @@
             results.Count().ShouldEqual(2);
         }
 
+        [Fact]
+        public void Should_not_return_errors_if_model_not_implements_IValidatableObject()
+        {
+            // Given
+            var instance = new ModelNotImplementingIValidatableObject();
+
+            // When
+            var result = this.validator.Validate(instance);
+
+            // Then
+            result.Count().ShouldEqual(0);
+        }
+
         public class ModelUnderTest : IValidatableObject
         {
             public object InstanceBeingValidated { get; set; }
@@ -78,6 +91,11 @@
                 
                 return this.ExpectedResults ?? Enumerable.Empty<ValidationResult>();
             }
+        }
+
+        public class ModelNotImplementingIValidatableObject
+        {
+            public int Value { get; set; }
         }
     }
 }

--- a/src/Nancy.Validation.DataAnnotations/DefaultValidatableObjectAdapter.cs
+++ b/src/Nancy.Validation.DataAnnotations/DefaultValidatableObjectAdapter.cs
@@ -16,11 +16,19 @@
         /// <returns>An <see cref="IEnumerable{T}"/> instance, containing <see cref="ModelValidationError"/> objects.</returns>
         public IEnumerable<ModelValidationError> Validate(object instance)
         {
+            var validateable =
+                instance as IValidatableObject;
+
+            if (validateable == null)
+            {
+                return Enumerable.Empty<ModelValidationError>();
+            }
+
             var context =
                 new ValidationContext(instance, null, null);
 
             var result =
-                ((IValidatableObject)instance).Validate(context);
+                validateable.Validate(context);
 
             return result.Select(r => new ModelValidationError(r.MemberNames, r.ErrorMessage));
         }


### PR DESCRIPTION
Part of model validation overhaul update incorrectly added a requirements on models to implement IValidatableObject
