### PR TITLE
Fixed Asserts.Equal, expected and actual were around the wrong way

### DIFF
--- a/src/Nancy.Testing/AssertExtensions.cs
+++ b/src/Nancy.Testing/AssertExtensions.cs
@@ -70,7 +70,7 @@ namespace Nancy.Testing
         /// </summary>
         public static AndConnector<NodeWrapper> ShouldBeOfClass(this NodeWrapper node, string className)
         {
-            Asserts.Equal(node.Attributes["class"], className);
+            Asserts.Equal(className, node.Attributes["class"]);
 
             return new AndConnector<NodeWrapper>(node);
         }


### PR DESCRIPTION
I noticed while writing some failing tests using the ShouldContainAttribute extension method that the expected and actual values have been incorrectly specified in the Nancy.Testing source code.

The attached Test Failure is from the following assertion:

response.Body["form#frm1 input[name=Id]"].ShouldExistOnce().And.ShouldContainAttribute("value", "cea085d7-4106-4a69-844b-2f3fc3404dbb");

![image](https://cloud.githubusercontent.com/assets/2233210/3399286/98c012a4-fd3a-11e3-9630-4177000e3f82.png)
