### PR TITLE
JSON serializer with *any* [ScriptIgnore] attribute

### DIFF
--- a/src/Nancy/Json/JsonSerializer.cs
+++ b/src/Nancy/Json/JsonSerializer.cs
@@ -33,6 +33,7 @@ namespace Nancy.Json
     using System.Collections.Generic;
     using System.Globalization;
     using System.IO;
+    using System.Linq;
     using System.Reflection;
     using System.Text;
 
@@ -265,8 +266,8 @@ namespace Nancy.Json
 			getMethod = null;
 			if (mi == null)
 				return true;
-			
-			if (mi.IsDefined (typeof (ScriptIgnoreAttribute), true))
+
+			if (mi.GetCustomAttributes(true).Any(a => a.GetType().Name == "ScriptIgnoreAttribute"))
 				return true;
 			
 			FieldInfo fi = mi as FieldInfo;


### PR DESCRIPTION
JSON serializer now recognizes any [ScriptIgnore] attribute (regardless of what namespace it came from).

So you can use the one provided by Nancy itself, but also the standard .NET one from System.Web.Extensions.
