### PR TITLE
Model binding support for fields

### DIFF
--- a/src/Nancy.Tests/Nancy.Tests.csproj
+++ b/src/Nancy.Tests/Nancy.Tests.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Unit\Json\TestPrimitiveConverter.cs" />
     <Compile Include="Unit\Json\TestPrimitiveConverterType.cs" />
     <Compile Include="Unit\MimeTypesFixture.cs" />
+    <Compile Include="Unit\ModelBinding\BindingMemberInfoFixture.cs" />
     <Compile Include="Unit\ModelBinding\ModelBindingExceptionFixture.cs" />
     <Compile Include="Unit\ModelBinding\PropertyBindingExceptionFixture.cs" />
     <Compile Include="Unit\NamedPipelineBaseFixture.cs" />

--- a/src/Nancy.Tests/Unit/ModelBinding/BindingMemberInfoFixture.cs
+++ b/src/Nancy.Tests/Unit/ModelBinding/BindingMemberInfoFixture.cs
@@ -1,0 +1,235 @@
+﻿namespace Nancy.Tests.Unit.ModelBinding
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Xml.Serialization;
+    using Nancy.ModelBinding;
+    using Xunit;
+    using Xunit.Sdk;
+
+    public class BindingMemberInfoFixture
+    {
+        [Fact]
+        public void Should_return_MemberInfo_for_properties_or_fields()
+        {
+            // Given
+            var type = typeof(TestModel);
+            var underlyingFieldInfo = type.GetFields().First();
+            var underlyingPropertyInfo = type.GetProperties().First();
+
+            // When
+            var fieldInfo = new BindingMemberInfo(underlyingFieldInfo);
+            var propertyInfo = new BindingMemberInfo(underlyingPropertyInfo);
+
+            // Then
+            fieldInfo.MemberInfo.ShouldEqual(underlyingFieldInfo);
+            propertyInfo.MemberInfo.ShouldEqual(underlyingPropertyInfo);
+        }
+
+        [Fact]
+        public void Should_return_Name_for_properties_or_fields()
+        {
+            // Given
+            var type = typeof(TestModel);
+            var underlyingFieldInfo = type.GetFields().First();
+            var underlyingPropertyInfo = type.GetProperties().First();
+
+            // When
+            var fieldInfo = new BindingMemberInfo(underlyingFieldInfo);
+            var propertyInfo = new BindingMemberInfo(underlyingPropertyInfo);
+
+            // Then
+            fieldInfo.Name.ShouldEqual(underlyingFieldInfo.Name);
+            propertyInfo.Name.ShouldEqual(underlyingPropertyInfo.Name);
+        }
+
+        [Fact]
+        public void Should_return_PropertyType_for_properties_or_fields()
+        {
+            // Given
+            var properties = BindingMemberInfo.Collect<TestModel>();
+
+            // When
+
+            // Then
+            properties.ShouldHaveCount(4);
+
+            foreach (var propInfo in properties)
+            {
+                if (propInfo.Name.StartsWith("Int"))
+                {
+                    propInfo.PropertyType.ShouldEqual(typeof(int));
+                }
+                else if (propInfo.Name.StartsWith("String"))
+                {
+                    propInfo.PropertyType.ShouldEqual(typeof(string));
+                }
+                else
+                {
+                    throw new AssertException("Internal error in unit test: Test model property/field name does not follow the expected convention: " + propInfo.Name);
+                }
+            }
+        }
+
+        [Fact]
+        public void Should_get_fields()
+        {
+            // Given
+            var propInfo = BindingMemberInfo.Collect<TestModel>().Where(prop => prop.Name.EndsWith("Field"));
+            var model = new TestModel();
+
+            // When
+            model.IntField = 669;
+            model.StringField = "testing";
+
+            // Then
+            propInfo.Single(prop => prop.PropertyType == typeof(int))
+                .GetValue(model)
+                .ShouldEqual(669);
+
+            propInfo.Single(prop => prop.PropertyType == typeof(string))
+                .GetValue(model)
+                .ShouldEqual("testing");
+        }
+
+        [Fact]
+        public void Should_set_fields()
+        {
+            // Given
+            var propInfo = BindingMemberInfo.Collect<TestModel>().Where(prop => prop.Name.EndsWith("Field"));
+            var model = new TestModel();
+
+            // When
+            propInfo.Single(prop => prop.PropertyType == typeof(int))
+                .SetValue(model, 42);
+
+            propInfo.Single(prop => prop.PropertyType == typeof(string))
+                .SetValue(model, "nineteen");
+
+            // Then
+            model.IntField.ShouldEqual(42);
+            model.StringField.ShouldEqual("nineteen");
+        }
+
+        [Fact]
+        public void Should_get_properties()
+        {
+            // Given
+            var propInfo = BindingMemberInfo.Collect<TestModel>().Where(prop => prop.Name.EndsWith("Property"));
+            var model = new TestModel();
+
+            // When
+            model.IntProperty = 1701;
+            model.StringProperty = "NancyFX Unit Testing";
+
+            // Then
+            propInfo.Single(prop => prop.PropertyType == typeof(int))
+                .GetValue(model)
+                .ShouldEqual(1701);
+
+            propInfo.Single(prop => prop.PropertyType == typeof(string))
+                .GetValue(model)
+                .ShouldEqual("NancyFX Unit Testing");
+        }
+
+        [Fact]
+        public void Should_set_properties()
+        {
+            // Given
+            var propInfo = BindingMemberInfo.Collect<TestModel>().Where(prop => prop.Name.EndsWith("Property"));
+            var model = new TestModel();
+
+            // When
+            propInfo.Single(prop => prop.PropertyType == typeof(int))
+                .SetValue(model, 2600);
+
+            propInfo.Single(prop => prop.PropertyType == typeof(string))
+                .SetValue(model, "R2D2");
+
+            // Then
+            model.IntProperty.ShouldEqual(2600);
+            model.StringProperty.ShouldEqual("R2D2");
+        }
+
+        [Fact]
+        public void Should_collect_all_bindable_members_and_skip_all_others()
+        {
+            // Given
+
+            // When
+            var properties = BindingMemberInfo.Collect<BiggerTestModel>();
+
+            // Then
+            properties.ShouldHaveCount(16);
+
+            foreach (var property in properties)
+                property.Name.ShouldStartWith("Bindable");
+        }
+
+        public class TestModel
+        {
+            public int IntField;
+            public string StringField;
+
+            public int IntProperty { get; set; }
+            public string StringProperty { get; set; }
+        }
+
+        public class BiggerTestModel
+        {
+            public int BindableIntField;
+            public int BindableIntProperty { get; set; }
+            public string BindableStringField;
+            public string BindableStringProperty { get; set; }
+            public TestModel BindableTestModelField;
+            public TestModel BindableTestModelProperty { get; set; }
+            public BiggerTestModel BindableBiggerTestModelField;
+            public BiggerTestModel BindableBiggerTestModelProperty { get; set; }
+            [XmlIgnore]
+            public IEnumerable<int> BindableEnumerableField;
+            [XmlIgnore]
+            public IEnumerable<int> BindableEnumerableProperty { get; set; }
+            public List<string> BindableListField;
+            public List<string> BindableListProperty { get; set; }
+            public double[] BindableArrayField;
+            public double[] BindableArrayProperty { get; set; }
+            public TestModel[] BindableArrayOfObjectsField;
+            public TestModel[] BindableArrayOfObjectsProperty { get; set; }
+
+            public int this[int index]
+            {
+                get { return 0; }
+                set { }
+            }
+
+            public int this[string index, int index2]
+            {
+                get { return 0; }
+                set { }
+            }
+
+            public readonly int UnbindableReadOnlyField = 74205;
+
+            public string UnbindableReadOnlyProperty
+            {
+                get { return "hi"; }
+            }
+
+            public string UnbindableWriteOnlyProperty
+            {
+                set { }
+            }
+
+            private int UnbindablePrivateField;
+
+            public static int UnbindableStaticField;
+
+            public static int UnbindableStaticProperty
+            {
+                get { return 0; }
+                set { }
+            }
+        }
+    }
+}

