### PR TITLE
Support early Flush() of AspNet responses

### DIFF
--- a/src/Nancy.Hosting.Aspnet/Nancy.Hosting.Aspnet.csproj
+++ b/src/Nancy.Hosting.Aspnet/Nancy.Hosting.Aspnet.csproj
@@ -116,6 +116,7 @@
     <Compile Include="NancyFxSection.cs" />
     <Compile Include="NancyHandler.cs" />
     <Compile Include="NancyHttpRequestHandler.cs" />
+    <Compile Include="NancyResponseStream.cs" />
     <Compile Include="TinyIoCAspNetExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Nancy.Hosting.Aspnet/NancyHandler.cs
+++ b/src/Nancy.Hosting.Aspnet/NancyHandler.cs
@@ -148,7 +148,7 @@ namespace Nancy.Hosting.Aspnet
             }
 
             context.Response.StatusCode = (int)response.StatusCode;
-            response.Contents.Invoke(context.Response.OutputStream);
+            response.Contents.Invoke(new NancyResponseStream(context.Response));
         }
 
         private static void SetHttpResponseHeaders(HttpContextBase context, Response response)

--- a/src/Nancy.Hosting.Aspnet/NancyResponseStream.cs
+++ b/src/Nancy.Hosting.Aspnet/NancyResponseStream.cs
@@ -1,0 +1,71 @@
+﻿namespace Nancy.Hosting.Aspnet
+{
+    using System.IO;
+    using System.Web;
+
+    public class NancyResponseStream : Stream
+    {
+        private readonly HttpResponseBase response;
+
+        public NancyResponseStream(HttpResponseBase response)
+        {
+            this.response = response;
+        }
+        public override bool CanRead
+        {
+            get { return this.response.OutputStream.CanRead; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return this.response.OutputStream.CanSeek; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return this.response.OutputStream.CanWrite; }
+        }
+
+        public override void Flush()
+        {
+            this.response.Flush();
+        }
+
+        public override long Length
+        {
+            get { return this.response.OutputStream.Length; }
+        }
+
+        public override long Position
+        {
+            get
+            {
+                return this.response.OutputStream.Position;
+            }
+            set
+            {
+                this.response.OutputStream.Position = value;
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return this.response.OutputStream.Read(buffer, offset, count);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return this.response.OutputStream.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            this.response.OutputStream.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            this.response.OutputStream.Write(buffer, offset, count);
+        }
+    }
+}

--- a/src/Nancy.Hosting.Aspnet/NancyResponseStream.cs
+++ b/src/Nancy.Hosting.Aspnet/NancyResponseStream.cs
@@ -3,6 +3,9 @@
     using System.IO;
     using System.Web;
 
+    /// <summary>
+    /// A wrapper around an AspNet OutputStream that defers .Flush() to the parent HttpResponseBase
+    /// </summary>
     public class NancyResponseStream : Stream
     {
         private readonly HttpResponseBase response;
@@ -26,6 +29,9 @@
             get { return this.response.OutputStream.CanWrite; }
         }
 
+        /// <summary>
+        /// Calls Flush() on the wrapped HttpResponseBase
+        /// </summary>
         public override void Flush()
         {
             this.response.Flush();


### PR DESCRIPTION
Created a wrapper stream for the AspNet response.
Calling `Flush()` on the `Stream` defers to `HttpResponse.Flush()`.

it should be noted that for this to work you also need to set `StaticConfiguration.DisableErrorTraces = true;` as it buffers responses.

Thoughts?