### PR TITLE
Don't lookup module description in resources for dynamic assemblies.

### DIFF
--- a/src/Nancy/Routing/DefaultRouteDescriptionProvider.cs
+++ b/src/Nancy/Routing/DefaultRouteDescriptionProvider.cs
@@ -22,6 +22,11 @@ namespace Nancy.Routing
             var assembly =
                 module.GetType().Assembly;
 
+            if (assembly.IsDynamic)
+            {
+                return string.Empty;
+            }
+
             var moduleName =
                 string.Concat(module.GetType().FullName, ".resources");
 


### PR DESCRIPTION
Fixes Issue #1622

There were no tests for this class, so none was added.