### PR TITLE
Fix assembly name

### DIFF
--- a/src/Nancy.Metadata.Modules/nancy.metadata.modules.nuspec
+++ b/src/Nancy.Metadata.Modules/nancy.metadata.modules.nuspec
@@ -18,9 +18,9 @@
     <tags>Nancy Meta MetaData</tags>
   </metadata>
   <files>
-    <file src="build\binaries\Nancy.Metadata.Module.dll" target="lib\net40" />
-    <file src="build\binaries\Nancy.Metadata.Module.pdb" target="lib\net40" />
-    <file src="build\binaries\Nancy.Metadata.Module.XML" target="lib\net40" />
+    <file src="build\binaries\Nancy.Metadata.Modules.dll" target="lib\net40" />
+    <file src="build\binaries\Nancy.Metadata.Modules.pdb" target="lib\net40" />
+    <file src="build\binaries\Nancy.Metadata.Modules.XML" target="lib\net40" />
     <file src="src\Nancy.Metadata.Module\**\*.cs" target="src" />
   </files>
 </package>


### PR DESCRIPTION
The nightly builds are failing now due to the assembly being renamed in #1650
