### PR TITLE
Ignore invalid cookie attributes

### DIFF
--- a/src/Nancy.Tests/Unit/RequestFixture.cs
+++ b/src/Nancy.Tests/Unit/RequestFixture.cs
@@ -631,6 +631,25 @@ namespace Nancy.Tests.Unit
         }
 
         [Fact]
+        public void Should_ignore_invalid_attribute_in_cookie()
+        {
+          // Given, when
+          const string cookieName = "path";
+          const string cookieData = "/";
+          var headers = new Dictionary<string, IEnumerable<string>>();
+          var cookies = new List<string> { string.Format("{0}={1}; InvalidAttribute", cookieName, cookieData) };
+          headers.Add("cookie", cookies);
+          var newUrl = new Url
+          {
+            Path = "/"
+          };
+          var request = new Request("GET", newUrl, null, headers);
+
+          // Then
+          request.Cookies[cookieName].ShouldEqual(cookieData);
+        }
+
+        [Fact]
         public void Should_move_request_body_position_to_zero_after_parsing_url_encoded_data()
         {
             // Given

--- a/src/Nancy.Tests/Unit/RequestFixture.cs
+++ b/src/Nancy.Tests/Unit/RequestFixture.cs
@@ -631,13 +631,14 @@ namespace Nancy.Tests.Unit
         }
 
         [Fact]
-        public void Should_ignore_invalid_attribute_in_cookie()
+        public void Should_add_attribute_in_cookie_as_empty_value()
         {
           // Given, when
           const string cookieName = "path";
           const string cookieData = "/";
+          const string cookieAttribute = "SomeAttribute";
           var headers = new Dictionary<string, IEnumerable<string>>();
-          var cookies = new List<string> { string.Format("{0}={1}; InvalidAttribute", cookieName, cookieData) };
+          var cookies = new List<string> { string.Format("{0}={1}; {2}", cookieName, cookieData, cookieAttribute) };
           headers.Add("cookie", cookies);
           var newUrl = new Url
           {
@@ -647,6 +648,7 @@ namespace Nancy.Tests.Unit
 
           // Then
           request.Cookies[cookieName].ShouldEqual(cookieData);
+          request.Cookies[cookieAttribute].ShouldEqual(string.Empty);
         }
 
         [Fact]

--- a/src/Nancy/Request.cs
+++ b/src/Nancy/Request.cs
@@ -167,13 +167,19 @@ namespace Nancy
             foreach (var parts in values.Select(c => c.Split(new[] { '=' }, 2)))
             {
                 var cookieName = parts[0].Trim();
+                string cookieValue;
 
                 if (parts.Length == 1)
                 {
-                    continue;
+                    //Cookie attribute
+                    cookieValue = string.Empty;
+                }
+                else
+                {
+                    cookieValue = parts[1];
                 }
 
-                cookieDictionary[cookieName] = parts[1];
+                cookieDictionary[cookieName] = cookieValue;
             }
 
             return cookieDictionary;

--- a/src/Nancy/Request.cs
+++ b/src/Nancy/Request.cs
@@ -170,11 +170,7 @@ namespace Nancy
 
                 if (parts.Length == 1)
                 {
-                    if (cookieName.Equals("HttpOnly", StringComparison.InvariantCultureIgnoreCase) ||
-                        cookieName.Equals("Secure", StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        continue;
-                    }
+                    continue;
                 }
 
                 cookieDictionary[cookieName] = parts[1];


### PR DESCRIPTION
If a cookie contains an invalid attribute the current code throws an System.IndexOutOfRangeException.
Why are attributes other then HttpOnly and Secure not accepted?

I see this error frequently in my logging, so I propose to just ignore all attributes.