--- a/src/Nancy.Tests/Unit/ModelBinding/DefaultBodyDeserializers/JsonBodyDeserializerFixture.cs
+++ b/src/Nancy.Tests/Unit/ModelBinding/DefaultBodyDeserializers/JsonBodyDeserializerFixture.cs
@@ -115,7 +115,7 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
             var context = new BindingContext()
             {
                 DestinationType = typeof(TimeSpan),
-                ValidModelProperties = typeof(TimeSpan).GetProperties(),
+                ValidModelBindingMembers = BindingMemberInfo.Collect<TimeSpan>().ToList(),
             };
 
             // When
@@ -135,13 +135,14 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
             var context = new BindingContext()
             {
                 DestinationType = typeof(TestModel),
-                ValidModelProperties = typeof(TestModel).GetProperties(),
+                ValidModelBindingMembers = BindingMemberInfo.Collect<TestModel>().ToList(),
             };
 
             var model =
                 new TestModel
                 {
-                    ListOfPrimitivesProperty = new List<int> { 1, 3, 5 }
+                    ListOfPrimitivesProperty = new List<int> { 1, 3, 5 },
+                    ListOfPrimitivesField = new List<int> { 2, 4, 6 },
                 };
 
             var s = new JavaScriptSerializer();
@@ -159,6 +160,11 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
             result.ListOfPrimitivesProperty[0].ShouldEqual(1);
             result.ListOfPrimitivesProperty[1].ShouldEqual(3);
             result.ListOfPrimitivesProperty[2].ShouldEqual(5);
