### PR TITLE
Workaround Mono HttpListener bug

### DIFF
--- a/src/Nancy.Hosting.Self/NancyHost.cs
+++ b/src/Nancy.Hosting.Self/NancyHost.cs
@@ -223,7 +223,7 @@
         {
             foreach (var baseUri in this.baseUriList)
             {
-                var prefix = baseUri.ToString();
+                var prefix = baseUri.Scheme + "://" + baseUri.Host + ":" + baseUri.Port + baseUri.AbsolutePath;
 
                 if (this.configuration.RewriteLocalhost && !baseUri.Host.Contains("."))
                 {


### PR DESCRIPTION
This is more like suggestion then actual pull request since I'm not 100% that baseUri.AbsolutePath is covering all scenarios... One other option could be baseUri.OriginalString(breaking change?)

For more info about Mono bug see https://github.com/mono/mono/pull/891 and http://stackoverflow.com/questions/19741880/nancy-mono-self-host-wont-start-on-port-80.

Basically problem is that with ToString() ports 80 and 443 are removed and Mono's HttpListener has bug that does not listen on default port if port is not specified but random. This workaround is to be able to work on older versions of Mono because apt-get mono is updating really slow and will take probably year to get into apt-get...

As you wish ;)
