### PR TITLE
Fixed nuget package spec for razor 

### DIFF
--- a/src/Nancy.ViewEngines.Razor/nancy.viewengines.razor.nuspec
+++ b/src/Nancy.ViewEngines.Razor/nancy.viewengines.razor.nuspec
@@ -13,8 +13,14 @@
     <licenseUrl>https://github.com/NancyFx/Nancy/blob/master/license.txt</licenseUrl>
     <projectUrl>http://nancyfx.org</projectUrl>
     <dependencies>
-      <dependency id="Nancy" />
-      <dependency id="Microsoft.AspNet.Razor" />
+      <group>
+        <dependency id="Nancy" />
+        <dependency id="Microsoft.AspNet.Razor" />
+      </group>
+      <group targetFramework="net40">
+        <dependency id="Nancy" />
+        <dependency id="Microsoft.AspNet.Razor" version="2.0.30506" />
+      </group>
     </dependencies> 
     <tags>Nancy Viewengine Razor</tags>
   </metadata>


### PR DESCRIPTION
Fixed the nuget package targets for Razor.

For some reason nuget will will pick the 4.0 for a 4.5 project, but doesn't prevent you from upgrading. But to me it's working as expected.
# .NET 4.0

```
PM> install-package nancy.hosting.aspnet
Attempting to resolve dependency 'Nancy (≥ 0.23.0)'.
Installing 'Nancy 0.23.0'.
Successfully installed 'Nancy 0.23.0'.
Installing 'Nancy.Hosting.Aspnet 0.23.0'.
Successfully installed 'Nancy.Hosting.Aspnet 0.23.0'.
Adding 'Nancy 0.23.0' to WebApplication4.
Successfully added 'Nancy 0.23.0' to WebApplication4.
Adding 'Nancy.Hosting.Aspnet 0.23.0' to WebApplication4.
Successfully added 'Nancy.Hosting.Aspnet 0.23.0' to WebApplication4.

PM> install-package nancy.viewengines.razor
Attempting to resolve dependency 'Nancy'.
Attempting to resolve dependency 'Microsoft.AspNet.Razor (≥ 2.0.30506)'.
Installing 'Microsoft.AspNet.Razor 2.0.30506.0'.
You are downloading Microsoft.AspNet.Razor from Microsoft, the license agreement to which is available at http://www.microsoft.com/web/webpi/eula/webpages_2_eula_enu.htm. Check the package for additional dependencies, which may come with their own license agreement(s). Your use of the package and dependencies constitutes your acceptance of their license agreements. If you do not accept the license agreement(s), then delete the relevant components from your device.
Successfully installed 'Microsoft.AspNet.Razor 2.0.30506.0'.
Installing 'Nancy.Viewengines.Razor 0.0.0'.
Successfully installed 'Nancy.Viewengines.Razor 0.0.0'.
Adding 'Microsoft.AspNet.Razor 2.0.30506.0' to WebApplication4.
Successfully added 'Microsoft.AspNet.Razor 2.0.30506.0' to WebApplication4.
Adding 'Nancy.Viewengines.Razor 0.0.0' to WebApplication4.
Successfully added 'Nancy.Viewengines.Razor 0.0.0' to WebApplication4.

PM> update-package Microsoft.AspNet.Razor
Updating 'Microsoft.AspNet.Razor' from version '2.0.30506.0' to '3.1.2' in project 'WebApplication4'.
Removing 'Microsoft.AspNet.Razor 2.0.30506.0' from WebApplication4.
Successfully removed 'Microsoft.AspNet.Razor 2.0.30506.0' from WebApplication4.
Adding 'Microsoft.AspNet.Razor 3.1.2' to WebApplication4.
Installing 'Microsoft.AspNet.Razor 3.1.2'.
You are downloading Microsoft.AspNet.Razor from Microsoft, the license agreement to which is available at http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_ENU.htm. Check the package for additional dependencies, which may come with their own license agreement(s). Your use of the package and dependencies constitutes your acceptance of their license agreements. If you do not accept the license agreement(s), then delete the relevant components from your device.
Successfully installed 'Microsoft.AspNet.Razor 3.1.2'.
Uninstalling 'Microsoft.AspNet.Razor 3.1.2'.
Successfully uninstalled 'Microsoft.AspNet.Razor 3.1.2'.
Install failed. Rolling back...
update-package : Could not install package 'Microsoft.AspNet.Razor 3.1.2'. You are trying to install this package into a project that targets '.NETFramework,Version=v4.0', but the package does not contain any assembly references or content files that are 
compatible with that framework. For more information, contact the package author.
At line:1 char:1
+ update-package Microsoft.AspNet.Razor
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Update-Package], Exception
    + FullyQualifiedErrorId : NuGetCmdletUnhandledException,NuGet.PowerShell.Commands.UpdatePackageCommand


PM> 
```
# .NET 4.5

