### PR TITLE
Ignoring case for Secure or HttpOnly sections of the cookie header.

### DIFF
--- a/src/Nancy.Tests/Unit/RequestFixture.cs
+++ b/src/Nancy.Tests/Unit/RequestFixture.cs
@@ -593,6 +593,25 @@ namespace Nancy.Tests.Unit
         }
 
         [Fact]
+        public void Should_split_cookie_in_two_parts_with_httponly_and_secure_attribute_ignoring_case()
+        {
+            // Given, when
+            const string cookieName = "path";
+            const string cookieData = "/";
+            var headers = new Dictionary<string, IEnumerable<string>>();
+            var cookies = new List<string> { string.Format("{0}={1}; httponly; secure", cookieName, cookieData) };
+            headers.Add("cookie", cookies);
+            var newUrl = new Url
+            {
+                Path = "/"
+            };
+            var request = new Request("GET", newUrl, null, headers);
+
+            // Then
+            request.Cookies[cookieName].ShouldEqual(cookieData);
+        }
+
+        [Fact]
         public void Should_split_cookie_in_two_parts_with_httponly_attribute()
         {
             // Given, when

--- a/src/Nancy/Request.cs
+++ b/src/Nancy/Request.cs
@@ -170,8 +170,8 @@ namespace Nancy
 
                 if (parts.Length == 1)
                 {
-                    if (cookieName.Equals("HttpOnly", StringComparison.InvariantCulture) ||
-                        cookieName.Equals("Secure", StringComparison.InvariantCulture))
+                    if (cookieName.Equals("HttpOnly", StringComparison.InvariantCultureIgnoreCase) ||
+                        cookieName.Equals("Secure", StringComparison.InvariantCultureIgnoreCase))
                     {
                         continue;
                     }


### PR DESCRIPTION
We have some clients sending cookie headers on request with lower case secure and httponly bits. Simply ignoring case when checking for these situations.
