### PR TITLE
Fix JsonSettings XML docs typo

### DIFF
--- a/src/Nancy/Json/JsonSettings.cs
+++ b/src/Nancy/Json/JsonSettings.cs
@@ -27,7 +27,7 @@ namespace Nancy.Json
         
         /// <summary>
         /// Set to true to retain the casing used in the C# code in produced JSON.
-        /// Set to false to use camelCasig in the produced JSON.
+        /// Set to false to use camelCasing in the produced JSON.
         /// False by default.
         /// </summary>
         public static bool RetainCasing { get; set; }


### PR DESCRIPTION
1. Find a typo
2. Fix it
3. ...
4. PROFIT

:metal: 
