### PR TITLE
fixed the token auth demo bootstrap to register a default tokenizer.

### DIFF
--- a/src/Nancy.Demo.Authentication.Token/TokenAuthBootstrapper.cs
+++ b/src/Nancy.Demo.Authentication.Token/TokenAuthBootstrapper.cs
@@ -10,6 +10,7 @@
     {
         protected override void ConfigureApplicationContainer(TinyIoCContainer container)
         {
+            container.Register<ITokenizer>(new Tokenizer());
             // Example options for specifying additional values for token generation
 
             //container.Register<ITokenizer>(new Tokenizer(cfg =>


### PR DESCRIPTION
The first time I attempted to use the demo the ITokenizer could not be resolved.  There is an example commented out, but it's not apparent that you must either comment it back in or register your own tokenizer.  I just registered the Tokenizer with the default ctor.
