### PR TITLE
Remove duplicate TargetFrameworkVersion properties

### DIFF
--- a/src/Nancy.Tests.Functional/Nancy.Tests.Functional.csproj
+++ b/src/Nancy.Tests.Functional/Nancy.Tests.Functional.csproj
@@ -36,7 +36,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -46,7 +45,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'MonoRelease|AnyCPU' ">


### PR DESCRIPTION
If you change the target framework version Visual Studio will update the main property but leave the conditional ones alone. You'll then spend a half hour or more trying to figure out why the project is targeting v4.5 while VS insists it's targeting v4.0 still. This should save someone some time in the future :smile:
