### PR TITLE
Moved ITextResource from NancyModule to NancyContext

### DIFF
--- a/src/Nancy.Demo.Hosting.Aspnet/MainModule.cs
+++ b/src/Nancy.Demo.Hosting.Aspnet/MainModule.cs
@@ -16,6 +16,11 @@ namespace Nancy.Demo.Hosting.Aspnet
                 return View["routes", routeCacheProvider.GetCache()];
             };
 
+            Get["/texts"] = parameters => {
+                return (string)this.Context.Text.Menu.Home;
+                
+            };
+
             Get["/meta"] = parameters =>
             {
                 return Negotiate
@@ -32,7 +37,7 @@ namespace Nancy.Demo.Hosting.Aspnet
 
             Get["/text"] = x =>
             {
-                var value = (string)this.Text.Home;
+                var value = (string)this.Context.Text.Menu.Home;
                 return string.Concat("Value of 'Home' resource key in the Menu resource file: ", value);
             };
 

--- a/src/Nancy.Tests/Unit/Diagnostics/CustomInteractiveDiagnosticsFixture.cs
+++ b/src/Nancy.Tests/Unit/Diagnostics/CustomInteractiveDiagnosticsFixture.cs
@@ -8,6 +8,7 @@
     using Nancy.Cryptography;
     using Nancy.Culture;
     using Nancy.Diagnostics;
+    using Nancy.Localization;
     using Nancy.ModelBinding;
     using Nancy.Responses.Negotiation;
     using Nancy.Routing;
@@ -43,6 +44,7 @@
             private readonly ICultureService cultureService;
             private readonly IRequestTraceFactory requestTraceFactory;
             private readonly IEnumerable<IRouteMetadataProvider> routeMetadataProviders;
+            private readonly ITextResource textResource;
 
             public FakeDiagnostics(
                 DiagnosticsConfiguration diagnosticsConfiguration,
@@ -54,7 +56,8 @@
                 IEnumerable<IRouteSegmentConstraint> routeSegmentConstraints,
                 ICultureService cultureService,
                 IRequestTraceFactory requestTraceFactory,
-                IEnumerable<IRouteMetadataProvider> routeMetadataProviders)
+                IEnumerable<IRouteMetadataProvider> routeMetadataProviders,
+                ITextResource textResource)
             {
                 this.diagnosticsConfiguration = diagnosticsConfiguration;
                 this.diagnosticProviders = (new IDiagnosticsProvider[] { new FakeDiagnosticsProvider() }).ToArray();
@@ -67,6 +70,7 @@
                 this.cultureService = cultureService;
                 this.requestTraceFactory = requestTraceFactory;
                 this.routeMetadataProviders = routeMetadataProviders;
+                this.textResource = textResource;
             }
 
             public void Initialize(IPipelines pipelines)
@@ -82,7 +86,8 @@
                     this.routeSegmentConstraints,
                     this.cultureService,
                     this.requestTraceFactory,
-                    this.routeMetadataProviders);
+                    this.routeMetadataProviders,
+                    this.textResource);
             }
         }
 

--- a/src/Nancy.Tests/Unit/Routing/DefaultNancyModuleBuilderFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/DefaultNancyModuleBuilderFixture.cs
@@ -18,7 +18,6 @@
         private readonly NancyModule module;
         private readonly IModelBinderLocator modelBinderLocator;
         private readonly IModelValidatorLocator validatorLocator;
-        private readonly ITextResource textResource;
 
         public DefaultNancyModuleBuilderFixture()
         {
@@ -30,9 +29,8 @@
             this.viewFactory = A.Fake<IViewFactory>();
             this.modelBinderLocator = A.Fake<IModelBinderLocator>();
             this.validatorLocator = A.Fake<IModelValidatorLocator>();
-            this.textResource = A.Fake<ITextResource>();
 
-            this.builder = new DefaultNancyModuleBuilder(this.viewFactory, this.responseFormatterFactory, this.modelBinderLocator, this.validatorLocator, this.textResource);
+            this.builder = new DefaultNancyModuleBuilder(this.viewFactory, this.responseFormatterFactory, this.modelBinderLocator, this.validatorLocator);
         }
 
         [Fact]
@@ -113,32 +111,6 @@
 
             // Then
             result.ModelBinderLocator.ShouldBeSameAs(this.modelBinderLocator);
