### PR TITLE
Fixing data annotations unit tests

### DIFF
--- a/src/Nancy.Validation.DataAnnotatioins.Tests/DataAnnotationValidatorFixture.cs
+++ b/src/Nancy.Validation.DataAnnotatioins.Tests/DataAnnotationValidatorFixture.cs
@@ -142,7 +142,7 @@
         {
             protected override ValidationResult IsValid(object value, ValidationContext validationContext)
             {
-                return new ValidationResult("Oops");
+                return new ValidationResult("Oops", new[] { string.Empty });
             }
         }
 

--- a/src/Nancy.Validation.DataAnnotations/DataAnnotationsValidatorAdapter.cs
+++ b/src/Nancy.Validation.DataAnnotations/DataAnnotationsValidatorAdapter.cs
@@ -38,7 +38,7 @@
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="ModelValidationRule"/> instances.</returns>
         public virtual IEnumerable<ModelValidationRule> GetRules(ValidationAttribute attribute, PropertyDescriptor descriptor)
         {
-            yield return new ModelValidationRule(ruleType, attribute.FormatErrorMessage, descriptor == null ? null : new[] { descriptor.Name });
+            yield return new ModelValidationRule(ruleType, attribute.FormatErrorMessage, new [] { descriptor == null ? string.Empty : descriptor.Name });
         }
 
         /// <summary>

--- a/src/Nancy.Validation.DataAnnotations/DefaultPropertyValidatorFactory.cs
+++ b/src/Nancy.Validation.DataAnnotations/DefaultPropertyValidatorFactory.cs
@@ -38,6 +38,17 @@
             var results =
                 new List<IPropertyValidator>();
 
+            var classAttributes =
+                typeDescriptor.GetAttributes().OfType<ValidationAttribute>();
+
+            var classValidator =
+                new PropertyValidator
+                {
+                    AttributeAdaptors = this.GetAttributeAdaptors(classAttributes)
+                };
+
+            results.Add(classValidator);
+
             foreach (PropertyDescriptor descriptor in propertyDescriptors)
             {
                 var attributes =


### PR DESCRIPTION
The first commit turns the tests back on but they don't pass because the validation refactoring removed class level attribute support. The second commit tries to add this back in.

From what I know ASP.NET MVC adds class level errors to the results with an empty member name which is what I did here. This also required modifying the custom attribute in the tests to return a member name otherwise the tests still failed.

Another option is to modify the `OopsAdapter` and override the `Validate` function like this

``` c#
yield return new ModelValidationError(new[] { string.Empty }, result.ErrorMessage);
```

I think this is the better of the two options, I just don't like how the rest of the function is duplicated. I had to do this when implementing an adapter for the `CompareAttribute` so maybe this could be refactored a bit more to remove the duplication?

I still need to make the change to handle display names as per https://github.com/NancyFx/Nancy/issues/1469 but I was looking for feedback on these changes first.
