### PR TITLE
Removed explicit registration of IModelValidationFactory

### DIFF
--- a/src/Nancy.Validation.DataAnnotations/Registrations.cs
+++ b/src/Nancy.Validation.DataAnnotations/Registrations.cs
@@ -14,7 +14,6 @@ namespace Nancy.Validation.DataAnnotations
         public Registrations()
         {
             this.Register<IModelValidator>(typeof(DataAnnotationsValidator));
-            this.Register<IModelValidatorFactory>(typeof(DataAnnotationsValidatorFactory));
             this.RegisterAll<IDataAnnotationsValidatorAdapter>();
             this.RegisterWithDefault<IPropertyValidatorFactory>(typeof(DefaultPropertyValidatorFactory));
             this.RegisterWithDefault<IValidatableObjectAdapter>(typeof(DefaultValidatableObjectAdapter));

--- a/src/Nancy.Validation.FluentValidation/Registrations.cs
+++ b/src/Nancy.Validation.FluentValidation/Registrations.cs
@@ -16,9 +16,7 @@ namespace Nancy.Validation.FluentValidation
         public Registrations()
         {
             this.Register<IModelValidator>(typeof(FluentValidationValidator));
-            this.Register<IModelValidatorFactory>(typeof(FluentValidationValidatorFactory));
             this.Register<IFluentAdapterFactory>(typeof(DefaultFluentAdapterFactory));
-
             this.RegisterAll<IFluentAdapter>();
             this.RegisterAll<IValidator>();
         }


### PR DESCRIPTION
They where being registered both by using `IApplicationRegistration`, in the validation packages, and through the `ModelValidationFactories` in the `NancyBootstrapperBase`
