### PR TITLE
Fix test in DefaultBinderFixture

### DIFF
--- a/src/Nancy.Tests/Unit/ModelBinding/DefaultBinderFixture.cs
+++ b/src/Nancy.Tests/Unit/ModelBinding/DefaultBinderFixture.cs
@@ -278,19 +278,19 @@ namespace Nancy.Tests.Unit.ModelBinding
             context.Request.Form["AnotherIntProperty"] = "morebad";
 
             // Then
-            Assert.Throws<ModelBindingException>(() => binder.Bind(context, typeof(TestModel), null, BindingConfig.Default))
+            Type modelType = typeof(TestModel);
+            Assert.Throws<ModelBindingException>(() => binder.Bind(context, modelType, null, BindingConfig.Default))
                 .ShouldMatch(exception =>
-                             exception.BoundType == typeof(TestModel)
+                             exception.BoundType == modelType
                              && exception.PropertyBindingExceptions.Any(pe =>
                                                                         pe.PropertyName == "IntProperty"
-                                                                        && pe.AttemptedValue == "badint"
-                                                                        && pe.InnerException.Message.Contains("badint")
-                                                                        && pe.InnerException.Message.Contains("Int32"))
+                                                                        && pe.AttemptedValue == "badint")
                              && exception.PropertyBindingExceptions.Any(pe =>
                                                                         pe.PropertyName == "AnotherIntProperty"
-                                                                        && pe.AttemptedValue == "morebad"
-                                                                        && pe.InnerException.Message.Contains("morebad")
-                                                                        && pe.InnerException.Message.Contains("Int32")));
+                                                                        && pe.AttemptedValue == "morebad")
+                             && exception.PropertyBindingExceptions.All(pe =>
+                                                                        pe.InnerException.Message.Contains(pe.AttemptedValue)
+                                                                        && pe.InnerException.Message.Contains(modelType.GetProperty(pe.PropertyName).PropertyType.Name)));
         }
 
         [Fact]


### PR DESCRIPTION
In test Should_throw_ModelBindingException_if_convertion_of_a_property_fails we compare inner exception message with constant in english. Using another locale (for example rus) this test is always failed. I change constant to a general pattern.
