### PR TITLE
requestscopedtype fix being overwritten

### DIFF
--- a/src/Nancy/Bootstrapper/NancyBootstrapperWithRequestContainerBase.cs
+++ b/src/Nancy/Bootstrapper/NancyBootstrapperWithRequestContainerBase.cs
@@ -17,6 +17,7 @@ namespace Nancy.Bootstrapper
         protected NancyBootstrapperWithRequestContainerBase()
         {
             this.RequestScopedTypes = new TypeRegistration[0];
+            this.RequestScopedCollectionTypes = new CollectionTypeRegistration[0];
         }
         /// <summary>
         /// Context key for storing the child container in the context
@@ -126,8 +127,8 @@ namespace Nancy.Bootstrapper
                                                             applicationRegistrationTask.CollectionTypeRegistrations.ToArray();
 
                 this.RegisterCollectionTypes(this.ApplicationContainer, applicationCollectionRegistrations.Where(tr => tr.Lifetime != Lifetime.PerRequest));
-                this.RequestScopedCollectionTypes = applicationCollectionRegistrations.Where(tr => tr.Lifetime == Lifetime.PerRequest)
-                                                      .Select(tr => new CollectionTypeRegistration(tr.RegistrationType, tr.ImplementationTypes, Lifetime.Singleton))
+                this.RequestScopedCollectionTypes = this.RequestScopedCollectionTypes.Concat(applicationCollectionRegistrations.Where(tr => tr.Lifetime == Lifetime.PerRequest)
+                                                      .Select(tr => new CollectionTypeRegistration(tr.RegistrationType, tr.ImplementationTypes, Lifetime.Singleton)))
                                                       .ToArray();
 
                 var applicationInstanceRegistrations = applicationRegistrationTask.InstanceRegistrations;


### PR DESCRIPTION
When you have an application wide dependency registered and a request based dependency defined in a `IRegistrations` implemnetation it is not getting picked up.

This is because the foreach loop is overriding `RequestScopedTypes` on each iteration here https://github.com/NancyFx/Nancy/blob/master/src/Nancy/Bootstrapper/NancyBootstrapperWithRequestContainerBase.cs#L116

So when it registers the request scoped types here there is nothing to register https://github.com/NancyFx/Nancy/blob/master/src/Nancy/Bootstrapper/NancyBootstrapperWithRequestContainerBase.cs#L157

A repro can be seen here https://github.com/jchannon/nancyrequestproj
