### PR TITLE
Fix incorrect error traces message

### DIFF
--- a/src/Nancy/ErrorHandling/DefaultStatusCodeHandler.cs
+++ b/src/Nancy/ErrorHandling/DefaultStatusCodeHandler.cs
@@ -13,7 +13,7 @@ namespace Nancy.ErrorHandling
     /// </summary>
     public class DefaultStatusCodeHandler : IStatusCodeHandler
     {
-        private const string DisableErrorTracesTrueMessage = "Error details are currently disabled. Please set <code>StaticConfiguration.DisableErrorTraces = true;</code> to enable.";
+        private const string DisableErrorTracesTrueMessage = "Error details are currently disabled. Please set <code>StaticConfiguration.DisableErrorTraces = false;</code> to enable.";
 
         private readonly IDictionary<HttpStatusCode, string> errorPages;
 


### PR DESCRIPTION
When error traces are disabled and some error occurs, the page returned currently tells you to set `DisableErrorTraces = true;` to see the error details.

This should be `DisableErrorTraces = false;`
