### PR TITLE
Populated NegotiationContext when NancyContext is created

### DIFF
--- a/src/Nancy.Tests.Functional/Modules/StatusCodeHandlerModule.cs
+++ b/src/Nancy.Tests.Functional/Modules/StatusCodeHandlerModule.cs
@@ -1,7 +1,0 @@
-﻿namespace Nancy.Tests.Functional.Modules
-{
-    public class StatusCodeHandlerModule : NancyModule
-    {
-
-    }
-}

--- a/src/Nancy.Tests.Functional/Modules/StatusCodeHandlerModule.cs
+++ b/src/Nancy.Tests.Functional/Modules/StatusCodeHandlerModule.cs
@@ -1,0 +1,7 @@
+﻿namespace Nancy.Tests.Functional.Modules
+{
+    public class StatusCodeHandlerModule : NancyModule
+    {
+
+    }
+}

--- a/src/Nancy.Tests.Functional/Nancy.Tests.Functional.csproj
+++ b/src/Nancy.Tests.Functional/Nancy.Tests.Functional.csproj
@@ -88,7 +88,6 @@
     <Compile Include="Modules\JsonpTestModule.cs" />
     <Compile Include="Modules\RazorTestModule.cs" />
     <Compile Include="Modules\SerializerTestModule.cs" />
-    <Compile Include="Modules\StatusCodeHandlerModule.cs" />
     <Compile Include="Tests\AbsoluteUrlTests.cs" />
     <Compile Include="Tests\AsyncExceptionTests.cs" />
     <Compile Include="Tests\BasicRouteInvocationsFixture.cs" />

--- a/src/Nancy.Tests.Functional/Nancy.Tests.Functional.csproj
+++ b/src/Nancy.Tests.Functional/Nancy.Tests.Functional.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Modules\JsonpTestModule.cs" />
     <Compile Include="Modules\RazorTestModule.cs" />
     <Compile Include="Modules\SerializerTestModule.cs" />
+    <Compile Include="Modules\StatusCodeHandlerModule.cs" />
     <Compile Include="Tests\AbsoluteUrlTests.cs" />
     <Compile Include="Tests\AsyncExceptionTests.cs" />
     <Compile Include="Tests\BasicRouteInvocationsFixture.cs" />
@@ -96,6 +97,7 @@
     <Compile Include="Tests\MethodRewriteFixture.cs" />
     <Compile Include="Tests\PerRouteAuthFixture.cs" />
     <Compile Include="Tests\SerializerTests.cs" />
+    <Compile Include="Tests\StatusCodeHandlerFixture.cs" />
     <Compile Include="Tests\TracingSmokeTests.cs" />
     <Compile Include="Tests\JsonpTests.cs" />
     <Compile Include="Tests\ModelBindingTests.cs" />

--- a/src/Nancy.Tests.Functional/Tests/StatusCodeHandlerFixture.cs
+++ b/src/Nancy.Tests.Functional/Tests/StatusCodeHandlerFixture.cs
@@ -1,0 +1,96 @@
+﻿
+namespace Nancy.Tests.Functional.Tests
+{
+    using System;
+
+    using Nancy.Bootstrapper;
+    using Nancy.ErrorHandling;
+    using Nancy.Responses.Negotiation;
+    using Nancy.Testing;
+    using Nancy.Tests.Functional.Modules;
+
+    using Xunit;
+
+    public class StatusCodeHandlerFixture
+    {
+        private readonly INancyBootstrapper bootstrapper;
+
+        private readonly Browser browser;
+
+        public StatusCodeHandlerFixture()
+        {
+            this.bootstrapper = new ConfigurableBootstrapper(
+                configuration =>
+                {
+                    configuration.ApplicationStartup((container, pipelines) =>
+                    {
+                        pipelines.BeforeRequest += (ctx) =>
+                        {
+                            ctx.Items.Add("OnErrorException", new Exception("What a mistaka da maka!"));
+                            throw new Exception("What a mistaka da maka!");
+                        };
+                    });
+
+                    configuration.Module<PerRouteAuthModule>();
+                    configuration.StatusCodeHandler<ErrorStatusCodeHandler>();
+                });
+
+            this.browser = new Browser(bootstrapper);
+        }
+
+        [Fact]
+        public void Should_Return_Error_Model_From_StatusCodeHandler_Before_Module_Built()
+        {
+            //Given
+            var response = browser.Get("/nonsecured", with =>
+            {
+                with.HttpRequest();
+                with.Accept("application/json");
+            });
+
+            //When
+            var actualModel = response.Body.DeserializeJson<ErrorPageViewModel>();
+
+            //Then
+            Assert.Equal("Sorry, something went wrong", actualModel.Title);
+            Assert.Equal("What a mistaka da maka!", actualModel.Summary);
+        }
+    }
+
+    public class ErrorPageViewModel
+    {
+        public string Title { get; set; }
+        public string Summary { get; set; }
+    }
+
+    public class ErrorStatusCodeHandler : IStatusCodeHandler
+    {
+        private readonly IResponseNegotiator responseNegotiator;
+
+        public ErrorStatusCodeHandler(IResponseNegotiator responseNegotiator)
+        {
+            this.responseNegotiator = responseNegotiator;
+        }
+
+        public bool HandlesStatusCode(HttpStatusCode statusCode, NancyContext context)
+        {
+            return statusCode == HttpStatusCode.InternalServerError;
+        }
+
+        public void Handle(HttpStatusCode statusCode, NancyContext context)
+        {
+            var response = new Negotiator(context);
+
+            var exception = context.Items["OnErrorException"] as Exception;
+
+            response.WithModel(new ErrorPageViewModel
+            {
+                Title = "Sorry, something went wrong",
+                Summary = exception.Message,
+            }).WithStatusCode(statusCode).WithView("Error");
+
+            var errorresponse = responseNegotiator.NegotiateResponse(response, context);
+            context.Response = errorresponse;
+        }
+    }
+}

--- a/src/Nancy/DefaultNancyContextFactory.cs
+++ b/src/Nancy/DefaultNancyContextFactory.cs
@@ -3,6 +3,7 @@ namespace Nancy
     using Nancy.Culture;
     using Nancy.Diagnostics;
     using Nancy.Localization;
+    using Nancy.Responses.Negotiation;
 
     /// <summary>
     /// Creates NancyContext instances
@@ -39,6 +40,7 @@ namespace Nancy
             context.Request = request;
             context.Culture = this.cultureService.DetermineCurrentCulture(context);
             context.Text = new TextResourceFinder(this.textResource, context);
+            context.NegotiationContext = new NegotiationContext();
 
             // Move this to DefaultRequestTrace.
             context.Trace.TraceLog.WriteLog(s => s.AppendLine("New Request Started"));


### PR DESCRIPTION
If you have a `StatusCodeHandler` that responds to exceptions and returns a negotiated response the `NegotiationContext` is null when an exception occurs before a module is built.  `NegotiationContext` is needed in the  `WithModel` method. The `DefaultNancyModuleBuilder` is where it currently only gets set. I have set the `NegotiationContext` now in `DefaultNancyContextFactory` when the `NancyContext` is created.