### PR TITLE
Improved handling of exceptions in Hosting.Aspnet (Avoids YSOD)

### DIFF
--- a/src/Nancy.Hosting.Aspnet/NancyHttpRequestHandler.cs
+++ b/src/Nancy.Hosting.Aspnet/NancyHttpRequestHandler.cs
@@ -99,7 +99,7 @@ namespace Nancy.Hosting.Aspnet
 
         public void EndProcessRequest(IAsyncResult result)
         {
-            NancyHandler.EndProcessRequest((Task<Tuple<NancyContext, HttpContextBase>>)result);
+            NancyHandler.EndProcessRequest((Task<Tuple<NancyContext, HttpContextBase>>)result, engine);
         }
     }
 }

--- a/src/Nancy/NancyEngine.cs
+++ b/src/Nancy/NancyEngine.cs
@@ -126,7 +126,7 @@
 
         public IStatusCodeHandler FindStatusCodeHandler(HttpStatusCode statusCode, NancyContext context)
         {
-            var relevantHandlers = this.statusCodeHandlers.Where(h => h.HandlesStatusCode(statusCode, context));
+            var relevantHandlers = this.statusCodeHandlers.Where(h => h.HandlesStatusCode(statusCode, context)).ToList();
             var customHandler = relevantHandlers.FirstOrDefault(h => !(h is DefaultStatusCodeHandler));
             return customHandler ?? relevantHandlers.FirstOrDefault(h => h is DefaultStatusCodeHandler);
         }


### PR DESCRIPTION
While working through some Razor view issues, I noticed that `Nancy.Hosting.Aspnet.NancyHandler.SetNancyResponseToHttpResponse` doesn't handle an exception being thrown in `response.Contents.Invoke`. You therefore get thrown back to YSOD rather than the (nicer) 500 page that Nancy would usually provide.

Although the MaterialisingResponse (#1504) that @grumpydev implemented sort-of offers a workaround for this with the warning of "Copies the existing response into memory, so use with caution.", because of the output buffering mentioned in #1549, you actually get a double-whammy of memory usage if configured to use it (plus you show users your error stack).

This is a first attempt to fix the issue as I couldn't find anything to suggest this (YSOD) is desired behaviour. I've tried to do it in a way that doesn't mean any breaking changes, though I have re-implemented #1668 as I noticed the issue separately (sorry, couldn't work out how to pull it into my branch), which may or may not be breaking. Ideally the two new public methods would be added to `INancyEngine` (and have some tests written!! :worried: ) to avoid the `as NancyEngine` cast and additional `if` block.`

To try and make sure tests are consistent, I'd be interested in applying the same kind of try-catch block to `Nancy.Testing.BrowserResponseBodyWrapper` (and indeed the other Hosting implementations should probably be adjusted). Not much point doing any of that if this PR isn't actually wanted though! :smile: 