### PR TITLE
Significantly reduce DefaultObjectSerializor output length in some cases

### DIFF
--- a/src/Nancy/DefaultObjectSerializer.cs
+++ b/src/Nancy/DefaultObjectSerializer.cs
@@ -27,7 +27,7 @@ namespace Nancy
 
                 var outputBytes = outputStream.GetBuffer();
 
-                return Convert.ToBase64String(outputBytes);
+                return Convert.ToBase64String(outputBytes, 0, (int)outputStream.Length);
             }
         }
 


### PR DESCRIPTION
MemoryStream's internal buffer can be quite a bit longer than the length
of the data inside it, which is an optimization. However, this doesn't
mean that DefaultObjectSerializer should output all of these empty bytes
at the end (which appear as "AAAAAA" etc).

Instead, just output that segment of the buffer which actually contains
data.
