### PR TITLE
Allow configuring reading authentication token from request query.

### DIFF
--- a/src/Nancy.Authentication.Token.Tests/TokenAuthenticationConfigurationFixture.cs
+++ b/src/Nancy.Authentication.Token.Tests/TokenAuthenticationConfigurationFixture.cs
@@ -1,8 +1,12 @@
 ﻿namespace Nancy.Authentication.Token.Tests
 {
     using System;
+
+    using FakeItEasy;
+
     using Nancy.Tests;
     using Xunit;
+    using Xunit.Extensions;
 
     public class TokenAuthenticationConfigurationFixture
     {
@@ -12,6 +16,24 @@
             var result = Record.Exception(() => new TokenAuthenticationConfiguration(null));
 
             result.ShouldBeOfType(typeof (ArgumentException));
+        }
+
+        [Fact]
+        public void Should_set_header_source_by_default()
+        {
+            var configuration = new TokenAuthenticationConfiguration(A.Fake<ITokenizer>());
+
+            configuration.TokenSource.ShouldEqual(TokenSource.Header);
+        }
+
+        [Theory]
+        [InlineData(TokenSource.Header)]
+        [InlineData(TokenSource.Query)]
+        public void Should_set_token_source(TokenSource tokenSource)
+        {
+            var configuration = new TokenAuthenticationConfiguration(A.Fake<ITokenizer>(), tokenSource);
+
+            configuration.TokenSource.ShouldEqual(tokenSource);
         }
     }
 }

--- a/src/Nancy.Authentication.Token.Tests/TokenAuthenticationFixture.cs
+++ b/src/Nancy.Authentication.Token.Tests/TokenAuthenticationFixture.cs
@@ -10,6 +10,7 @@
     using Nancy.Bootstrapper;
     using Nancy.Tests.Fakes;
     using Xunit;
+    using Xunit.Extensions;
 
     public class TokenAuthenticationFixture
     {
@@ -70,10 +71,13 @@
             result.ShouldBeOfType(typeof(ArgumentNullException));
         }
 
