### PR TITLE
Removed dependency on System.Drawing

### DIFF
--- a/src/Nancy/Bootstrapper/FavIconApplicationStartup.cs
+++ b/src/Nancy/Bootstrapper/FavIconApplicationStartup.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Drawing;
     using System.IO;
     using System.Linq;
 
@@ -78,17 +77,13 @@
 
             try
             {
-                var image = Image.FromFile(locatedFavIcon);
-
-                var converter = new ImageConverter();
-
-                return (byte[]) converter.ConvertTo(image, typeof(byte[]));
+                return File.ReadAllBytes(locatedFavIcon);
             }
             catch (Exception e)
             {
                 if (!StaticConfiguration.DisableErrorTraces)
                 {
-                    throw new InvalidDataException("Unable to load favicon, please check the format is compatible with GDI+", e);
+                    throw new InvalidDataException("Unable to load favicon", e);
                 }
 
                 return null;

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -99,8 +99,6 @@
     </Reference>
     <Reference Include="System.Core">
     </Reference>
-    <Reference Include="System.Drawing">
-    </Reference>
     <Reference Include="System.Xml">
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
We had a dependency on System.Drawing because we used it in the
FavIconApplicationStartup class to load a favicon to disk and
convert it to a byte array (with the help of an ImageConverter).

This made it impossible to use Nancy with Mono to target Android.
I've replaced the System.Drawing dependency with the use of
File.ReadAllBytes instead.

Hope I didn't break anything ;)
