### PR TITLE
BrowserResponseExtensions - extended range of valid HttpStatusCodes

### DIFF
--- a/src/Nancy.Testing/BrowserResponseExtensions.cs
+++ b/src/Nancy.Testing/BrowserResponseExtensions.cs
@@ -37,14 +37,14 @@ namespace Nancy.Testing
             }
         }
 
-		public static XDocument BodyAsXml(this BrowserResponse response)
-		{
-			using (var contentsStream = new MemoryStream())
-			{
-				response.Context.Response.Contents.Invoke(contentsStream);
-				contentsStream.Position = 0;
-				return XDocument.Load(contentsStream);
-			}
-		}
+        public static XDocument BodyAsXml(this BrowserResponse response)
+        {
+            using (var contentsStream = new MemoryStream())
+            {
+                response.Context.Response.Contents.Invoke(contentsStream);
+                contentsStream.Position = 0;
+                return XDocument.Load(contentsStream);
+            }
+        }
     }
 }


### PR DESCRIPTION
The extension ShouldHaveRedirectedTo only allowed for '303 See Other' in the BrowserResponse Status, which is the default behaviour of the RedirectResponse class. However there are 2 other valid statuses and if you invoked the RedirectResponse directly using either of these, the testing extension method failed, so I extended the check to include those other two statuses.