-        [Fact]
-        public void Pre_request_hook_should_not_set_auth_details_with_no_auth_headers()
+        [Theory]
+        [InlineData(TokenSource.Header)]
+        [InlineData(TokenSource.Query)]
+        public void Pre_request_hook_should_not_set_auth_details_with_no_auth_headers_or_query_param(TokenSource tokenSource)
         {
             // Given
+            this.config.TokenSource = tokenSource;
             var context = new NancyContext()
             {
                 Request = new FakeRequest("GET", "/")
@@ -91,8 +95,26 @@
         public void Pre_request_hook_should_not_set_auth_details_when_invalid_scheme_in_auth_header()
         {
             // Given
-            var context = CreateContextWithHeader(
-                "Authorization", new[] { "FooScheme" + " " + "A-FAKE-TOKEN" });
+            this.config.TokenSource = TokenSource.Header;
+            var context = CreateContextWithHeaderAndQuery(new Tuple<string, IEnumerable<string>>(
+                "Authorization", new[] { "FooScheme" + " " + "A-FAKE-TOKEN" }));
+
+            // When
+            var result = this.hooks.BeforeRequest.Invoke(context, new CancellationToken());
+
+            // Then
+            result.Result.ShouldBeNull();
+            context.CurrentUser.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Pre_request_hook_should_not_set_auth_details_when_invalid_scheme_in_auth_query_param()
+        {
+            // Given
+            this.config.TokenSource = TokenSource.Query;
+            var context = CreateContextWithHeaderAndQuery(
+                null,
+                new Tuple<string, string>("Authorization",  "FooScheme" + " " + "A-FAKE-TOKEN"));
 
             // When
             var result = this.hooks.BeforeRequest.Invoke(context, new CancellationToken());
@@ -106,8 +128,9 @@
         public void Pre_request_hook_should_call_tokenizer_with_token_in_auth_header()
         {
             // Given
-            var context = CreateContextWithHeader(
-               "Authorization", new[] { "Token" + " " + "mytoken" });
+            this.config.TokenSource = TokenSource.Header;
+            var context = CreateContextWithHeaderAndQuery(
+                new Tuple<string, IEnumerable<string>>("Authorization", new[] { "Token" + " " + "mytoken" }));
 
             // When
             this.hooks.BeforeRequest.Invoke(context, new CancellationToken());
@@ -117,19 +140,35 @@
         }
 
         [Fact]
+        public void Pre_request_hook_should_call_tokenizer_with_token_in_auth_query_param()
+        {
+            // Given
+            this.config.TokenSource = TokenSource.Query;
+            var context = CreateContextWithHeaderAndQuery(
+                null,
+                new Tuple<string, string>("authorization", "Token" + " " + "querytoken"));
+
+            // When
+            this.hooks.BeforeRequest.Invoke(context, new CancellationToken());
+
+            // Then
+            A.CallTo(() => config.Tokenizer.Detokenize("querytoken", context)).MustHaveHappened();
+        }
+
+        [Fact]
         public void Should_set_user_in_context_with_valid_username_in_auth_header()
         {
             // Given
             var fakePipelines = new Pipelines();
 
-            var context = CreateContextWithHeader(
-               "Authorization", new[] { "Token" + " " + "mytoken" });
+            var context = CreateContextWithHeaderAndQuery(new Tuple<string, IEnumerable<string>>(
+               "Authorization", new[] { "Token" + " " + "mytoken" }));
 
             var tokenizer = A.Fake<ITokenizer>();
             var fakeUser = A.Fake<IUserIdentity>();
             A.CallTo(() => tokenizer.Detokenize("mytoken", context)).Returns(fakeUser);
 
-            var cfg = new TokenAuthenticationConfiguration(tokenizer);
+            var cfg = new TokenAuthenticationConfiguration(tokenizer, TokenSource.Header);
 
             TokenAuthentication.Enable(fakePipelines, cfg);
 
@@ -140,16 +179,44 @@
             context.CurrentUser.ShouldBeSameAs(fakeUser);
         }
 
-        private static NancyContext CreateContextWithHeader(string name, IEnumerable<string> values)
+        [Fact]
+        public void Should_set_user_in_context_with_valid_username_in_auth_query_param()
         {
-            var header = new Dictionary<string, IEnumerable<string>>
-            {
-                { name, values }
-            };
+            // Given
+            var fakePipelines = new Pipelines();
 
+            var context = CreateContextWithHeaderAndQuery(
+                null,
+                new Tuple<string, string>("Authorization", "Token" + " " + "querytoken"));
+
+            var tokenizer = A.Fake<ITokenizer>();
+            var fakeUser = A.Fake<IUserIdentity>();
+            A.CallTo(() => tokenizer.Detokenize("querytoken", context)).Returns(fakeUser);
+
+            var cfg = new TokenAuthenticationConfiguration(tokenizer, TokenSource.Query);
+
+            TokenAuthentication.Enable(fakePipelines, cfg);
+
+            // When
+            fakePipelines.BeforeRequest.Invoke(context, new CancellationToken());
+
+            // Then
+            context.CurrentUser.ShouldBeSameAs(fakeUser);
+        }
+
+        private static NancyContext CreateContextWithHeaderAndQuery(Tuple<string, IEnumerable<string>> header = null,
+            Tuple<string, string> queryParam = null)
+        {
+            var headers = new Dictionary<string, IEnumerable<string>>();
+            if (header != null)
+            {
+                headers.Add(header.Item1, header.Item2);
+            }
+
+            var query = queryParam != null ? queryParam.Item1 + "=" + queryParam.Item2 : String.Empty;
             return new NancyContext()
             {
-                Request = new FakeRequest("GET", "/", header)
+                Request = new FakeRequest("GET", "/", headers, query)
             };
         }
 

--- a/src/Nancy.Authentication.Token/Nancy.Authentication.Token.csproj
+++ b/src/Nancy.Authentication.Token/Nancy.Authentication.Token.csproj
@@ -75,6 +75,7 @@
     <Compile Include="TokenAuthentication.cs" />
     <Compile Include="TokenAuthenticationConfiguration.cs" />
     <Compile Include="Tokenizer.cs" />
+    <Compile Include="TokenSource.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nancy\Nancy.csproj">

--- a/src/Nancy.Authentication.Token/TokenAuthentication.cs
+++ b/src/Nancy.Authentication.Token/TokenAuthentication.cs
@@ -74,7 +74,7 @@
 
         private static void RetrieveCredentials(NancyContext context, TokenAuthenticationConfiguration configuration)
         {
-            var token = ExtractTokenFromHeader(context.Request);
+            var token = ExtractToken(context.Request, configuration.TokenSource);
 
             if (token != null)
             {
@@ -87,10 +87,11 @@
             }
         }
 
-        private static string ExtractTokenFromHeader(Request request)
+        private static string ExtractToken(Request request, TokenSource tokenLocation)
         {
-            var authorization =
-                request.Headers.Authorization;
+            var authorization = tokenLocation == TokenSource.Header ?
+                request.Headers.Authorization :
+                request.Query.Authorization.ToString();
 
             if (string.IsNullOrEmpty(authorization))
             {

--- a/src/Nancy.Authentication.Token/TokenAuthenticationConfiguration.cs
+++ b/src/Nancy.Authentication.Token/TokenAuthenticationConfiguration.cs
@@ -11,7 +11,8 @@
         /// Initializes a new instance of the <see cref="TokenAuthenticationConfiguration"/> class.
         /// </summary>
         /// <param name="tokenizer">A valid instance of <see cref="ITokenizer"/> class</param>
-        public TokenAuthenticationConfiguration(ITokenizer tokenizer)
+        /// <param name="tokenSource">Where in the request the token should be looked for. Defaults to <see cref="TokenSource.Header"/></param>
+        public TokenAuthenticationConfiguration(ITokenizer tokenizer, TokenSource tokenSource = TokenSource.Header)
         {
             if (tokenizer == null)
             {
@@ -19,11 +20,17 @@
             }
 
             this.Tokenizer = tokenizer;
+            this.TokenSource = tokenSource;
         }
 
         /// <summary>
         /// Gets the token validator
         /// </summary>
         public ITokenizer Tokenizer { get; private set; }
+
+        /// <summary>
+        /// Gets the token location on the request
+        /// </summary>
+        public TokenSource TokenSource { get; set; }
     }
 }

--- a/src/Nancy.Authentication.Token/TokenSource.cs
+++ b/src/Nancy.Authentication.Token/TokenSource.cs
@@ -1,0 +1,17 @@
+﻿namespace Nancy.Authentication.Token
+{
+    /// <summary>
+    /// Represents where to get the auth token from
+    /// </summary>
+    public enum TokenSource
+    {
+        /// <summary>
+        /// Use Authorization header
+        /// </summary>
+        Header,
+        /// <summary>
+        /// User Authorization query parameter
+        /// </summary>
+        Query
+    }
+}

--- a/src/Nancy.Tests/Fakes/FakeRequest.cs
+++ b/src/Nancy.Tests/Fakes/FakeRequest.cs
@@ -16,6 +16,11 @@
         {
         }
 
+        public FakeRequest(string method, string path, IDictionary<string, IEnumerable<string>> headers, string query)
+            : this(method, path, headers, RequestStream.FromStream(new MemoryStream()), "http", query)
+        {
+        }
+
         public FakeRequest(string method, string path, string query, string userHostAddress = null)
             : this(method, path, new Dictionary<string, IEnumerable<string>>(), RequestStream.FromStream(new MemoryStream()), "http", query, userHostAddress)
         {


### PR DESCRIPTION
Sometimes it's not possible (or difficult) for an the consumer to set the auth header with a token. Example: JS app, which creates "img" tags with links to put in the DOM.

As we still want to be able to secure the images, it's much better if the JS adds the token as part of the query to the image URL.

This change adds a configuration option to change where from the authentication token is read - the Authorization header, or Authorization query parameter.

The default (header) behavior is preserved, so this should not introduce breaking change to existing apps.