### PR TITLE
Move modules registration after all other registrations

### DIFF
--- a/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
+++ b/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
@@ -263,9 +263,9 @@
 
             this.RegisterTypes(this.ApplicationContainer, typeRegistrations);
             this.RegisterCollectionTypes(this.ApplicationContainer, collectionTypeRegistrations);
-            this.RegisterModules(this.ApplicationContainer, this.Modules);
             this.RegisterInstances(this.ApplicationContainer, instanceRegistrations);
             this.RegisterRegistrationTasks(this.GetRegistrationTasks());
+            this.RegisterModules(this.ApplicationContainer, this.Modules);
 
             foreach (var applicationStartupTask in this.GetApplicationStartupTasks().ToList())
             {


### PR DESCRIPTION
Move module registrations after all other registrations.

That way the container will have everything in place to be used if one overrides RegisterModules.