### PR TITLE
NancyContextExtensions JsonBody: Allow custom JavaScriptSerializer to be used for serialization

### DIFF
--- a/src/Nancy.Testing/NancyContextExtensions.cs
+++ b/src/Nancy.Testing/NancyContextExtensions.cs
@@ -50,6 +50,11 @@ namespace Nancy.Testing
 
 		public static TModel JsonBody<TModel>(this NancyContext context)
 		{
+			return context.JsonBody<TModel>(new JavaScriptSerializer());
+		}
+
+		public static TModel JsonBody<TModel>(this NancyContext context, JavaScriptSerializer serializer)
+		{
 			return Cache(context, JSONRESPONSE_KEY_NAME, () =>
 			{
 				using (var contentsStream = new MemoryStream())
@@ -58,7 +63,6 @@ namespace Nancy.Testing
 					contentsStream.Position = 0;
 					using (var contents = new StreamReader(contentsStream))
 					{
-						var serializer = new JavaScriptSerializer();
 						var model = serializer.Deserialize<TModel>(contents.ReadToEnd());
 						return model;
 					}


### PR DESCRIPTION
This is similar to https://github.com/NancyFx/Nancy/pull/1149 but allows same functionality in the JsonBody method.

Currently my unit tests use JsonBody<T>, and they are failing because I cannot set MaxJsonLength.