+
+            result.ListOfPrimitivesField.ShouldHaveCount(3);
+            result.ListOfPrimitivesField[0].ShouldEqual(2);
+            result.ListOfPrimitivesField[1].ShouldEqual(4);
+            result.ListOfPrimitivesField[2].ShouldEqual(6);
         }
 
         [Fact]
@@ -168,7 +174,7 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
             var context = new BindingContext()
             {
                 DestinationType = typeof(TestModel),
-                ValidModelProperties = typeof(TestModel).GetProperties(),
+                ValidModelBindingMembers = BindingMemberInfo.Collect<TestModel>().ToList(),
             };
 
             var model =
@@ -178,6 +184,11 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
                     {
                         new ModelWithStringValues() { Value1 = "one", Value2 = "two"},
                         new ModelWithStringValues() { Value1 = "three", Value2 = "four"}
+                    },
+                    ListOfComplexObjectsField = new List<ModelWithStringValues>
+                    {
+                        new ModelWithStringValues() { Value1 = "five", Value2 = "six"},
+                        new ModelWithStringValues() { Value1 = "seven", Value2 = "eight"}
                     }
                 };
 
@@ -197,21 +208,29 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
             result.ListOfComplexObjectsProperty[0].Value2.ShouldEqual("two");
             result.ListOfComplexObjectsProperty[1].Value1.ShouldEqual("three");
             result.ListOfComplexObjectsProperty[1].Value2.ShouldEqual("four");
+            result.ListOfComplexObjectsField.ShouldHaveCount(2);
+            result.ListOfComplexObjectsField[0].Value1.ShouldEqual("five");
+            result.ListOfComplexObjectsField[0].Value2.ShouldEqual("six");
+            result.ListOfComplexObjectsField[1].Value1.ShouldEqual("seven");
+            result.ListOfComplexObjectsField[1].Value2.ShouldEqual("eight");
         }
 
         [Fact]
         public void Should_Deserialize_Signed_And_Unsigned_Nullable_Numeric_Types()
         {
             //Given
-            const string json = "{F1: 1, F2: 2, F3: 3}";
+            const string json = "{P1: 1, P2: 2, P3: 3, F1: 4, F2: 5, F3: 6}";
 
             //When
             var model = this.serializer.Deserialize<ModelWithNullables> (json);
 
             //Should
-            Assert.Equal (1, model.F1);
-            Assert.Equal ((uint)2, model.F2);
-            Assert.Equal ((uint)3, model.F3);
+            Assert.Equal (1, model.P1);
+            Assert.Equal ((uint)2, model.P2);
+            Assert.Equal ((uint)3, model.P3);
+            Assert.Equal (4, model.F1);
+            Assert.Equal ((uint)5, model.F2);
+            Assert.Equal ((uint)6, model.F3);
         }
 
 #if !__MonoCS__
@@ -286,7 +305,11 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
 
             public List<int> ListOfPrimitivesProperty { get; set; }
 
+            public List<int> ListOfPrimitivesField;
+
             public List<ModelWithStringValues> ListOfComplexObjectsProperty { get; set; }
