### PR TITLE
Add Content-Length header for static content

### DIFF
--- a/src/Nancy.Tests/Unit/Responses/GenericFileResponseFixture.cs
+++ b/src/Nancy.Tests/Unit/Responses/GenericFileResponseFixture.cs
@@ -6,8 +6,8 @@
     using Xunit;
 
     public class GenericFileResponseFixture
-	{
-		private readonly string imagePath;
+    {
+        private readonly string imagePath;
         private const string imageContentType = "image/png";
 
         public GenericFileResponseFixture()
@@ -17,9 +17,9 @@
 
             GenericFileResponse.SafePaths = new List<string> {assemblyPath};
 
-			this.imagePath =
+            this.imagePath =
                 Path.GetFileName(this.GetType().Assembly.Location);
-		}
+        }
 
         [Fact]
         public void Should_set_status_code_to_not_found_when_file_name_is_empty()
@@ -81,29 +81,29 @@
             response.StatusCode.ShouldEqual(HttpStatusCode.NotFound);
         }
 
-		[Fact]
-		public void Should_set_status_code_to_ok()
-		{
-			// Given, When
-			var response = new GenericFileResponse(this.imagePath, imageContentType);
-						
-			// Then
-			response.StatusCode.ShouldEqual(HttpStatusCode.OK);
-		}
-		
-		[Fact]
-		public void Should_return_file_unchanged()
-		{
-			// Given
-			var expected = File.ReadAllBytes(this.imagePath);
+        [Fact]
+        public void Should_set_status_code_to_ok()
+        {
+            // Given, When
             var response = new GenericFileResponse(this.imagePath, imageContentType);
-			
-			// When
-			var result = GetResponseContents(response);
-			
-			// Then
-			result.ShouldEqualSequence(expected);
-		}
+                        
+            // Then
+            response.StatusCode.ShouldEqual(HttpStatusCode.OK);
+        }
+        
+        [Fact]
+        public void Should_return_file_unchanged()
+        {
+            // Given
+            var expected = File.ReadAllBytes(this.imagePath);
+            var response = new GenericFileResponse(this.imagePath, imageContentType);
+            
+            // When
+            var result = GetResponseContents(response);
+            
+            // Then
+            result.ShouldEqualSequence(expected);
+        }
         
         [Fact]
         public void Should_set_filename_property_to_filename()
@@ -138,14 +138,14 @@
             // Then
             response.Headers["Content-Length"].ShouldEqual(expected);
         }
-		
-		private static IEnumerable<byte> GetResponseContents(Response response)
-		{
-			var ms = new MemoryStream();
-			response.Contents(ms);
-			ms.Flush();
-			
-			return ms.ToArray();
-		}
-	}
+        
+        private static IEnumerable<byte> GetResponseContents(Response response)
+        {
+            var ms = new MemoryStream();
+            response.Contents(ms);
+            ms.Flush();
+            
+            return ms.ToArray();
+        }
+    }
 }

--- a/src/Nancy/Responses/GenericFileResponse.cs
+++ b/src/Nancy/Responses/GenericFileResponse.cs
@@ -145,7 +145,7 @@ namespace Nancy.Responses
             var lastWriteTimeUtc = fi.LastWriteTimeUtc;
             var etag = string.Concat("\"", lastWriteTimeUtc.Ticks.ToString("x"), "\"");
             var lastModified = lastWriteTimeUtc.ToString("R");
-            long length = fi.Length;
+            var length = fi.Length;
 
             if (CacheHelpers.ReturnNotModified(etag, lastWriteTimeUtc, context))
             {


### PR DESCRIPTION
Nancy does not set Content-Length header for static content. Setting of Content-Length was introduced in in this commit: 3220e472128b78544e6e3c35ff07d0165a665273. However this change was lost in the next commit: 0a7a8f4872c4dffc6b09b4ff72896805afab264c. This pull request re-introduces setting of Content-Length in GenericFileResponse and adds a unit test in GenericFileResponseFixture.
