### PR TITLE
Fix for IndexOutOfRangeException in CookieBasedSessions

### DIFF
--- a/src/Nancy.Tests/Unit/Sessions/CookieBasedSessionsFixture.cs
+++ b/src/Nancy.Tests/Unit/Sessions/CookieBasedSessionsFixture.cs
@@ -388,6 +388,21 @@ namespace Nancy.Tests.Unit.Sessions
         }
 
         [Fact]
+        public void Should_return_blank_session_if_encrypted_data_are_invalid_but_contain_semicolon_when_decrypted()
+        {
+            var bogusEncrypted = this.rijndaelEncryptionProvider.Encrypt("foo;bar");
+            var inputValue = ValidHmac + bogusEncrypted;
+            inputValue = HttpUtility.UrlEncode(inputValue);
+            var store = new CookieBasedSessions(this.rijndaelEncryptionProvider, this.defaultHmacProvider, this.defaultObjectSerializer);
+            var request = new Request("GET", "/", "http");
+            request.Cookies.Add(store.CookieName, inputValue);
+
+            var result = store.Load(request);
+
+            result.Count.ShouldEqual(0);
+        }
+
+        [Fact]
         public void Should_use_CookieName_when_config_provides_cookiename_value()
         {
             //Given

--- a/src/Nancy/Session/CookieBasedSessions.cs
+++ b/src/Nancy/Session/CookieBasedSessions.cs
@@ -184,7 +184,7 @@ namespace Nancy.Session
 
                 var data = encryptionProvider.Decrypt(encryptedCookie);
                 var parts = data.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-                foreach (var part in parts.Select(part => part.Split('=')))
+                foreach (var part in parts.Select(part => part.Split('=')).Where(part => part.Length == 2))
                 {
                     var valueObject = this.currentConfiguration.Serializer.Deserialize(HttpUtility.UrlDecode(part[1]));
 


### PR DESCRIPTION
When CookieBasedSessions loads a session cookie that was created with a different key, it still tries to build a dictionary before clearing it because the HMAC is invalid. In that process, if the decrypted string (which is bogus given that it was encrypted with a different key) happens to contain a semicolon by chance, the code starts to split it into parts and then key-value pairs. However, it doesn't check that it actually gets an array with two elements before using part[1] => IndexOutOfRangeException.

I added a check to make sure that the code only uses a part as a key-value pair if it truly is one.

This is a fix for #1083
