### PR TITLE
Metadata Module Tidyup

### DIFF
--- a/src/Nancy.Demo.Hosting.Aspnet/Metadata/MainMetadataModule.cs
+++ b/src/Nancy.Demo.Hosting.Aspnet/Metadata/MainMetadataModule.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nancy.Demo.Hosting.Aspnet.Metadata
 {
-    using Nancy.Routing;
+    using Nancy.Metadata.Module;
 
     public class MainMetadataModule : MetadataModule<MyUberRouteMetadata>
     {

--- a/src/Nancy.Metadata.Module/IMetadataModule.cs
+++ b/src/Nancy.Metadata.Module/IMetadataModule.cs
@@ -1,6 +1,8 @@
-﻿namespace Nancy.Routing
+﻿namespace Nancy.Metadata.Module
 {
     using System;
+
+    using Nancy.Routing;
 
     /// <summary>
     /// Defines facilities for obtaining metadata for a given <see cref="RouteDescription"/>.

--- a/src/Nancy.Metadata.Module/MetadataModule.cs
+++ b/src/Nancy.Metadata.Module/MetadataModule.cs
@@ -1,7 +1,9 @@
-﻿namespace Nancy.Routing
+﻿namespace Nancy.Metadata.Module
 {
     using System;
     using System.Collections.Generic;
+
+    using Nancy.Routing;
 
     /// <summary>
     /// Base class containing the functionality for obtaining metadata for a given <see cref="RouteDescription"/>.

--- a/src/Nancy.Metadata.Module/Nancy.Metadata.Module.csproj
+++ b/src/Nancy.Metadata.Module/Nancy.Metadata.Module.csproj
@@ -66,8 +66,10 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="DefaultMetadataModuleResolver.cs" />
+    <Compile Include="IMetadataModule.cs" />
     <Compile Include="IMetadataModuleResolver.cs" />
     <Compile Include="DefaultMetadataModuleConventions.cs" />
+    <Compile Include="MetadataModule.cs" />
     <Compile Include="MetadataModuleRegistrations.cs" />
     <Compile Include="MetadataModuleRouteMetadataProvider.cs" />
   </ItemGroup>

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -248,13 +248,11 @@
     <Compile Include="Routing\DefaultRouteDescriptionProvider.cs" />
     <Compile Include="Routing\DefaultRouteInvoker.cs" />
     <Compile Include="Routing\DefaultRouteSegmentExtractor.cs" />
-    <Compile Include="Routing\IMetadataModule.cs" />
     <Compile Include="Routing\IRequestDispatcher.cs" />
     <Compile Include="Routing\IRouteDescriptionProvider.cs" />
     <Compile Include="Routing\IRouteInvoker.cs" />
     <Compile Include="Routing\IRouteMetadataProvider.cs" />
     <Compile Include="Routing\IRouteSegmentExtractor.cs" />
-    <Compile Include="Routing\MetadataModule.cs" />
     <Compile Include="Routing\ParameterSegmentInformation.cs" />
     <Compile Include="Routing\ResolveResult.cs" />
     <Compile Include="Routing\OptionsRoute.cs" />


### PR DESCRIPTION
Spotted two classed in the Nancy.Routing namespace that should have got moved in the refactor to move the metadata module stuff into a separate project. This PR cleans those up by moving them to the new project.
