### PR TITLE
Prevent ArgumentOutOfRangeException for emtpy files

### DIFF
--- a/src/Nancy/Responses/GenericFileResponse.cs
+++ b/src/Nancy/Responses/GenericFileResponse.cs
@@ -157,7 +157,12 @@ namespace Nancy.Responses
 
             this.Headers["ETag"] = etag;
             this.Headers["Last-Modified"] = lastModified;
-            this.Contents = GetFileContent(fullPath, fi.Length);
+            
+            if (fi.Length > 0)
+            {
+                this.Contents = GetFileContent(fullPath, fi.Length);
+            }
+            
             this.ContentType = contentType;
             this.StatusCode = HttpStatusCode.OK;
         }


### PR DESCRIPTION
What the title says :smile:

If you try to return `Response.AsFile(...)` with and empty file. The following exception will be thrown:

```
[ArgumentOutOfRangeException: Positive number required.
Parameter name: bufferSize]
   System.IO.Stream.CopyTo(Stream destination, Int32 bufferSize) +11218826
   Nancy.Responses.<>c__DisplayClass1.<GetFileContent>b__0(Stream stream) +192
   Nancy.Hosting.Aspnet.NancyHandler.SetNancyResponseToHttpResponse(HttpContextBase context, Response response) +272
   Nancy.Hosting.Aspnet.NancyHandler.EndProcessRequest(Task`1 task) +279
   Nancy.Hosting.Aspnet.NancyHttpRequestHandler.EndProcessRequest(IAsyncResult result) +73
   System.Web.CallHandlerExecutionStep.OnAsyncHandlerCompletion(IAsyncResult ar) +129
   System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw() +22
   System.Web.AsyncStepCompletionInfo.ReportError() +16
   System.Web.CallHandlerExecutionStep.System.Web.HttpApplication.IExecutionStep.Execute() +9688714
   System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& completedSynchronously) +155
```

This check should fix that
