### PR TITLE
Update data annotations validation to support the DisplayName attribute

### DIFF
--- a/src/Nancy.Validation.DataAnnotatioins.Tests/DataAnnotationValidatorFixture.cs
+++ b/src/Nancy.Validation.DataAnnotatioins.Tests/DataAnnotationValidatorFixture.cs
@@ -1,6 +1,7 @@
 ﻿namespace Nancy.Validation.DataAnnotations.Tests
 {
     using System;
+    using System.ComponentModel;
     using System.ComponentModel.DataAnnotations;
     using System.Linq;
 
@@ -161,9 +162,25 @@
             subject.Description.Rules.SelectMany(r => r.Value).ShouldHave(r => r.RuleType == "Oops" && r.MemberNames.Contains(string.Empty));
         }
 
+        [Fact]
+        public void Should_use_display_name_attribute()
+        {
+            // Given
+            var subject = this.factory.Create(typeof(TestModel));
+            var instance = new TestModel { FirstName = "a long name", Age = "1" };
+
+            // When
+            var result = subject.Validate(instance, new NancyContext());
+
+            // Then
+            result.IsValid.ShouldBeFalse();
+            result.Errors["FirstName"][0].ErrorMessage.ShouldContain("First Name");
+        }
+
         [OopsValidation]
         private class TestModel : IValidatableObject
         {
+            [DisplayName("First Name")]
             [Required]
             [StringLength(5)]
             public string FirstName { get; set; }

--- a/src/Nancy.Validation.DataAnnotatioins.Tests/DataAnnotationValidatorFixture.cs
+++ b/src/Nancy.Validation.DataAnnotatioins.Tests/DataAnnotationValidatorFixture.cs
@@ -202,7 +202,7 @@
         {
             protected override ValidationResult IsValid(object value, ValidationContext validationContext)
             {
-                return new ValidationResult("Oops", new[] { string.Empty });
+                return new ValidationResult("Oops");
             }
         }
 
@@ -216,6 +216,11 @@
             public override bool CanHandle(ValidationAttribute attribute)
             {
                 return attribute.GetType() == typeof(OopsValidationAttribute);
+            }
+
+            protected override ModelValidationError GetValidationError(ValidationResult result, ValidationContext context, ValidationAttribute attribute)
+            {
+                return new ModelValidationError(new[] { string.Empty }, result.ErrorMessage);
             }
         }
 

--- a/src/Nancy.Validation.DataAnnotatioins.Tests/DataAnnotationValidatorFixture.cs
+++ b/src/Nancy.Validation.DataAnnotatioins.Tests/DataAnnotationValidatorFixture.cs
@@ -65,7 +65,7 @@
 
             // Then
             subject.Description.ShouldNotBeNull();
-            subject.Description.Rules.SelectMany(r => r.Value).ShouldHaveCount(9);
+            subject.Description.Rules.SelectMany(r => r.Value).ShouldHaveCount(10);
         }
 
         [Fact]
@@ -163,7 +163,22 @@
         }
 
         [Fact]
-        public void Should_use_display_name_attribute()
+        public void Should_use_display_attribute()
+        {
+            // Given
+            var subject = this.factory.Create(typeof(TestModel));
+            var instance = new TestModel { FirstName = "name", LastName = "a long name", Age = "1" };
+
+            // When
+            var result = subject.Validate(instance, new NancyContext());
+
+            // Then
+            result.IsValid.ShouldBeFalse();
+            result.Errors["LastName"][0].ErrorMessage.ShouldContain("Last Name");
+        }
+
+        [Fact]
+        public void Should_use_displayname_attribute()
         {
             // Given
             var subject = this.factory.Create(typeof(TestModel));
@@ -184,6 +199,10 @@
             [Required]
             [StringLength(5)]
             public string FirstName { get; set; }
+
+            [Display(Name = "Last Name")]
+            [StringLength(5)]
+            public string LastName { get; set; }
 
             [RegularExpression("\\d+")]
             [Required]

--- a/src/Nancy.Validation.DataAnnotations/DataAnnotationsValidatorAdapter.cs
+++ b/src/Nancy.Validation.DataAnnotations/DataAnnotationsValidatorAdapter.cs
@@ -59,7 +59,8 @@
 
             if (descriptor != null)
             {
-                if (!string.IsNullOrEmpty(descriptor.DisplayName))
+                // Display(Name) will auto populate the context, while DisplayName() needs to be manually set
+                if (validationContext.MemberName == validationContext.DisplayName && !string.IsNullOrEmpty(descriptor.DisplayName))
                 {
                     validationContext.DisplayName = descriptor.DisplayName;
                 }

--- a/src/Nancy.Validation.DataAnnotations/DataAnnotationsValidatorAdapter.cs
+++ b/src/Nancy.Validation.DataAnnotations/DataAnnotationsValidatorAdapter.cs
@@ -72,8 +72,20 @@
 
             if (result != null)
             {
-                yield return new ModelValidationError(result.MemberNames, result.ErrorMessage);
+                yield return this.GetValidationError(result, validationContext, attribute);
             }
+        }
+
+        /// <summary>
+        /// Gets a <see cref="ModelValidationError"/> instance based on the supplied <see cref="ValidationResult"/>.
+        /// </summary>
+        /// <param name="result">The <see cref="ValidationResult"/> to create a <see cref="ModelValidationError"/> for.</param>
+        /// <param name="context">The <see cref="ValidationContext"/> of the supplied <see cref="ValidationResult"/>.</param>
+        /// <param name="attribute">The <see cref="ValidationAttribute"/> being validated.</param>
+        /// <returns>A <see cref="ModelValidationError"/> of member names.</returns>
+        protected virtual ModelValidationError GetValidationError(ValidationResult result, ValidationContext context, ValidationAttribute attribute)
+        {
+            return new ModelValidationError(result.MemberNames, result.ErrorMessage);
         }
     }
 }

--- a/src/Nancy.Validation.DataAnnotations/DataAnnotationsValidatorAdapter.cs
+++ b/src/Nancy.Validation.DataAnnotations/DataAnnotationsValidatorAdapter.cs
@@ -57,8 +57,13 @@
                     MemberName = descriptor == null ? null : descriptor.Name
                 };
 
-            if(descriptor != null)
+            if (descriptor != null)
             {
+                if (!string.IsNullOrEmpty(descriptor.DisplayName))
+                {
+                    validationContext.DisplayName = descriptor.DisplayName;
+                }
+
                 instance = descriptor.GetValue(instance);
             }
 
@@ -67,7 +72,7 @@
 
             if (result != null)
             {
-                yield return new ModelValidationError(result.MemberNames, string.Join(" ", result.MemberNames.Select(attribute.FormatErrorMessage)));
+                yield return new ModelValidationError(result.MemberNames, result.ErrorMessage);
             }
         }
     }


### PR DESCRIPTION
This fixes https://github.com/NancyFx/Nancy/issues/1469

It also contains a change to allow modifying the `ModelValidationError` returned from the `Validate` method without the need to override it.

This is useful for class level validators which won't return member names, or even built-in attributes such as the `CompareAttribute` which also doesn't return member names.
