### PR TITLE
Updated the minetype for javascript

### DIFF
--- a/src/Nancy/MimeTypes.cs
+++ b/src/Nancy/MimeTypes.cs
@@ -212,7 +212,7 @@ namespace Nancy
 			mimeTypes.Add ("jpe", "image/jpeg");
 			mimeTypes.Add ("jpg", "image/jpeg");
 			mimeTypes.Add ("jps", "image/x-jps");
-			mimeTypes.Add ("js", "application/x-javascript");
+			mimeTypes.Add ("js", "application/javascript");
 			mimeTypes.Add ("json", "application/json");
 			mimeTypes.Add ("jut", "image/jutvision");
 			mimeTypes.Add ("kar", "audio/midi");


### PR DESCRIPTION
It used to be application/x-javascript, but was change to use
application/javascript instread. This is in line with the RFC 4329
http://tools.ietf.org/html/rfc4329#section-3