+
+            public List<ModelWithStringValues> ListOfComplexObjectsField { get; set; }
 
             public bool Equals(TestModel other)
             {
@@ -354,21 +377,25 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
     {
         public string Value1 { get; set; }
 
-        public string Value2 { get; set; }
+        public string Value2;
     }
 
     public class ModelWithDoubleValues
     {
         public double Latitude { get; set; }
 
-        public double Longitude { get; set; }
+        public double Longitude;
     }
 
     public class ModelWithNullables 
     {
-        public int? F1 { get; set; } 
-        public uint F2 { get; set; } 
-        public uint? F3 { get; set; } 
+        public int? P1 { get; set; }
+        public uint P2 { get; set; }
+        public uint? P3 { get; set; }
+
+        public int? F1;
+        public uint F2;
+        public uint? F3;
     }
 
 }

--- a/src/Nancy.Tests/Unit/ModelBinding/DefaultBodyDeserializers/XmlBodyDeserializerfixture.cs
+++ b/src/Nancy.Tests/Unit/ModelBinding/DefaultBodyDeserializers/XmlBodyDeserializerfixture.cs
@@ -1,6 +1,7 @@
 namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
 {
     using System.IO;
+    using System.Linq;
     using System.Text;
     using System.Xml.Serialization;
     using FakeItEasy;
@@ -81,7 +82,7 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
             var context = new BindingContext()
             {
                 DestinationType = typeof(TestModel),
-                ValidModelProperties = typeof(TestModel).GetProperties(),
+                ValidModelBindingMembers = BindingMemberInfo.Collect<TestModel>(),
             };
 
             var reader = new StreamReader(bodyStream);
@@ -107,7 +108,7 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
             var context = new BindingContext()
             {
                 DestinationType = typeof(TestModel),
-                ValidModelProperties = typeof(TestModel).GetProperties(),
+                ValidModelBindingMembers = BindingMemberInfo.Collect<TestModel>().ToArray(),
             };
 
             // When

--- a/src/Nancy/ModelBinding/BindingContext.cs
+++ b/src/Nancy/ModelBinding/BindingContext.cs
@@ -37,7 +37,7 @@
         /// <summary>
         /// DestinationType properties that are not black listed
         /// </summary>
-        public IEnumerable<PropertyInfo> ValidModelProperties { get; set; }
+        public IEnumerable<BindingMemberInfo> ValidModelBindingMembers { get; set; }
 
         /// <summary>
         /// The incoming data fields

--- a/src/Nancy/ModelBinding/BindingMemberInfo.cs
+++ b/src/Nancy/ModelBinding/BindingMemberInfo.cs
@@ -1,0 +1,140 @@
+﻿namespace Nancy.ModelBinding
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+
+    /// <summary>
+    /// Represents a bindable member of a type, which can be a property or a field.
+    /// </summary>
+    public class BindingMemberInfo
+    {
+        PropertyInfo propertyInfo;
+        FieldInfo fieldInfo;
+
+        /// <summary>
+        /// Gets a reference to the MemberInfo that this BindingMemberInfo represents. This can be a property or a field.
+        /// </summary>
+        public MemberInfo MemberInfo
+        {
+            get { return this.propertyInfo ?? (MemberInfo)this.fieldInfo; }
+        }
+
+        /// <summary>
+        /// Gets the name of the property or field represented by this BindingMemberInfo.
+        /// </summary>
+        public string Name
+        {
+            get { return this.MemberInfo.Name; }
+        }
+
+        /// <summary>
+        /// Gets the data type of the property or field represented by this BindingMemberInfo.
+        /// </summary>
+        public Type PropertyType
+        {
+            get
+            {
+                if (this.propertyInfo != null)
+                {
+                    return this.propertyInfo.PropertyType;
+                }
+                else
+                {
+                    return this.fieldInfo.FieldType;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Constructs a BindingMemberInfo instance for a property.
+        /// </summary>
+        /// <param name="propertyInfo">The bindable property to represent.</param>
+        public BindingMemberInfo(PropertyInfo propertyInfo)
+        {
+            if (propertyInfo == null)
+            {
+                throw new ArgumentNullException("propertyInfo");
+            }
+
+            this.propertyInfo = propertyInfo;
+        }
+
+        /// <summary>
+        /// Constructs a BindingMemberInfo instance for a field.
+        /// </summary>
+        /// <param name="fieldInfo">The bindable field to represent.</param>
+        public BindingMemberInfo(FieldInfo fieldInfo)
+        {
+            if (fieldInfo == null)
+            {
+                throw new ArgumentNullException("fieldInfo");
+            }
+
+            this.fieldInfo = fieldInfo;
+        }
+
+        /// <summary>
+        /// Gets the value from a specified object associated with the property or field represented by this BindingMemberInfo.
+        /// </summary>
+        /// <param name="sourceObject">The object whose property or field should be retrieved.</param>
+        /// <returns>The value for this BindingMemberInfo's property or field in the specified object.</returns>
+        public object GetValue(object sourceObject)
+        {
+            if (this.propertyInfo != null)
+            {
+                return this.propertyInfo.GetValue(sourceObject, null);
+            }
+            else
+            {
+                return this.fieldInfo.GetValue(sourceObject);
+            }
+        }
+
+        /// <summary>
+        /// Sets the value from a specified object associated with the property or field represented by this BindingMemberInfo.
+        /// </summary>
+        /// <param name="destinationObject">The object whose property or field should be assigned.</param>
+        /// <param name="newValue">The value to assign in the specified object to this BindingMemberInfo's property or field.</param>
+        public void SetValue(object destinationObject, object newValue)
+        {
+            if (this.propertyInfo != null)
+            {
+                this.propertyInfo.SetValue(destinationObject, newValue, null);
+            }
+            else
+            {
+                this.fieldInfo.SetValue(destinationObject, newValue);
+            }
+        }
+
+        /// <summary>
+        /// Returns an enumerable sequence of bindable properties for the specified type.
+        /// </summary>
+        /// <typeparam name="T">The type to enumerate.</typeparam>
+        /// <returns>Bindable properties.</returns>
+        public static IEnumerable<BindingMemberInfo> Collect<T>()
+        {
+            return Collect(typeof(T));
+        }
+
+        /// <summary>
+        /// Returns an enumerable sequence of bindable properties for the specified type.
+        /// </summary>
+        /// <param name="type">The type to enumerate.</param>
+        /// <returns>Bindable properties.</returns>
+        public static IEnumerable<BindingMemberInfo> Collect(Type type)
+        {
+            var fromProperties = type
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance).Where(p => p.CanRead && p.CanWrite)
+                .Where(property => !property.GetIndexParameters().Any())
+                .Select(property => new BindingMemberInfo(property));
+
+            var fromFields = type.GetFields(BindingFlags.Public | BindingFlags.Instance).Where(f => !f.IsInitOnly)
+                .Select(field => new BindingMemberInfo(field));
+
+            return fromProperties.Concat(fromFields);
+        }
+    }
+}

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -178,6 +178,7 @@
     <Compile Include="Localization\TextResourceFinder.cs" />
     <Compile Include="Helpers\TaskHelpers.cs" />
     <Compile Include="ModelBinding\BindingConfig.cs" />
+    <Compile Include="ModelBinding\BindingMemberInfo.cs" />
     <Compile Include="ModelBinding\DefaultConverters\DateTimeConverter.cs" />
     <Compile Include="ModelBinding\DefaultConverters\NumericConverter.cs" />
     <Compile Include="ModelBinding\ExpressionExtensions.cs" />


### PR DESCRIPTION
This commit adds support to the `ModelBinding` code for binding fields, not just properties, in models. This allows the POD types for a project to look like:

```
public class Employee
{
  public int EmployeeID;
  public string Name;
  public string PhoneNumber;
  public decimal Salary;
}
```

There is a good reason to write POD types this way, rather than using implicit property implementations. The last paragraph below explains it, though it is not strictly pertinent to this pull request.

This commit includes full unit testing of this change, including all of the necessary changes to existing tests.

Implicit property implementations create backing fields that include `<` and `>` characters, in order to ensure that you cannot, in your own C# code, ever create another member with the same name. This, in turn, causes performance issues if `DataContractSerializer` is used on the same type. `DataContractSerializer` works like a traditional serializer, enumerating the _private_ members of the type. It then tries to create XML elements named after these members. If the members contain `<` and `>` characters, an `XmlException` is produced. This exception can be seen by running code in a debugger set to break on all thrown exceptions, even if they're handled. The `DataContractSerializer` code is aware of this problem and handles the exception internally by doing additional escaping on the member name, but by then the performance hit of the exception has already been incurred. The only ways to avoid this exception are to either expand out the property definitions so that you control the name of the backing field, or to not use properties at all, and the latter solution is much more concise and has no downsides when the type really is just a POD type.

<hr>
# Breaking Change

The specific way in which this change is breaking is that in the past, fields within models would simply be ignored by Nancy's model binding. Thus, if you had a mix of properties and fields, assuming that the properties would receive bound values and the fields would be ignored, starting with the release including this pull request that is no longer the case.
