### PR TITLE
Add NuGet dependency versions to framework profiles

### DIFF
--- a/rakefile.rb
+++ b/rakefile.rb
@@ -123,10 +123,11 @@ task :nuget_package => [:publish] do
         update_xml nuspec do |xml|
             # Override the version number in the nuspec file with the one from this rake file (set above)
             xml.root.elements["metadata/version"].text = $nancy_version
-			
-			# Override the Nancy dependencies to match this version
-            nancy_dependencies = xml.root.elements["metadata/dependencies/dependency[contains(@id,'Nancy')]"]
-            nancy_dependencies.attributes["version"] = "#{$nancy_version}" unless nancy_dependencies.nil?
+
+            # Override the Nancy dependencies to match this version
+            xml.root.elements.each("metadata/dependencies//dependency[contains(@id,'Nancy')]") do |dependency|
+            	dependency.attributes["version"] = "#{$nancy_version}"
+            end
 
             # Override common values
             xml.root.elements["metadata/authors"].text = "Andreas Håkansson, Steven Robbins and contributors"


### PR DESCRIPTION
This allows the nuspecs to use framework profiles which may also contain multiple Nancy dependencies. An example of why can be seen here [nancy.viewengines.razor.nuspec#L15-24](https://github.com/NancyFx/Nancy/blob/79a1eec5d8e94c5d428d99e04bbe642746d906a6/src/Nancy.ViewEngines.Razor/nancy.viewengines.razor.nuspec#L15-24)

Fixes #1634 