-        }
-
-        [Fact]
-        public void Should_set_text_to_textresourcefinder_instance()
-        {
-            // Given
-            var context = new NancyContext();
-
-            // When
-            var result = this.builder.BuildModule(this.module, context);
-
-            // Then
-            ((object)result.Text).ShouldBeOfType<TextResourceFinder>();
-        }
-
-        [Fact]
-        public void Should_pass_text_resource_to_textresourcefinder_instance()
-        {
-            // Given
-            var context = new NancyContext();
-
-            // When
-            var result = this.builder.BuildModule(this.module, context);
-
-            // Then
-            ((TextResourceFinder)result.Text).Resource.ShouldBeSameAs(this.textResource);
         }
     }
 }

--- a/src/Nancy/DefaultNancyContextFactory.cs
+++ b/src/Nancy/DefaultNancyContextFactory.cs
@@ -2,6 +2,7 @@ namespace Nancy
 {
     using Nancy.Culture;
     using Nancy.Diagnostics;
+    using Nancy.Localization;
 
     /// <summary>
     /// Creates NancyContext instances
@@ -10,16 +11,19 @@ namespace Nancy
     {
         private readonly ICultureService cultureService;
         private readonly IRequestTraceFactory requestTraceFactory;
+        private readonly ITextResource textResource;
 
         /// <summary>
         /// Creates a new instance of the <see cref="DefaultNancyContextFactory"/> class.
         /// </summary>
         /// <param name="cultureService">An <see cref="ICultureService"/> instance.</param>
         /// <param name="requestTraceFactory">An <see cref="IRequestTraceFactory"/> instance.</param>
-        public DefaultNancyContextFactory(ICultureService cultureService, IRequestTraceFactory requestTraceFactory)
+        /// <param name="textResource">An <see cref="ITextResource"/> instance.</param>
+        public DefaultNancyContextFactory(ICultureService cultureService, IRequestTraceFactory requestTraceFactory, ITextResource textResource)
         {
             this.cultureService = cultureService;
             this.requestTraceFactory = requestTraceFactory;
+            this.textResource = textResource;
         }
 
         /// <summary>
@@ -34,6 +38,7 @@ namespace Nancy
             context.Trace = this.requestTraceFactory.Create(request);
             context.Request = request;
             context.Culture = this.cultureService.DetermineCurrentCulture(context);
+            context.Text = new TextResourceFinder(this.textResource, context);
 
             // Move this to DefaultRequestTrace.
             context.Trace.TraceLog.WriteLog(s => s.AppendLine("New Request Started"));

--- a/src/Nancy/Diagnostics/DefaultDiagnostics.cs
+++ b/src/Nancy/Diagnostics/DefaultDiagnostics.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using ModelBinding;
     using Nancy.Bootstrapper;
+    using Nancy.Localization;
     using Nancy.Routing;
     using Nancy.Routing.Constraints;
 
@@ -25,6 +26,7 @@
         private readonly ICultureService cultureService;
         private readonly IRequestTraceFactory requestTraceFactory;
         private readonly IEnumerable<IRouteMetadataProvider> routeMetadataProviders;
+        private readonly ITextResource textResource;
 
         /// <summary>
         /// Creates a new instance of the <see cref="DefaultDiagnostics"/> class.
@@ -39,6 +41,8 @@
         /// <param name="routeSegmentConstraints"></param>
         /// <param name="cultureService"></param>
         /// <param name="requestTraceFactory"></param>
+        /// <param name="routeMetadataProviders"></param>
+        /// <param name="textResource"></param>
         public DefaultDiagnostics(
             DiagnosticsConfiguration diagnosticsConfiguration,
             IEnumerable<IDiagnosticsProvider> diagnosticProviders,
@@ -50,7 +54,8 @@
             IEnumerable<IRouteSegmentConstraint> routeSegmentConstraints,
             ICultureService cultureService,
             IRequestTraceFactory requestTraceFactory,
-            IEnumerable<IRouteMetadataProvider> routeMetadataProviders)
+            IEnumerable<IRouteMetadataProvider> routeMetadataProviders,
+            ITextResource textResource)
         {
             this.diagnosticsConfiguration = diagnosticsConfiguration;
             this.diagnosticProviders = diagnosticProviders;
@@ -63,6 +68,7 @@
             this.cultureService = cultureService;
             this.requestTraceFactory = requestTraceFactory;
             this.routeMetadataProviders = routeMetadataProviders;
+            this.textResource = textResource;
         }
 
         /// <summary>
@@ -82,7 +88,8 @@
                 this.routeSegmentConstraints,
                 this.cultureService,
                 this.requestTraceFactory,
-                this.routeMetadataProviders);
+                this.routeMetadataProviders,
+                this.textResource);
         }
     }
 }

--- a/src/Nancy/Diagnostics/DiagnosticsHook.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsHook.cs
@@ -12,6 +12,7 @@ namespace Nancy.Diagnostics
     using Helpers;
     using ModelBinding;
 
