### PR TITLE
Prevent ArgumentOutOfRangeException on empty cookie

### DIFF
--- a/src/Nancy.Authentication.Forms.Tests/FormsAuthenticationFixture.cs
+++ b/src/Nancy.Authentication.Forms.Tests/FormsAuthenticationFixture.cs
@@ -415,6 +415,22 @@ namespace Nancy.Authentication.Forms.Tests
         }
 
         [Fact]
+        public void Should_not_set_user_in_context_with_empty_cookie()
+        {
+            var fakePipelines = new Pipelines();
+            var fakeMapper = A.Fake<IUserMapper>();
+            var fakeUser = new FakeUserIdentity {UserName = "Bob"};
+            A.CallTo(() => fakeMapper.GetUserFromIdentifier(this.userGuid, this.context)).Returns(fakeUser);
+            this.config.UserMapper = fakeMapper;
+            FormsAuthentication.Enable(fakePipelines, this.config);
+            this.context.Request.Cookies.Add(FormsAuthentication.FormsAuthenticationCookieName, string.Empty);
+
+            var result = fakePipelines.BeforeRequest.Invoke(this.context, new CancellationToken());
+
+            context.CurrentUser.ShouldBeNull();
+        }
+
+        [Fact]
         public void Should_not_set_user_in_context_with_invalid_hmac()
         {
             var fakePipelines = new Pipelines();

--- a/src/Nancy.Authentication.Forms/FormsAuthentication.cs
+++ b/src/Nancy.Authentication.Forms/FormsAuthentication.cs
@@ -218,8 +218,15 @@ namespace Nancy.Authentication.Forms
             {
                 return Guid.Empty;
             }
+            
+            var cookieValueEncrypted = context.Request.Cookies[formsAuthenticationCookieName];
+            
+            if (string.IsNullOrEmpty(cookieValueEncrypted))
+            {
+                return Guid.Empty;
+            }
 
-            var cookieValue = DecryptAndValidateAuthenticationCookie(context.Request.Cookies[formsAuthenticationCookieName], configuration);
+            var cookieValue = DecryptAndValidateAuthenticationCookie(cookieValueEncrypted, configuration);
 
             Guid returnGuid;
             if (String.IsNullOrEmpty(cookieValue) || !Guid.TryParse(cookieValue, out returnGuid))


### PR DESCRIPTION
An empty cookie would cause an ArgumentOutOfRangeException (edge case).

Stack trace:

```
System.ArgumentOutOfRangeException: startIndex cannot be larger than length of string. Parameter name: startIndex
at System.String.InternalSubStringWithChecks(Int32 startIndex, Int32 length, Boolean fAlwaysCopy)
at System.String.Substring(Int32 startIndex, Int32 length)
at System.String.Substring(Int32 startIndex)
at Nancy.Authentication.Forms.FormsAuthentication.DecryptAndValidateAuthenticationCookie(String cookieValue, FormsAuthenticationConfiguration configuration)
at Nancy.Authentication.Forms.FormsAuthentication.GetAuthenticatedUserFromCookie(NancyContext context, FormsAuthenticationConfiguration configuration)
at Nancy.Authentication.Forms.FormsAuthentication.<>c__DisplayClass7.<GetLoadAuthenticationHook>b__6(NancyContext context)
at Nancy.BeforePipeline.<>c__DisplayClass4.<Wrap>b__3(NancyContext ctx, CancellationToken ct)
```

The issue wasn't caused by Nancy, but this happened to a colleague, where all her cookies were empty for some reason (external ones as well).

Would you like a test for this as well?
