### PR TITLE
Maintain QueryWrapper Selector

### DIFF
--- a/src/Nancy.Testing.Tests/QueryWrapperTests.cs
+++ b/src/Nancy.Testing.Tests/QueryWrapperTests.cs
@@ -12,13 +12,13 @@ namespace Nancy.Testing.Tests
         public void Should_use_cq_find_when_indexer_invoked()
         {
             // Given
-            var document = 
+            var document =
                 CQ.Create(@"<html><head></head><body><div id='testId' class='myClass'>Test</div></body></html>");
 
             var queryResult =
                 document.Find("#testId").FirstOrDefault();
 
-            var wrapper = 
+            var wrapper =
                 new QueryWrapper(document);
 
             // When
@@ -27,6 +27,26 @@ namespace Nancy.Testing.Tests
             // Then
             Assert.NotNull(result);
             Assert.Same(queryResult, result);
+        }
+
+        [Fact]
+        public void Should_filter_selection_when_second_indexer_invoked()
+        {
+            // Given
+            var document =
+                CQ.Create(
+                    @"<html><head></head><body><table><tr><td></td><td></td></tr><tr><td></td><td></td></tr></body></html>");
+
+            var wrapper = new QueryWrapper(document);
+
+            var row = wrapper["tr:first"];
+
+            // When
+            var cells = row["td"];
+
+            // Then
+            Assert.NotNull(cells);
+            Assert.Equal(2, cells.Count());
         }
     }
 }

--- a/src/Nancy.Testing/QueryWrapper.cs
+++ b/src/Nancy.Testing/QueryWrapper.cs
@@ -27,7 +27,13 @@
         /// <returns>A <see cref="QueryWrapper"/> instance</returns>
         public QueryWrapper this[string selector]
         {
-            get { return new QueryWrapper(this.document[selector]); }
+            get
+            {
+                var newDocument = this.document.Selector == null
+                                      ? this.document
+                                      : new CQ(this.document.RenderSelection());
+                return new QueryWrapper(newDocument[selector]);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
I'm not sure if this is a valid issue or not, but when selecting an element from the response:

var row = response.Body["tr:first"];

And then querying the cells in that row:

var cells = row["td"];

The scope of the query resets to the main document rather than just the current selection which wasn't what I expected. 

Thoughts?
