### PR TITLE
Break when status code has been handled

### DIFF
--- a/src/Nancy/NancyEngine.cs
+++ b/src/Nancy/NancyEngine.cs
@@ -197,13 +197,15 @@
                 return;
             }
 
-            foreach (var statusCodeHandler in this.statusCodeHandlers)
+            var handler = this.statusCodeHandlers
+                .FirstOrDefault(x => x.HandlesStatusCode(context.Response.StatusCode, context));
+
+            if (handler == null)
             {
-                if (statusCodeHandler.HandlesStatusCode(context.Response.StatusCode, context))
-                {
-                    statusCodeHandler.Handle(context.Response.StatusCode, context);
-                }
+                return;
             }
+
+            handler.Handle(context.Response.StatusCode, context);
         }
 
         private Task<NancyContext> InvokeRequestLifeCycle(NancyContext context, CancellationToken cancellationToken, IPipelines pipelines)

--- a/src/Nancy/NancyEngine.cs
+++ b/src/Nancy/NancyEngine.cs
@@ -197,9 +197,17 @@
                 return;
             }
 
-            var handler = this.statusCodeHandlers
-                .FirstOrDefault(x => x.HandlesStatusCode(context.Response.StatusCode, context));
+            var handlers = this.statusCodeHandlers
+                .Where(x => x.HandlesStatusCode(context.Response.StatusCode, context))
+                .ToList();
 
+            var defaultHandler = handlers
+                .FirstOrDefault(x => x is DefaultStatusCodeHandler);
+
+            var customHandler = handlers
+                .FirstOrDefault(x => !(x is DefaultStatusCodeHandler));
+
+            var handler = customHandler ?? defaultHandler;
             if (handler == null)
             {
                 return;


### PR DESCRIPTION
Fixes #1667. I don't think it makes sense to run through all status code handlers even after one has been called. This will try to find a custom handler and fall back on the `DefaultStatusCodeHandler` if no custom handler is found.