### PR TITLE
Added overload for SecurityHooks.RequiresHttps to set the redirect URL port

### DIFF
--- a/src/Nancy/Security/SecurityHooks.cs
+++ b/src/Nancy/Security/SecurityHooks.cs
@@ -104,7 +104,29 @@
             };
         }
 
+        /// <summary>
+        /// Creates a hook to be used in a pipeline before a route handler to ensure that
+        /// the resource is served over HTTPS
+        /// </summary>
+        /// <param name="redirect"><see langword="true"/> if the user should be redirected to HTTPS (no port number) if the incoming request was made using HTTP, otherwise <see langword="false"/> if <see cref="HttpStatusCode.Forbidden"/> should be returned.</param>
+        /// <returns>Hook that returns a RedirectResponse with the Url scheme set to HTTPS, 
+        /// or a Response with a Forbidden HTTP status code if <c>redirect</c> is false or the method is not GET,
+        /// null otherwise</returns>
         public static Func<NancyContext, Response> RequiresHttps(bool redirect)
+        {
+            return RequiresHttps(redirect, null);
+        }
+
+        /// <summary>
+        /// Creates a hook to be used in a pipeline before a route handler to ensure that
+        /// the resource is served over HTTPS
+        /// </summary>
+        /// <param name="redirect"><see langword="true"/> if the user should be redirected to HTTPS (no port number) if the incoming request was made using HTTP, otherwise <see langword="false"/> if <see cref="HttpStatusCode.Forbidden"/> should be returned.</param>
+        /// <param name="httpsPort">The HTTPS port number to use</param>
+        /// <returns>Hook that returns a <see cref="RedirectResponse"/> with the Url scheme set to HTTPS, 
+        /// or a <see cref="Response"/> with a <see cref="HttpStatusCode.Forbidden"/> status code if <c>redirect</c> is false or the method is not GET,
+        /// null otherwise</returns>
+        public static Func<NancyContext, Response> RequiresHttps(bool redirect, int? httpsPort)
         {
             return (ctx) =>
             {
@@ -115,6 +137,7 @@
                     if (redirect && request.Method.Equals("GET", StringComparison.OrdinalIgnoreCase))
                     {
                         var redirectUrl = request.Url.Clone();
+                        redirectUrl.Port = httpsPort;
                         redirectUrl.Scheme = "https";
                         response = new RedirectResponse(redirectUrl.ToString());
                     }


### PR DESCRIPTION
Hi,

This pull request is a fix for #1455. That issue is a follow up from #1005.

For consistency, I followed a similar approach by adding an overload which accepts an `ìnt?` paramater for `httpsPort`. The port value is assigned to the `Url.Port` property.

I also added comments for both methods.

Andrew
