### PR TITLE
Json empty body behaviour

### DIFF
--- a/src/Nancy.Tests/Unit/JsonFormatterExtensionsFixtures.cs
+++ b/src/Nancy.Tests/Unit/JsonFormatterExtensionsFixtures.cs
@@ -52,7 +52,7 @@ namespace Nancy.Tests.Unit
             using (var stream = new MemoryStream())
             {
                 nullResponse.Contents(stream);
-                Encoding.UTF8.GetString(stream.ToArray()).ShouldEqual("null");
+                Encoding.UTF8.GetString(stream.ToArray()).ShouldHaveCount(0);
             }
         }
 

--- a/src/Nancy/Responses/JsonResponse.cs
+++ b/src/Nancy/Responses/JsonResponse.cs
@@ -21,7 +21,7 @@
                 throw new InvalidOperationException("JSON Serializer not set");
             }
 
-            this.Contents = GetJsonContents(model, serializer);
+            this.Contents = model == null ? NoBody : GetJsonContents(model, serializer);
             this.ContentType = contentType;
             this.StatusCode = HttpStatusCode.OK;
         }


### PR DESCRIPTION
I tried the serializers in nancy, newtonsoft and servicestack. All three act the same for `""` as for `"null"`. 

When returning a negotiator without a body. And you request json you get `null` back. And because of that it doesn't go by the StatusCodeHandler. 
