### PR TITLE
Added a MaterialisingResponse

### DIFF
--- a/src/Nancy.Demo.Hosting.Aspnet/MainModule.cs
+++ b/src/Nancy.Demo.Hosting.Aspnet/MainModule.cs
@@ -70,6 +70,12 @@ namespace Nancy.Demo.Hosting.Aspnet
                 return View["razor.cshtml", model];
             };
 
+            Get["/razor-divzero"] = x =>
+            {
+                var model = new { FirstName = "Frank", Number = 22 };
+                return View["razor-divzero.cshtml", model];
+            };
+
             Get["/razorError"] = x =>
             {
                 var model = new RatPack { FirstName = "Frank" };

--- a/src/Nancy.Demo.Hosting.Aspnet/Nancy.Demo.Hosting.Aspnet.csproj
+++ b/src/Nancy.Demo.Hosting.Aspnet/Nancy.Demo.Hosting.Aspnet.csproj
@@ -196,6 +196,7 @@
     <None Include="Views\anon.spark" />
     <Content Include="Views\csrf.cshtml" />
     <Content Include="Views\razor-strong.cshtml" />
+    <Content Include="Views\razor-divzero.cshtml" />
     <None Include="Views\razor-strong.vbhtml" />
     <None Include="Views\dot.liquid" />
     <Content Include="Views\razor-dependency.cshtml" />

--- a/src/Nancy.Demo.Hosting.Aspnet/Views/razor-divzero.cshtml
+++ b/src/Nancy.Demo.Hosting.Aspnet/Views/razor-divzero.cshtml
@@ -1,0 +1,14 @@
+﻿@{
+    Layout = "razor-layout.cshtml";
+}
+@section Header
+{
+    <!-- This comment should appear in the header -->
+}
+<h1>Hello @Model.FirstName</h1>
+<p>This is a sample Razor view! @(Model.Number / 0)</p>
+@section Footer
+{
+<p>This is footer content!</p>
+    <img src='@Url.Content("~/content/face.png")' alt="Face"/>
+}

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -199,6 +199,7 @@
     <Compile Include="Jsonp.cs" />
     <Compile Include="JsonpApplicationStartup.cs" />
     <Compile Include="RequestExecutionException.cs" />
+    <Compile Include="Responses\MaterialisingResponse.cs" />
     <Compile Include="Responses\NegotiatedResponse.cs" />
     <Compile Include="Responses\Negotiation\DefaultResponseNegotiator.cs" />
     <Compile Include="Responses\Negotiation\IResponseNegotiator.cs" />

--- a/src/Nancy/Responses/MaterialisingResponse.cs
+++ b/src/Nancy/Responses/MaterialisingResponse.cs
@@ -1,0 +1,31 @@
+﻿namespace Nancy.Responses
+{
+    using System.IO;
+
+    /// <summary>
+    /// Takes an existing response and materialises the body.
+    /// Can be used as a wrapper to force execution of the deferred body for
+    /// error checking etc.
+    /// Copies the existing response into memory, so use with caution.
+    /// </summary>
+    public class MaterialisingResponse : Response
+    {
+        private readonly byte[] oldResponseOutput;
+
+        public MaterialisingResponse(Response sourceResponse)
+        {
+            this.ContentType = sourceResponse.ContentType;
+            this.Headers = sourceResponse.Headers;
+            this.StatusCode = sourceResponse.StatusCode;
+            this.ReasonPhrase = sourceResponse.ReasonPhrase;
+
+            using (var memoryStream = new MemoryStream())
+            {
+                sourceResponse.Contents.Invoke(memoryStream);
+                this.oldResponseOutput = memoryStream.ToArray();
+            }
+
+            this.Contents = stream => stream.Write(this.oldResponseOutput, 0, this.oldResponseOutput.Length);
+        }
+    }
+}

--- a/src/Nancy/Responses/Negotiation/ViewProcessor.cs
+++ b/src/Nancy/Responses/Negotiation/ViewProcessor.cs
@@ -56,7 +56,9 @@
         /// <returns>A <see cref="Response"/> instance.</returns>
         public Response Process(MediaRange requestedMediaRange, dynamic model, NancyContext context)
         {
-            return this.viewFactory.RenderView(context.NegotiationContext.ViewName, model, GetViewLocationContext(context));
+            var viewResponse = this.viewFactory.RenderView(context.NegotiationContext.ViewName, model, GetViewLocationContext(context));
+
+            return StaticConfiguration.DisableErrorTraces ? viewResponse : new MaterialisingResponse(viewResponse);
         }
 
         private static ViewLocationContext GetViewLocationContext(NancyContext context)


### PR DESCRIPTION
It executes the deferred body immediately and stores the results in memory to be sent on later.

Wired it into the ViewProcessor to catch template execution errors if error traces are on - added a demo for it to the main asp.net project.

Missing tests, so not ready to pull in yet, just putting this here to see if it fits the bill. The error message could be better, but not if there's anything we can do about that - the template has been and gone at that point.
