### PR TITLE
Issue #1589 update MP3 mime type to be IANA standard "audio/mpeg"

### DIFF
--- a/src/Nancy/MimeTypes.cs
+++ b/src/Nancy/MimeTypes.cs
@@ -267,7 +267,7 @@ namespace Nancy
 			mimeTypes.Add ("movie", "video/x-sgi-movie");
 			mimeTypes.Add ("mov", "video/quicktime");
 			mimeTypes.Add ("mp2", "video/mpeg");
-			mimeTypes.Add ("mp3", "audio/mpeg3");
+			mimeTypes.Add ("mp3", "audio/mpeg");
 			mimeTypes.Add ("mp4", "video/mp4");
 			mimeTypes.Add ("mp4v", "video/mp4");
 			mimeTypes.Add ("mpa", "audio/mpeg");


### PR DESCRIPTION
Updated MIME Type for MP3 per IANA spec for MP3 file extension

http://www.iana.org/assignments/media-types/audio/mpeg
