### PR TITLE
Changed JsonSettings to use Encoding instead of string

### DIFF
--- a/src/Nancy/Json/JsonSettings.cs
+++ b/src/Nancy/Json/JsonSettings.cs
@@ -1,15 +1,35 @@
 namespace Nancy.Json
 {
+    using System;
     using System.Collections.Generic;
-    using Converters;
+    using System.Text;
+
+    using Nancy.Json.Converters;
 
     /// <summary>
-    /// Json serializer settings
+    /// JSON serializer settings
     /// </summary>
     public static class JsonSettings
     {
+        private static string _defaultCharset;
+
+        static JsonSettings()
+        {
+            ISO8601DateFormat = true;
+            MaxJsonLength = 102400;
+            MaxRecursions = 100;
+            DefaultEncoding = Encoding.UTF8;
+            Converters = new List<JavaScriptConverter>
+            {
+                new TimeSpanConverter(),
+                new TupleConverter()
+            };
+            PrimitiveConverters = new List<JavaScriptPrimitiveConverter>();
+            RetainCasing = false;
+        }
+
         /// <summary>
-        /// Max length of json output
+        /// Max length of JSON output
         /// </summary>
         public static int MaxJsonLength { get; set; }
 
@@ -19,9 +39,22 @@ namespace Nancy.Json
         public static int MaxRecursions { get; set; }
 
         /// <summary>
-        /// Default charset for json responses.
+        /// Default charset for JSON responses.
         /// </summary>
-        public static string DefaultCharset { get; set; }
+        [Obsolete("This property is obsolete and will be removed in a future version. Please use DefaultEncoding instead.")]
+        public static string DefaultCharset
+        {
+            get { return _defaultCharset ?? DefaultEncoding.WebName; }
+            set { _defaultCharset = value; }
+        }
+
+        /// <summary>
+        /// Gets the default encoding for JSON responses.
+        /// </summary>
+        /// <remarks>
+        /// The default value is <see langword="Encoding.UTF8" />
+        /// </remarks>
+        public static Encoding DefaultEncoding { get; set; }
 
         public static IList<JavaScriptConverter> Converters { get; set; }
 
@@ -38,20 +71,5 @@ namespace Nancy.Json
         /// Serialized date format
         /// </summary>
         public static bool ISO8601DateFormat { get; set; }
-
-        static JsonSettings()
-        {
-            ISO8601DateFormat = true;
-            MaxJsonLength = 102400;
-            MaxRecursions = 100;
-            DefaultCharset = "utf-8";
-            Converters = new List<JavaScriptConverter>
-                             {
-                                 new TimeSpanConverter(),
-                                 new TupleConverter()
-                             };
-            PrimitiveConverters = new List<JavaScriptPrimitiveConverter>();
-            RetainCasing = false;
-        }
     }
 }

--- a/src/Nancy/Jsonp.cs
+++ b/src/Nancy/Jsonp.cs
@@ -9,11 +9,16 @@
 
     public static class Jsonp
     {
-        static PipelineItem<Action<NancyContext>> JsonpItem;
+        private static readonly PipelineItem<Action<NancyContext>> JsonpItem;
 
         static Jsonp()
         {
             JsonpItem = new PipelineItem<Action<NancyContext>>("JSONP", PrepareJsonp);
+        }
+
+        private static string Encoding
+        {
+            get { return string.Concat("; charset=", JsonSettings.DefaultEncoding.WebName); }
         }
 
         /// <summary>
@@ -22,7 +27,7 @@
         /// <param name="pipelines">Application Pipeline to Hook into</param>
         public static void Enable(IPipelines pipelines)
         {
-            bool jsonpEnabled = pipelines.AfterRequest.PipelineItems.Any(ctx => ctx.Name == "JSONP");
+            var jsonpEnabled = pipelines.AfterRequest.PipelineItems.Any(ctx => ctx.Name == "JSONP");
 
             if (!jsonpEnabled)
             {
@@ -45,31 +50,34 @@
         /// <param name="context">Current Nancy Context</param>
         private static void PrepareJsonp(NancyContext context)
         {
-            bool isJson = Nancy.Json.Json.IsJsonContentType(context.Response.ContentType);
+            var isJson = Json.Json.IsJsonContentType(context.Response.ContentType);
             bool hasCallback = context.Request.Query["callback"].HasValue;
 
-            if (isJson && hasCallback)
+            if (!isJson || !hasCallback)
             {
-                // grab original contents for running later
-                Action<Stream> original = context.Response.Contents;
-                string callback = context.Request.Query["callback"].Value;
-
-                // set content type to application/javascript so browsers can handle it by default
-                // http://stackoverflow.com/questions/111302/best-content-type-to-serve-jsonp
-                context.Response.ContentType = "application/javascript" + (String.IsNullOrWhiteSpace(JsonSettings.DefaultCharset) ? "" : "; charset=" + JsonSettings.DefaultCharset);
-                context.Response.Contents = stream =>
-                {
-                    // disposing of stream is handled elsewhere
-                    StreamWriter writer = new StreamWriter(stream)
-                    {
-                        AutoFlush = true
-                    };
-
-                    writer.Write("{0}(", callback);
-                    original(stream);
-                    writer.Write(");");
-                };
+                return;
             }
+
+            // grab original contents for running later
+            var original = context.Response.Contents;
+            string callback = context.Request.Query["callback"].Value;
+
+            // set content type to application/javascript so browsers can handle it by default
+            // http://stackoverflow.com/questions/111302/best-content-type-to-serve-jsonp
+            context.Response.ContentType = string.Concat("application/javascript", Encoding);
+
+            context.Response.Contents = stream =>
+            {
+                // disposing of stream is handled elsewhere
+                var writer = new StreamWriter(stream)
+                {
+                    AutoFlush = true
+                };
+
+                writer.Write("{0}(", callback);
+                original(stream);
+                writer.Write(");");
+            };
         }
     }
 }

--- a/src/Nancy/Responses/JsonResponse.cs
+++ b/src/Nancy/Responses/JsonResponse.cs
@@ -25,12 +25,7 @@
 
         private static string Encoding
         {
-            get
-            {
-                return !string.IsNullOrWhiteSpace(JsonSettings.DefaultCharset)
-                    ? string.Concat("; charset=", JsonSettings.DefaultCharset)
-                    : string.Empty;
-            }
+            get { return string.Concat("; charset=", JsonSettings.DefaultEncoding.WebName); }
         }
 
         private static Action<Stream> GetJsonContents(TModel model, ISerializer serializer)


### PR DESCRIPTION
Instead of using a simple `string` for JSON charset, this adds a new property, `DefaultEncoding`, which is set to UTF8 by default, and we'll use the [`Encoding.WebName`](http://msdn.microsoft.com/en-us/library/system.text.encoding.webname(v=vs.110).aspx) property instead.