### PR TITLE
Added new long route constraint and updated the int route constraint to int

### DIFF
--- a/src/Nancy.Tests/Unit/Routing/ConstraintNodeRouteResolverFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/ConstraintNodeRouteResolverFixture.cs
@@ -24,6 +24,23 @@
         }
 
         [Fact]
+        public void When_int_is_larger_than_max_int_should_has_no_match()
+        {
+            var result = this.browser.Get("/intConstraint/" + long.MaxValue);
+
+            result.StatusCode.ShouldEqual(HttpStatusCode.NotFound);
+            result.Body.AsString().ShouldEqual("");
+        }
+
+        [Fact]
+        public void Should_resolve_long_constraint()
+        {
+            var result = this.browser.Get("/longConstraint/" + long.MaxValue);
+
+            result.Body.AsString().ShouldEqual("LongConstraint");
+        }
+
+        [Fact]
         public void Should_not_resolve_int_constraint()
         {
             var result = this.browser.Get("/intConstraint/foo");
@@ -294,6 +311,8 @@
             public TestModule()
             {
                 Get["/intConstraint/{value:int}"] = _ => "IntConstraint";
+
+                Get["/longConstraint/{value:long}"] = _ => "LongConstraint";
 
                 Get["/decimalConstraint/{value:decimal}"] = _ => "DecimalConstraint";
 

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -239,6 +239,7 @@
     <Compile Include="Routing\Constraints\DateTimeRouteSegmentConstraint.cs" />
     <Compile Include="Routing\Constraints\DecimalRouteSegmentConstraint.cs" />
     <Compile Include="Routing\Constraints\GuidRouteSegmentConstraint.cs" />
+    <Compile Include="Routing\Constraints\LongRouteSegmentConstraint.cs" />
     <Compile Include="Routing\Constraints\IntRouteSegmentConstraint.cs" />
     <Compile Include="Routing\Constraints\IRouteSegmentConstraint.cs" />
     <Compile Include="Routing\Constraints\LengthRouteSegmentConstraint.cs" />

--- a/src/Nancy/Routing/Constraints/IntRouteSegmentConstraint.cs
+++ b/src/Nancy/Routing/Constraints/IntRouteSegmentConstraint.cs
@@ -3,18 +3,18 @@
     using System.Globalization;
 
     /// <summary>
-    /// Constraint for <see cref="long"/> route segments.
+    /// Constraint for <see cref="int"/> route segments.
     /// </summary>
-    public class IntRouteSegmentConstraint : RouteSegmentConstraintBase<long>
+    public class IntRouteSegmentConstraint : RouteSegmentConstraintBase<int>
     {
         public override string Name
         {
             get { return "int"; }
         }
 
-        protected override bool TryMatch(string constraint, string segment, out long matchedValue)
+        protected override bool TryMatch(string constraint, string segment, out int matchedValue)
         {
-            return long.TryParse(segment, NumberStyles.Integer, CultureInfo.InvariantCulture, out matchedValue);
+            return int.TryParse(segment, NumberStyles.Integer, CultureInfo.InvariantCulture, out matchedValue);
         }
     }
 }

--- a/src/Nancy/Routing/Constraints/LongRouteSegmentConstraint.cs
+++ b/src/Nancy/Routing/Constraints/LongRouteSegmentConstraint.cs
@@ -1,0 +1,20 @@
+﻿namespace Nancy.Routing.Constraints
+{
+    using System.Globalization;
+
+    /// <summary>
+    /// Constraint for <see cref="long"/> route segments.
+    /// </summary>
+    public class LongRouteSegmentConstraint : RouteSegmentConstraintBase<long>
+    {
+        public override string Name
+        {
+            get { return "long"; }
+        }
+
+        protected override bool TryMatch(string constraint, string segment, out long matchedValue)
+        {
+            return long.TryParse(segment, NumberStyles.Integer, CultureInfo.InvariantCulture, out matchedValue);
+        }
+    }
+}


### PR DESCRIPTION
Fix for #1565 because @mat-mcloughlin was too slow.

Note:

If you have two constraints on the same URL for `int` and `long` then first in wins since the scoring will be the same. But there's no way for us to truly know which route to pick.

If the user puts in 1000 but wants it to hit the long route then it may pick the int route.

But we can't prevent this, and the user is stupid if they're making routes like this anyway.
