### PR TITLE
Response pre-execute and materialising response update

### DIFF
--- a/src/Nancy.Tests/Unit/NancyEngineFixture.cs
+++ b/src/Nancy.Tests/Unit/NancyEngineFixture.cs
@@ -761,9 +761,9 @@ namespace Nancy.Tests.Unit
 
     public class PreExecuteFailureResponse : Response
     {
-        public override Task<NancyContext> PreExecute(NancyContext context)
+        public override Task PreExecute(NancyContext context)
         {
-            return TaskHelpers.GetFaultedTask<NancyContext>(new InvalidOperationException());
+            return TaskHelpers.GetFaultedTask<object>(new InvalidOperationException());
         }
     }
 }

--- a/src/Nancy/Response.cs
+++ b/src/Nancy/Response.cs
@@ -75,9 +75,9 @@ namespace Nancy
         /// </summary>
         /// <param name="context">Nancy context</param>
         /// <returns>Task for completion/erroring</returns>
-        public virtual Task<NancyContext> PreExecute(NancyContext context)
+        public virtual Task PreExecute(NancyContext context)
         {
-            return TaskHelpers.GetCompletedTask(context);
+            return TaskHelpers.GetCompletedTask();
         }
 
         /// <summary>

--- a/src/Nancy/Responses/MaterialisingResponse.cs
+++ b/src/Nancy/Responses/MaterialisingResponse.cs
@@ -17,7 +17,7 @@
         private readonly Response sourceResponse;
         private byte[] oldResponseOutput;
 
-        public override Task<NancyContext> PreExecute(NancyContext context)
+        public override Task PreExecute(NancyContext context)
         {
             try
             {
@@ -31,7 +31,7 @@
             }
             catch (Exception e)
             {
-                return TaskHelpers.GetFaultedTask<NancyContext>(e);
+                return TaskHelpers.GetFaultedTask<object>(e);
             }
         }
 


### PR DESCRIPTION
Added a PreExecute method to response that allows for pre-rendering or validation of the response before Nancy hands off to the hosting, allowing any exceptions to be captured by Nancy's normal error handling pipeline(s). Updated the materialising response to use the new method, so now the view bodies are executed after the rest of the pipeline, rather than before the post request hoook was executed, so should fix CSRF etc.
