### PR TITLE
Additional ScanModes in AssemblyTypeScanner

### DIFF
--- a/src/Nancy/Bootstrapper/AppDomainAssemblyTypeScanner.cs
+++ b/src/Nancy/Bootstrapper/AppDomainAssemblyTypeScanner.cs
@@ -282,14 +282,19 @@ namespace Nancy.Bootstrapper
             var returnTypes =
                 Types.Where(type.IsAssignableFrom);
 
-            if (mode == ScanMode.All)
+            switch (mode)
             {
-                return returnTypes;
+                case ScanMode.OnlyNancy:
+                    return returnTypes.Where(t => t.Assembly == nancyAssembly);
+                case ScanMode.ExcludeNancy:
+                    return returnTypes.Where(t => t.Assembly != nancyAssembly);
+                case ScanMode.OnlyNancyNamespace:
+                    return returnTypes.Where(t => t.Namespace.StartsWith("Nancy"));
+                case ScanMode.ExcludeNancyNamespace:
+                    return returnTypes.Where(t => !t.Namespace.StartsWith("Nancy"));
+                default://mode == ScanMode.All
+                    return returnTypes;
             }
-
-            return (mode == ScanMode.OnlyNancy) ?
-                returnTypes.Where(t => t.Assembly == nancyAssembly) :
-                returnTypes.Where(t => t.Assembly != nancyAssembly);
         }
 
         /// <summary>

--- a/src/Nancy/Bootstrapper/ScanMode.cs
+++ b/src/Nancy/Bootstrapper/ScanMode.cs
@@ -18,6 +18,16 @@
         /// <summary>
         /// Only types that are defined outside the Nancy assembly.
         /// </summary>
-        ExcludeNancy
+        ExcludeNancy,
+
+        // <summary>
+        /// Only Namespaces that starts with 'Nancy'
+        /// </summary>
+        OnlyNancyNamespace,
+
+        /// <summary>
+        /// Only Namespaces that does not start with Nancy
+        /// </summary>
+        ExcludeNancyNamespace
     }
 }


### PR DESCRIPTION
Added ScanModes.OnlyNancyNamespace and ExcludeNancyNamespace. This will
check for types with namespaces starting with "Nancy"

Usage:
You can make use of these scanmodes via AppDomainAssemblyTypeScanner, e.g
```
var providerTypes = AppDomainAssemblyTypeScanner
.TypesOf(ScanMode.ExcludeNancyNamespace)
.ToArray();
```
It is possible to override default behaviour by overriding default nancy bootstrapper

Note:
The old pull request #1492 is closed and replaced with this one due to wrongly branched pull request