### PR TITLE
Don't crash on an invalid cookie

### DIFF
--- a/src/Nancy.Tests/Unit/Sessions/CookieBasedSessionsFixture.cs
+++ b/src/Nancy.Tests/Unit/Sessions/CookieBasedSessionsFixture.cs
@@ -125,6 +125,23 @@ namespace Nancy.Tests.Unit.Sessions
         }
 
         [Fact]
+        public void Should_load_an_empty_session_if_session_cookie_is_invalid()
+        {
+          //given
+          var inputValue = ValidHmac.Substring(0, 5); //invalid Hmac
+          inputValue = HttpUtility.UrlEncode(inputValue);
+          var store = new CookieBasedSessions(this.rijndaelEncryptionProvider, this.defaultHmacProvider, this.defaultObjectSerializer);
+          var request = new Request("GET", "/", "http");
+          request.Cookies.Add(store.CookieName, inputValue);
+
+          //when
+          var result = store.Load(request);
+
+          //then
+          result.Count.ShouldEqual(0);
+        }
+
+        [Fact]
         public void Should_load_a_single_valued_session()
         {
             var request = CreateRequest("encryptedkey1=value1");

--- a/src/Nancy/Session/CookieBasedSessions.cs
+++ b/src/Nancy/Session/CookieBasedSessions.cs
@@ -175,6 +175,11 @@ namespace Nancy.Session
             {
                 var cookieData = HttpUtility.UrlDecode(request.Cookies[cookieName]);
                 var hmacLength = Base64Helpers.GetBase64Length(hmacProvider.HmacLength);
+                if (cookieData.Length < hmacLength)
+                {
+                  return new Session(dictionary);
+                }
+
                 var hmacString = cookieData.Substring(0, hmacLength);
                 var encryptedCookie = cookieData.Substring(hmacLength);
 


### PR DESCRIPTION
If, for some reason, someone has a broken cookie, all the requests end in an exception.

It seems logical to just ignore the session if that happens.