### PR TITLE
Changes to IRouteMetadataProvider and friends

### DIFF
--- a/src/Nancy/Routing/IRouteMetadataProvider.cs
+++ b/src/Nancy/Routing/IRouteMetadataProvider.cs
@@ -10,15 +10,17 @@ namespace Nancy.Routing
         /// <summary>
         /// Gets the <see cref="Type"/> of the metadata that is created by the provider.
         /// </summary>
-        /// <value>A <see cref="Type"/> instance.</value>
-        Type MetadataType { get; }
+        /// <param name="module">The <see cref="INancyModule"/> instance that the route is declared in.</param>
+        /// <param name="routeDescription">A <see cref="RouteDescription"/> for the route.</param>
+        /// <returns>A <see cref="Type"/> instance, or <see langword="null" /> if nothing is found.</returns>
+        Type GetMetadataType(INancyModule module, RouteDescription routeDescription);
 
         /// <summary>
         /// Gets the metadata for the provided route.
         /// </summary>
         /// <param name="module">The <see cref="INancyModule"/> instance that the route is declared in.</param>
         /// <param name="routeDescription">A <see cref="RouteDescription"/> for the route.</param>
-        /// <returns>An instance of <see cref="MetadataType"/>.</returns>
+        /// <returns>An object representing the metadata for the given route, or <see langword="null" /> if nothing is found.</returns>
         object GetMetadata(INancyModule module, RouteDescription routeDescription);
     }
 }

--- a/src/Nancy/Routing/RouteCache.cs
+++ b/src/Nancy/Routing/RouteCache.cs
@@ -1,9 +1,9 @@
 ﻿namespace Nancy.Routing
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
-    using Nancy.Bootstrapper;
-    using System;
+
     using Nancy.Culture;
 
     /// <summary>
@@ -69,9 +69,18 @@
 
         private RouteMetadata GetRouteMetadata(INancyModule module, RouteDescription routeDescription)
         {
-            var data = this.routeMetadataProviders
-                .Select(x => new {Type = x.MetadataType, Data = x.GetMetadata(module, routeDescription)})
-                .ToDictionary(x => x.Type, x => x.Data);
+            var data = new Dictionary<Type, object>();
+
+            foreach (var provider in this.routeMetadataProviders)
+            {
+                var type = provider.GetMetadataType(module, routeDescription);
+                var metadata = provider.GetMetadata(module, routeDescription);
+
+                if (type != null && metadata != null)
+                {
+                    data.Add(type, metadata);
+                }
+            }
 
             return new RouteMetadata(data);
         }

--- a/src/Nancy/Routing/RouteMetadataProvider.cs
+++ b/src/Nancy/Routing/RouteMetadataProvider.cs
@@ -9,12 +9,14 @@ namespace Nancy.Routing
     public abstract class RouteMetadataProvider<TMetadata> : IRouteMetadataProvider
     {
         /// <summary>
-        /// Gets the <see cref="Type" /> of the metadata that is created by the provider.
+        /// Gets the <see cref="Type"/> of the metadata that is created by the provider.
         /// </summary>
-        /// <value>A <see cref="Type" /> instance.</value>
-        public Type MetadataType
+        /// <param name="module">The <see cref="INancyModule"/> instance that the route is declared in.</param>
+        /// <param name="routeDescription">A <see cref="RouteDescription"/> for the route.</param>
+        /// <returns>A <see cref="Type"/> instance, or null if none are found.</returns>
+        public Type GetMetadataType(INancyModule module, RouteDescription routeDescription)
         {
-            get { return typeof(TMetadata); }
+            return typeof(TMetadata);
         }
 
         /// <summary>


### PR DESCRIPTION
These are a subset of the changes from #1519 that @thecodejunkie and @grumpydev requested be sent as a separate PR.
- A minor improvement to the `IRouteMetadataProvider` interface to allow implementations to support returning more than one type of metadata.
- A tweak to the docs for `IRouteMetadataProvider` to indicate that an implementation may return `null` if no matching metadata is found.
- A related tweak to `RouteCache` to have it handle `null` metadata.
