### PR TITLE
Remove ModelValidationResult.Valid so every request is unique

### DIFF
--- a/src/Nancy.Tests/Unit/Validation/ModuleExtensionsFixture.cs
+++ b/src/Nancy.Tests/Unit/Validation/ModuleExtensionsFixture.cs
@@ -38,7 +38,7 @@
         {
             // Given
             var validator = A.Fake<IModelValidator>();
-            A.CallTo(() => validator.Validate(A<object>.Ignored, A<NancyContext>._)).Returns(ModelValidationResult.Valid);
+            A.CallTo(() => validator.Validate(A<object>.Ignored, A<NancyContext>._)).Returns(new ModelValidationResult());
             A.CallTo(() => validatorLocator.GetValidatorForType(A<Type>.Ignored)).Returns(validator);
 
             // When

--- a/src/Nancy/NancyContext.cs
+++ b/src/Nancy/NancyContext.cs
@@ -96,7 +96,7 @@ namespace Nancy
         /// </summary>
         public ModelValidationResult ModelValidationResult
         {
-            get { return this.modelValidationResult ?? ModelValidationResult.Valid; }
+            get { return this.modelValidationResult ?? (this.modelValidationResult = new ModelValidationResult()); }
             set { this.modelValidationResult = value; }
         }
 

--- a/src/Nancy/Validation/CompositeValidator.cs
+++ b/src/Nancy/Validation/CompositeValidator.cs
@@ -51,7 +51,7 @@
                 .ToDictionary(x => x.Key, x => x.Value); ;
 
             return (!errors.Any()) ?
-                ModelValidationResult.Valid :
+                new ModelValidationResult() :
                 new ModelValidationResult(errors);
         }
 

--- a/src/Nancy/Validation/ModelValidationResult.cs
+++ b/src/Nancy/Validation/ModelValidationResult.cs
@@ -10,10 +10,12 @@
     public class ModelValidationResult
     {
         /// <summary>
-        /// Represents an instance of the <see cref="ModelValidationResult"/> type that will
-        /// return <see langword="true"/> when <see cref="IsValid"/> is queried.
+        /// Initializes a new instance of the <see cref="ModelValidationResult"/> class.
         /// </summary>
-        public static readonly ModelValidationResult Valid = new ModelValidationResult();
+        public ModelValidationResult()
+            : this(Enumerable.Empty<ModelValidationError>())
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ModelValidationResult"/> class.
@@ -31,11 +33,6 @@
         public ModelValidationResult(IDictionary<string, IList<ModelValidationError>> errors)
         {
             this.Errors = errors;
-        }
-
-        private ModelValidationResult()
-            : this(Enumerable.Empty<ModelValidationError>())
-        {
         }
 
         /// <summary>

--- a/src/Nancy/Validation/ModuleExtensions.cs
+++ b/src/Nancy/Validation/ModuleExtensions.cs
@@ -20,7 +20,7 @@
                 module.ValidatorLocator.GetValidatorForType(typeof(T));
 
             var result = (validator == null) ?
-                ModelValidationResult.Valid :
+                new ModelValidationResult() :
                 validator.Validate(instance, module.Context);
 
             if (module.ModelValidationResult.Errors.Any())


### PR DESCRIPTION
This prevents the user from modifying a valid result and then those changes persisting to future requests. Fixes #1457
