### PR TITLE
Support explicit case-sensitivity in HttpUtility.ParseQueryString (take 2)

### DIFF
--- a/src/Nancy.Tests/Unit/Helpers/HttpUtilityFixture.cs
+++ b/src/Nancy.Tests/Unit/Helpers/HttpUtilityFixture.cs
@@ -67,6 +67,36 @@
         }
 
         [Fact]
+        public void ParseQueryString_explicit_case_insensitivity_overrides_global_setting()
+        {
+            // Given
+            StaticConfiguration.CaseSensitive = true;
+            var query = "key=value";
+
+            // When
+            var collection = HttpUtility.ParseQueryString(query, caseSensitive: false);
+
+            // Then
+            collection["key"].ShouldEqual("value");
+            collection["KEY"].ShouldEqual("value");
+        }
+
+        [Fact]
+        public void ParseQueryString_explicit_case_sensitivity_overrides_global_setting()
+        {
+            // Given
+            StaticConfiguration.CaseSensitive = false;
+            var query = "key=value";
+
+            // When
+            var collection = HttpUtility.ParseQueryString(query, caseSensitive: true);
+
+            // Then
+            collection["key"].ShouldEqual("value");
+            collection["KEY"].ShouldBeNull();
+        }
+
+        [Fact]
         public void ParseQueryString_handles_keys_without_values()
         {
             // Given

--- a/src/Nancy/Helpers/HttpUtility.cs
+++ b/src/Nancy/Helpers/HttpUtility.cs
@@ -43,7 +43,12 @@ namespace Nancy.Helpers
         sealed class HttpQSCollection : NameValueCollection
         {
             public HttpQSCollection()
-                : base(StaticConfiguration.CaseSensitive ? StringComparer.InvariantCulture : StringComparer.InvariantCultureIgnoreCase)
+                : this(StaticConfiguration.CaseSensitive)
+            {
+            }
+
+            public HttpQSCollection(bool caseSensitive)
+                : base(caseSensitive ? StringComparer.InvariantCulture : StringComparer.InvariantCultureIgnoreCase)
             {
             }
 
@@ -685,18 +690,28 @@ namespace Nancy.Helpers
             return ParseQueryString(query, Encoding.UTF8);
         }
 
+        public static NameValueCollection ParseQueryString(string query, bool caseSensitive)
+        {
+            return ParseQueryString(query, Encoding.UTF8, caseSensitive);
+        }
+
         public static NameValueCollection ParseQueryString(string query, Encoding encoding)
+        {
+            return ParseQueryString(query, encoding, StaticConfiguration.CaseSensitive);
+        }
+
+        public static NameValueCollection ParseQueryString(string query, Encoding encoding, bool caseSensitive)
         {
             if (query == null)
                 throw new ArgumentNullException("query");
             if (encoding == null)
                 throw new ArgumentNullException("encoding");
             if (query.Length == 0 || (query.Length == 1 && query[0] == '?'))
-                return new HttpQSCollection();
+                return new HttpQSCollection(caseSensitive);
             if (query[0] == '?')
                 query = query.Substring(1);
 
-            NameValueCollection result = new HttpQSCollection();
+            NameValueCollection result = new HttpQSCollection(caseSensitive);
             ParseQueryString(query, encoding, result);
             return result;
         }


### PR DESCRIPTION
Sometimes it would be useful to be able to parse querystrings with an explicit case-sensitivity that might differ from the global setting defined by `StaticConfiguration.CaseSensitive`. An example scenario would be handling an incoming webhook from a third-party service that includes duplicates of keys but with different case (`key=value&Key=someOtherValue`) (I'm looking at you, [Mailgun](http://documentation.mailgun.com/user_manual.html#receiving-messages-via-http-through-a-forward-action)!).

I'm aware this is a pretty specific problem, but since both `HttpUtility.HttpQSCollection` and `HttpUtility.ParseQueryString(string, Encoding, NameValueCollection)` are internal to Nancy it would require a lot of duplicate code to implement it outside Nancy considering that the logic is already there (just hard-coded to use `StaticConfiguration.CaseSensitive`).

Feedback is very welcome!