+    using Nancy.Localization;
     using Nancy.Routing.Constraints;
     using Nancy.Routing.Trie;
 
@@ -40,13 +41,14 @@ namespace Nancy.Diagnostics
             IEnumerable<IRouteSegmentConstraint> routeSegmentConstraints,
             ICultureService cultureService,
             IRequestTraceFactory requestTraceFactory,
-            IEnumerable<IRouteMetadataProvider> routeMetadataProviders)
+            IEnumerable<IRouteMetadataProvider> routeMetadataProviders,
+            ITextResource textResource)
         {
             var diagnosticsModuleCatalog = new DiagnosticsModuleCatalog(providers, rootPathProvider, requestTracing, configuration, diagnosticsConfiguration);
 
             var diagnosticsRouteCache = new RouteCache(
                 diagnosticsModuleCatalog,
-                new DefaultNancyContextFactory(cultureService, requestTraceFactory),
+                new DefaultNancyContextFactory(cultureService, requestTraceFactory, textResource),
                 new DefaultRouteSegmentExtractor(),
                 new DefaultRouteDescriptionProvider(),
                 cultureService,

--- a/src/Nancy/INancyModule.cs
+++ b/src/Nancy/INancyModule.cs
@@ -88,6 +88,6 @@ namespace Nancy
         /// <summary>
         /// Gets or sets the dynamic object used to locate text resources.
         /// </summary>
-        dynamic Text { get; set; }
+        dynamic Text { get; }
     }
 }

--- a/src/Nancy/NancyContext.cs
+++ b/src/Nancy/NancyContext.cs
@@ -110,6 +110,11 @@ namespace Nancy
         public NegotiationContext NegotiationContext { get; set; }
 
         /// <summary>
+        /// Gets or sets the dynamic object used to locate text resources.
+        /// </summary>
+        public dynamic Text { get; set; }
+
+        /// <summary>
         /// Disposes any disposable items in the <see cref="Items"/> dictionary.
         /// </summary>
         public void Dispose()

--- a/src/Nancy/NancyModule.cs
+++ b/src/Nancy/NancyModule.cs
@@ -54,7 +54,10 @@ namespace Nancy
             }
         }
 
-        public dynamic Text { get; set; }
+        public dynamic Text
+        {
+            get { return this.Context.Text; }
+        }
 
         /// <summary>
         /// Gets <see cref="RouteBuilder"/> for declaring actions for DELETE requests.

--- a/src/Nancy/Routing/DefaultNancyModuleBuilder.cs
+++ b/src/Nancy/Routing/DefaultNancyModuleBuilder.cs
@@ -16,7 +16,6 @@
         private readonly IResponseFormatterFactory responseFormatterFactory;
         private readonly IModelBinderLocator modelBinderLocator;
         private readonly IModelValidatorLocator validatorLocator;
-        private readonly ITextResource textResource;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultNancyModuleBuilder"/> class.
@@ -25,13 +24,12 @@
         /// <param name="responseFormatterFactory">An <see cref="IResponseFormatterFactory"/> instance that should be used to create a response formatter for the module.</param>
         /// <param name="modelBinderLocator">A <see cref="IModelBinderLocator"/> instance that should be assigned to the module.</param>
         /// <param name="validatorLocator">A <see cref="IModelValidatorLocator"/> instance that should be assigned to the module.</param>
-        public DefaultNancyModuleBuilder(IViewFactory viewFactory, IResponseFormatterFactory responseFormatterFactory, IModelBinderLocator modelBinderLocator, IModelValidatorLocator validatorLocator, ITextResource textResource)
+        public DefaultNancyModuleBuilder(IViewFactory viewFactory, IResponseFormatterFactory responseFormatterFactory, IModelBinderLocator modelBinderLocator, IModelValidatorLocator validatorLocator)
         {
             this.viewFactory = viewFactory;
             this.responseFormatterFactory = responseFormatterFactory;
             this.modelBinderLocator = modelBinderLocator;
             this.validatorLocator = validatorLocator;
-            this.textResource = textResource;
         }
 
         /// <summary>
@@ -49,7 +47,6 @@
             module.ViewFactory = this.viewFactory;
             module.ModelBinderLocator = this.modelBinderLocator;
             module.ValidatorLocator = this.validatorLocator;
-            module.Text = new TextResourceFinder(this.textResource, context);
 
             return module;
         }


### PR DESCRIPTION
This change makes tranlations available everywhere that the
context is available. The Text property of NancyModule is a
helper wrapper around NancyContext.Text

Resolves #1529
