### PR TITLE
Negotiation throws in status code handler

### DIFF
--- a/src/Nancy.Tests.Functional/Tests/ContentNegotiationFixture.cs
+++ b/src/Nancy.Tests.Functional/Tests/ContentNegotiationFixture.cs
@@ -122,7 +122,7 @@ namespace Nancy.Tests.Functional.Tests
                 with.Get("/headers", (x, m) =>
                 {
                     var context =
-                        new NancyContext { NegotiationContext = new NegotiationContext() };
+                        new NancyContext();
 
                     var negotiator =
                         new Negotiator(context);
@@ -156,7 +156,7 @@ namespace Nancy.Tests.Functional.Tests
                 with.Get("/customPhrase", (x, m) =>
                 {
                     var context =
-                        new NancyContext { NegotiationContext = new NegotiationContext() };
+                        new NancyContext();
 
                     var negotiator =
                         new Negotiator(context);
@@ -190,7 +190,7 @@ namespace Nancy.Tests.Functional.Tests
             with.Get("/headers", (x, m) =>
             {
               var context =
-                  new NancyContext { NegotiationContext = new NegotiationContext() };
+                  new NancyContext();
 
               var negotiator =
                   new Negotiator(context);
@@ -227,7 +227,7 @@ namespace Nancy.Tests.Functional.Tests
                     x.Get("/", (parameters, module) =>
                     {
                         var context =
-                            new NancyContext { NegotiationContext = new NegotiationContext() };
+                            new NancyContext();
 
                         var negotiator =
                             new Negotiator(context);
@@ -257,7 +257,7 @@ namespace Nancy.Tests.Functional.Tests
                     x.Get("/", (parameters, module) =>
                     {
                         var context =
-                            new NancyContext { NegotiationContext = new NegotiationContext() };
+                            new NancyContext();
 
                         var negotiator =
                             new Negotiator(context);
@@ -296,7 +296,7 @@ namespace Nancy.Tests.Functional.Tests
                     x.Get("/test", (parameters, module) =>
                     {
                         var context =
-                            new NancyContext { NegotiationContext = new NegotiationContext() };
+                            new NancyContext();
 
                         var negotiator =
                             new Negotiator(context);

--- a/src/Nancy.Tests.Functional/Tests/ContentNegotiationFixture.cs
+++ b/src/Nancy.Tests.Functional/Tests/ContentNegotiationFixture.cs
@@ -663,10 +663,14 @@ namespace Nancy.Tests.Functional.Tests
             var browser = new Browser(with => with.StatusCodeHandler<NotFoundStatusCodeHandler>());
 
             // When
-            var result = browser.Get("/not-found");
+            var result = browser.Get("/not-found", with => with.Accept("application/json"));
+
+            var response = result.Body.DeserializeJson<NotFoundStatusCodeHandlerResult>();
 
             // Then
-            Assert.Equal(HttpStatusCode.NotFound, result.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.Equal("Not Found.", response.Message);
         }
 
         private static Func<dynamic, NancyModule, dynamic> CreateNegotiatedResponse(Action<Negotiator> action = null)
@@ -810,10 +814,21 @@ namespace Nancy.Tests.Functional.Tests
 
             public void Handle(HttpStatusCode statusCode, NancyContext context)
             {
-                var error = new { StatusCode = statusCode, Message = "Not Found." };
+                var error = new NotFoundStatusCodeHandlerResult
+                {
+                    StatusCode = statusCode,
+                    Message = "Not Found."
+                };
+
                 context.Response = this.responseNegotiator.NegotiateResponse(error, context);
             }
         }
-    }
 
+        private class NotFoundStatusCodeHandlerResult
+        {
+            public HttpStatusCode StatusCode { get; set; }
+
+            public string Message { get; set; }
+        }
+    }
 }

--- a/src/Nancy.ViewEngines.Spark/NancyViewFolder.cs
+++ b/src/Nancy.ViewEngines.Spark/NancyViewFolder.cs
@@ -185,13 +185,7 @@ namespace Nancy.ViewEngines.Spark
         // Horrible hack, but we have no way to get a context
         private static NancyContext GetFakeContext()
         {
-            var ctx = new NancyContext();
-
-            ctx.Request = new Request("GET", "/", "http");
-
-            ctx.NegotiationContext = new NegotiationContext();
-
-            return ctx;
+            return new NancyContext { Request = new Request("GET", "/", "http") };
         }
 
         public class NancyViewFile : IViewFile

--- a/src/Nancy/NancyContext.cs
+++ b/src/Nancy/NancyContext.cs
@@ -28,6 +28,7 @@ namespace Nancy
             this.Items = new Dictionary<string, object>();
             this.Trace = new DefaultRequestTrace();
             this.ViewBag = new DynamicDictionary();
+            this.NegotiationContext = new NegotiationContext();
 
             // TODO - potentially additional logic to lock to ip etc?
             this.ControlPanelEnabled = true;

--- a/src/Nancy/Responses/Negotiation/NegotiationContext.cs
+++ b/src/Nancy/Responses/Negotiation/NegotiationContext.cs
@@ -5,6 +5,8 @@
     using System.Linq;
     using Cookies;
 
+    using Nancy.Extensions;
+
     /// <summary>
     /// Context for content negotiation.
     /// </summary>
@@ -93,6 +95,12 @@
             return matching ?
                 this.MediaRangeModelMappings.First(m => mediaRange.Matches(m.Key)).Value.Invoke() :
                 this.DefaultModel;
+        }
+
+        internal void SetModule(INancyModule module)
+        {
+            this.ModuleName = module.GetModuleName();
+            this.ModulePath = module.ModulePath;
         }
     }
 }

--- a/src/Nancy/Responses/Negotiation/NegotiationContext.cs
+++ b/src/Nancy/Responses/Negotiation/NegotiationContext.cs
@@ -99,6 +99,11 @@
 
         internal void SetModule(INancyModule module)
         {
+            if (module == null)
+            {
+                throw new ArgumentNullException("module");
+            }
+
             this.ModuleName = module.GetModuleName();
             this.ModulePath = module.ModulePath;
         }

--- a/src/Nancy/Responses/Negotiation/Negotiator.cs
+++ b/src/Nancy/Responses/Negotiation/Negotiator.cs
@@ -20,11 +20,6 @@ namespace Nancy.Responses.Negotiation
                 throw new ArgumentNullException("context");
             }
 
-            if (context.NegotiationContext == null)
-            {
-                throw new ArgumentException("NegotiationContext must not be null.", "context");
-            }
-
             this.NegotiationContext = context.NegotiationContext;
         }
 

--- a/src/Nancy/Responses/Negotiation/Negotiator.cs
+++ b/src/Nancy/Responses/Negotiation/Negotiator.cs
@@ -1,5 +1,7 @@
 namespace Nancy.Responses.Negotiation
 {
+    using System;
+
     public class Negotiator : IHideObjectMembers
     {
         // TODO - this perhaps should be an interface, along with the view thing above
@@ -13,6 +15,16 @@ namespace Nancy.Responses.Negotiation
         /// <param name="context">The context that should be negotiated.</param>
         public Negotiator(NancyContext context)
         {
+            if (context == null)
+            {
+                throw new ArgumentNullException("context");
+            }
+
+            if (context.NegotiationContext == null)
+            {
+                throw new ArgumentException("NegotiationContext must not be null.", "context");
+            }
+
             this.NegotiationContext = context.NegotiationContext;
         }
 

--- a/src/Nancy/Routing/DefaultNancyModuleBuilder.cs
+++ b/src/Nancy/Routing/DefaultNancyModuleBuilder.cs
@@ -39,8 +39,6 @@
         /// <returns>A fully configured <see cref="INancyModule"/> instance.</returns>
         public INancyModule BuildModule(INancyModule module, NancyContext context)
         {
-            CreateNegotiationContext(module, context);
-
             module.Context = context;
             module.Response = this.responseFormatterFactory.Create(context);
             module.ViewFactory = this.viewFactory;
@@ -48,16 +46,6 @@
             module.ValidatorLocator = this.validatorLocator;
 
             return module;
-        }
-
-        private static void CreateNegotiationContext(INancyModule module, NancyContext context)
-        {
-            // TODO - not sure if this should be here or not, but it'll do for now :)
-            context.NegotiationContext = new NegotiationContext
-                                             {
-                                                 ModuleName = module.GetModuleName(),
-                                                 ModulePath = module.ModulePath,
-                                             };
         }
     }
 }

--- a/src/Nancy/Routing/DefaultRouteResolver.cs
+++ b/src/Nancy/Routing/DefaultRouteResolver.cs
@@ -122,6 +122,9 @@
         private ResolveResult BuildResult(NancyContext context, MatchResult result)
         {
             var associatedModule = this.GetModuleFromMatchResult(context, result);
+
+            context.NegotiationContext.SetModule(associatedModule);
+
             var route = associatedModule.Routes.ElementAt(result.RouteIndex);
             var parameters = DynamicDictionary.Create(result.Parameters);
 


### PR DESCRIPTION
The negotiation throws when used in a status code handler and no module is found (404). This was discovered in http://stackoverflow.com/questions/24112091/automatic-content-negotation-when-assigning-to-response.

The `NegotiationContext` is `null` because it's set in the [`DefaultNancyModuleBuilder`](https://github.com/NancyFx/Nancy/blob/master/src/Nancy/Routing/DefaultNancyModuleBuilder.cs#L60), which never gets invoked.

This PR sets the `NegotiationContext` of the `NancyContext` in the constructor and makes the property setter `private`. This way there will always be a negotiation context available.

@Grumpydev and @TheCodeJunkie, what do you think?

Fixes #1855. Closes #1663.