```
PM> install-package Nancy.hosting.aspnet
Attempting to resolve dependency 'Nancy (≥ 0.23.0)'.
Installing 'Nancy 0.23.0'.
Successfully installed 'Nancy 0.23.0'.
Installing 'Nancy.Hosting.Aspnet 0.23.0'.
Successfully installed 'Nancy.Hosting.Aspnet 0.23.0'.
Adding 'Nancy 0.23.0' to WebApplication2.
Successfully added 'Nancy 0.23.0' to WebApplication2.
Adding 'Nancy.Hosting.Aspnet 0.23.0' to WebApplication2.
Successfully added 'Nancy.Hosting.Aspnet 0.23.0' to WebApplication2.

PM> install-package nancy.viewengines.razor
Attempting to resolve dependency 'Nancy'.
Attempting to resolve dependency 'Microsoft.AspNet.Razor (≥ 2.0.30506)'.
Installing 'Microsoft.AspNet.Razor 2.0.30506.0'.
You are downloading Microsoft.AspNet.Razor from Microsoft, the license agreement to which is available at http://www.microsoft.com/web/webpi/eula/webpages_2_eula_enu.htm. Check the package for additional dependencies, which may come with their own license agreement(s). Your use of the package and dependencies constitutes your acceptance of their license agreements. If you do not accept the license agreement(s), then delete the relevant components from your device.
Successfully installed 'Microsoft.AspNet.Razor 2.0.30506.0'.
Installing 'Nancy.Viewengines.Razor 0.0.0'.
Successfully installed 'Nancy.Viewengines.Razor 0.0.0'.
Adding 'Microsoft.AspNet.Razor 2.0.30506.0' to WebApplication2.
Successfully added 'Microsoft.AspNet.Razor 2.0.30506.0' to WebApplication2.
Adding 'Nancy.Viewengines.Razor 0.0.0' to WebApplication2.
Successfully added 'Nancy.Viewengines.Razor 0.0.0' to WebApplication2.

PM> update-package Microsoft.AspNet.Razor
Updating 'Microsoft.AspNet.Razor' from version '2.0.30506.0' to '3.1.2' in project 'WebApplication2'.
Removing 'Microsoft.AspNet.Razor 2.0.30506.0' from WebApplication2.
Successfully removed 'Microsoft.AspNet.Razor 2.0.30506.0' from WebApplication2.
Adding 'Microsoft.AspNet.Razor 3.1.2' to WebApplication2.
Installing 'Microsoft.AspNet.Razor 3.1.2'.
You are downloading Microsoft.AspNet.Razor from Microsoft, the license agreement to which is available at http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_ENU.htm. Check the package for additional dependencies, which may come with their own license agreement(s). Your use of the package and dependencies constitutes your acceptance of their license agreements. If you do not accept the license agreement(s), then delete the relevant components from your device.
Successfully installed 'Microsoft.AspNet.Razor 3.1.2'.
Successfully added 'Microsoft.AspNet.Razor 3.1.2' to WebApplication2.
Uninstalling 'Microsoft.AspNet.Razor 2.0.30506.0'.
Successfully uninstalled 'Microsoft.AspNet.Razor 2.0.30506.0'.

PM>
```
