### PR TITLE
Pass NancyContext to DataAnnotationValidation Adapters

### DIFF
--- a/src/Nancy.Validation.DataAnnotatioins.Tests/DataAnnotationsValidatorFixture.cs
+++ b/src/Nancy.Validation.DataAnnotatioins.Tests/DataAnnotationsValidatorFixture.cs
@@ -40,9 +40,10 @@
         {
             // Given
             var instance = new ModelUnderTest();
+            var context = new NancyContext();
 
             // When
-            this.validator.Validate(instance, new NancyContext());
+            this.validator.Validate(instance, context);
 
             // Then
             A.CallTo(() => this.validatorFactory.GetValidators(typeof(ModelUnderTest))).MustHaveHappened();
@@ -53,13 +54,14 @@
         {
             // Given
             var instance = new ModelUnderTest();
+            var context = new NancyContext();
 
             // When
-            this.validator.Validate(instance, new NancyContext());
+            this.validator.Validate(instance, context);
 
             // Then
-            A.CallTo(() => this.propertyValidator1.Validate(instance)).MustHaveHappened();
-            A.CallTo(() => this.propertyValidator2.Validate(instance)).MustHaveHappened();
+            A.CallTo(() => this.propertyValidator1.Validate(instance, context)).MustHaveHappened();
+            A.CallTo(() => this.propertyValidator2.Validate(instance, context)).MustHaveHappened();
         }
 
         [Fact]
@@ -67,12 +69,13 @@
         {
             // Given
             var instance = new ModelUnderTest();
+            var context = new NancyContext();
 
             // When
-            this.validator.Validate(instance, new NancyContext());
+            this.validator.Validate(instance, context);
 
             // Then
-            A.CallTo(() => this.validatableObjectAdapter.Validate(instance)).MustHaveHappened();
+            A.CallTo(() => this.validatableObjectAdapter.Validate(instance, context)).MustHaveHappened();
         }
 
         [Fact]
@@ -80,16 +83,17 @@
         {
             // Given
             var instance = new ModelUnderTest();
+            var context = new NancyContext();
 
             var result1 = new ModelValidationError("Foo", string.Empty);
             var result2 = new ModelValidationError("Bar", string.Empty);
             var result3 = new ModelValidationError("Baz", string.Empty);
 
-            A.CallTo(() => this.propertyValidator1.Validate(instance)).Returns(new[] { result1 });
-            A.CallTo(() => this.propertyValidator2.Validate(instance)).Returns(new[] { result2, result3 });
+            A.CallTo(() => this.propertyValidator1.Validate(instance, context)).Returns(new[] { result1 });
+            A.CallTo(() => this.propertyValidator2.Validate(instance, context)).Returns(new[] { result2, result3 });
 
             // When
-            var results = this.validator.Validate(instance, new NancyContext());
+            var results = this.validator.Validate(instance, context);
 
             // Then
             results.Errors.Count().ShouldEqual(3);
@@ -101,11 +105,12 @@
             // Given
             var instance = new ModelUnderTest();
             var result = new ModelValidationError("Foo", string.Empty);
+            var context = new NancyContext();
 
-            A.CallTo(() => this.validatableObjectAdapter.Validate(instance)).Returns(new[] { result });
+            A.CallTo(() => this.validatableObjectAdapter.Validate(instance, context)).Returns(new[] { result });
 
             // When
-            var results = this.validator.Validate(instance, new NancyContext());
+            var results = this.validator.Validate(instance, context);
 
             // Then
             results.Errors.Count().ShouldEqual(1);

--- a/src/Nancy.Validation.DataAnnotatioins.Tests/DefaultValidatableObjectAdapterFixture.cs
+++ b/src/Nancy.Validation.DataAnnotatioins.Tests/DefaultValidatableObjectAdapterFixture.cs
@@ -25,7 +25,7 @@
             var instance = new ModelUnderTest();
 
             // When
-            this.validator.Validate(instance);
+            this.validator.Validate(instance, new NancyContext());
 
             // Then
             instance.ValidatedWasInvoked.ShouldBeTrue();
@@ -38,7 +38,7 @@
             var instance = new ModelUnderTest();
 
             // When
-            this.validator.Validate(instance);
+            this.validator.Validate(instance, new NancyContext());
 
             // Then
             instance.InstanceBeingValidated.ShouldBeSameAs(instance);
@@ -57,7 +57,7 @@
             };
 
             // When
-            var results = this.validator.Validate(instance);
+            var results = this.validator.Validate(instance, new NancyContext());
 
             // Then
             results.Count().ShouldEqual(2);
@@ -70,7 +70,7 @@
             var instance = new ModelNotImplementingIValidatableObject();
 
             // When
-            var result = this.validator.Validate(instance);
+            var result = this.validator.Validate(instance, new NancyContext());
 
             // Then
             result.Count().ShouldEqual(0);

--- a/src/Nancy.Validation.DataAnnotatioins.Tests/PropertyValidatorFixture.cs
+++ b/src/Nancy.Validation.DataAnnotatioins.Tests/PropertyValidatorFixture.cs
@@ -28,7 +28,7 @@
             this.error1 =
                 new ModelValidationError("error1", string.Empty);
 
-            A.CallTo(() => this.adapter1.Validate(A<object>._, A<ValidationAttribute>._, A<PropertyDescriptor>._))
+            A.CallTo(() => this.adapter1.Validate(A<object>._, A<ValidationAttribute>._, A<PropertyDescriptor>._, A<NancyContext>._))
                 .Returns(new[] {this.error1});
 
             this.adapter2 = 
@@ -37,7 +37,7 @@
             this.error2 =
                 new ModelValidationError("error2", string.Empty);
 
-            A.CallTo(() => this.adapter2.Validate(A<object>._, A<ValidationAttribute>._, A<PropertyDescriptor>._))
+            A.CallTo(() => this.adapter2.Validate(A<object>._, A<ValidationAttribute>._, A<PropertyDescriptor>._, A<NancyContext>._))
                 .Returns(new[] { this.error2 });
 
             this.mappings =
@@ -65,12 +65,14 @@
         public void Should_call_validate_on_each_validator_for_each_attribute_when_validate_is_invoked()
         {
             // Given
+            var context = new NancyContext();
+
             // When
-            this.validator.Validate(null);
+            this.validator.Validate(null, context);
 
             // Then
-            A.CallTo(() => this.adapter1.Validate(A<object>._, A<ValidationAttribute>._, A<PropertyDescriptor>._)).MustHaveHappened();
-            A.CallTo(() => this.adapter2.Validate(A<object>._, A<ValidationAttribute>._, A<PropertyDescriptor>._)).MustHaveHappened();
+            A.CallTo(() => this.adapter1.Validate(A<object>._, A<ValidationAttribute>._, A<PropertyDescriptor>._, A<NancyContext>._)).MustHaveHappened();
+            A.CallTo(() => this.adapter2.Validate(A<object>._, A<ValidationAttribute>._, A<PropertyDescriptor>._, A<NancyContext>._)).MustHaveHappened();
         }
 
         [Fact]
@@ -78,12 +80,13 @@
         {
             // Given
             var instance = new Model();
+            var context = new NancyContext();
 
             // When
-            this.validator.Validate(instance);
+            this.validator.Validate(instance, context);
 
             // Then
-            A.CallTo(() => this.adapter1.Validate(instance, A<ValidationAttribute>._, A<PropertyDescriptor>._)).MustHaveHappened();
+            A.CallTo(() => this.adapter1.Validate(instance, A<ValidationAttribute>._, A<PropertyDescriptor>._, context)).MustHaveHappened();
         }
 
         [Fact]
@@ -91,12 +94,13 @@
         {
             // Given
             var instance = new Model();
+            var context = new NancyContext();
 
             // When
-            this.validator.Validate(instance);
+            this.validator.Validate(instance, context);
 
             // Then
-            A.CallTo(() => this.adapter1.Validate(A<object>._, this.mappings.Keys.First(), A<PropertyDescriptor>._)).MustHaveHappened();
+            A.CallTo(() => this.adapter1.Validate(A<object>._, this.mappings.Keys.First(), A<PropertyDescriptor>._, A<NancyContext>._)).MustHaveHappened();
         }
 
         [Fact]
@@ -104,12 +108,13 @@
         {
             // Given
             var instance = new Model();
+            var context = new NancyContext();
 
             // When
-            this.validator.Validate(instance);
+            this.validator.Validate(instance, context);
 
             // Then
-            A.CallTo(() => this.adapter1.Validate(A<object>._, A<ValidationAttribute>._, this.descriptor)).MustHaveHappened();
+            A.CallTo(() => this.adapter1.Validate(A<object>._, A<ValidationAttribute>._, this.descriptor, A<NancyContext>._)).MustHaveHappened();
         }
 
         [Fact]
@@ -117,9 +122,10 @@
         {
             // Given
             var instance = new Model();
+            var context = new NancyContext();
 
             // When
-            var results = this.validator.Validate(instance);
+            var results = this.validator.Validate(instance, context);
             
             // Then
             results.Contains(this.error1).ShouldBeTrue();

--- a/src/Nancy.Validation.DataAnnotations/DataAnnotationsValidator.cs
+++ b/src/Nancy.Validation.DataAnnotations/DataAnnotationsValidator.cs
@@ -54,12 +54,12 @@
             foreach (var validator in this.validators)
             {
                 var results =
-                    validator.Validate(instance);
+                    validator.Validate(instance, context);
 
                 errors.AddRange(results);
             }
 
-            errors.AddRange(this.validatableObjectAdapter.Validate(instance));
+            errors.AddRange(this.validatableObjectAdapter.Validate(instance, context));
 
             return new ModelValidationResult(errors);
         }

--- a/src/Nancy.Validation.DataAnnotations/DataAnnotationsValidatorAdapter.cs
+++ b/src/Nancy.Validation.DataAnnotations/DataAnnotationsValidatorAdapter.cs
@@ -47,10 +47,11 @@
         /// <param name="instance">The instance that should be validated.</param>
         /// <param name="attribute">The <see cref="ValidationAttribute"/> that should be handled.</param>
         /// <param name="descriptor">A <see cref="PropertyDescriptor"/> instance for the property that is being validated.</param>
+        /// <param name="context">The <see cref="NancyContext"/> of the current request.</param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="ModelValidationRule"/> instances.</returns>
-        public virtual IEnumerable<ModelValidationError> Validate(object instance, ValidationAttribute attribute, PropertyDescriptor descriptor)
+        public virtual IEnumerable<ModelValidationError> Validate(object instance, ValidationAttribute attribute, PropertyDescriptor descriptor, NancyContext context)
         {
-            var context = 
+            var validationContext = 
                 new ValidationContext(instance, null, null)
                 {
                     MemberName = descriptor == null ? null : descriptor.Name
@@ -62,7 +63,7 @@
             }
 
             var result = 
-                attribute.GetValidationResult(instance, context);
+                attribute.GetValidationResult(instance, validationContext);
 
             if (result != null)
             {

--- a/src/Nancy.Validation.DataAnnotations/DefaultValidatableObjectAdapter.cs
+++ b/src/Nancy.Validation.DataAnnotations/DefaultValidatableObjectAdapter.cs
@@ -13,8 +13,9 @@
         /// Validates the specified instance.
         /// </summary>
         /// <param name="instance">The instance.</param>
+        /// <param name="context1"></param>
         /// <returns>An <see cref="IEnumerable{T}"/> instance, containing <see cref="ModelValidationError"/> objects.</returns>
-        public IEnumerable<ModelValidationError> Validate(object instance)
+        public IEnumerable<ModelValidationError> Validate(object instance, NancyContext context1)
         {
             var validateable =
                 instance as IValidatableObject;

--- a/src/Nancy.Validation.DataAnnotations/IDataAnnotationsValidatorAdapter.cs
+++ b/src/Nancy.Validation.DataAnnotations/IDataAnnotationsValidatorAdapter.cs
@@ -31,7 +31,8 @@
         /// <param name="instance">The instance that should be validated.</param>
         /// <param name="attribute">The <see cref="ValidationAttribute"/> that should be handled.</param>
         /// <param name="descriptor">A <see cref="PropertyDescriptor"/> instance for the property that is being validated.</param>
+        /// <param name="context">The <see cref="NancyContext"/> of the current request.</param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="ModelValidationRule"/> instances.</returns>
-        IEnumerable<ModelValidationError> Validate(object instance, ValidationAttribute attribute, PropertyDescriptor descriptor);
+        IEnumerable<ModelValidationError> Validate(object instance, ValidationAttribute attribute, PropertyDescriptor descriptor, NancyContext context);
     }
 }

--- a/src/Nancy.Validation.DataAnnotations/IPropertyValidator.cs
+++ b/src/Nancy.Validation.DataAnnotations/IPropertyValidator.cs
@@ -30,7 +30,8 @@
         /// Gets the validation result for the specified <paramref name="instance"/>.
         /// </summary>
         /// <param name="instance">The instance that should be validated.</param>
+        /// <param name="context">The <see cref="NancyContext"/> of the current request.</param>
         /// <returns>An <see cref="IEnumerable{T}"/> instance, containing <see cref="ModelValidationError"/> objects.</returns>
-        IEnumerable<ModelValidationError> Validate(object instance);
+        IEnumerable<ModelValidationError> Validate(object instance, NancyContext context);
     }
 }

--- a/src/Nancy.Validation.DataAnnotations/IValidatableObjectAdapter.cs
+++ b/src/Nancy.Validation.DataAnnotations/IValidatableObjectAdapter.cs
@@ -12,7 +12,8 @@
         /// Validates the given instance.
         /// </summary>
         /// <param name="instance">The instance.</param>
+        /// <param name="context">The <see cref="NancyContext"/> of the current request.</param>
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="ModelValidationRule"/> instances.</returns>
-        IEnumerable<ModelValidationError> Validate(object instance);
+        IEnumerable<ModelValidationError> Validate(object instance, NancyContext context);
     }
 }

--- a/src/Nancy.Validation.DataAnnotations/PropertyValidator.cs
+++ b/src/Nancy.Validation.DataAnnotations/PropertyValidator.cs
@@ -48,8 +48,9 @@
         /// Gets the validation result for the specified <paramref name="instance"/>.
         /// </summary>
         /// <param name="instance">The instance that should be validated.</param>
+        /// <param name="context">The <see cref="NancyContext"/> of the current request.</param>
         /// <returns>An <see cref="IEnumerable{T}"/> instance, containing <see cref="ModelValidationError"/> objects.</returns>
-        public IEnumerable<ModelValidationError> Validate(object instance)
+        public IEnumerable<ModelValidationError> Validate(object instance, NancyContext context)
         {
             var errors =
                 new List<ModelValidationError>();
@@ -59,7 +60,7 @@
                 foreach (var adapter in attributeAdapter.Value)
                 {
                     var results =
-                        adapter.Validate(instance, attributeAdapter.Key, this.Descriptor);
+                        adapter.Validate(instance, attributeAdapter.Key, this.Descriptor, context);
 
                     errors.AddRange(results);
                 }


### PR DESCRIPTION
The Data Annotation Validator Adapters have no way of accessing the NancyContext. `DataAnnotationsValidator` has access to the context, but [drops it on the floor](https://github.com/NancyFx/Nancy/blob/master/src/Nancy.Validation.DataAnnotations/DataAnnotationsValidator.cs#L57) rather than passing it on to `IPropertyValidator` (and ultimately onto the Adapters).

This PR extends the `Validate` method on `IPropertyValidator` and subsequent adapters to also accept `NancyContext`, passing the context down from the core objects and making it accessible for custom validation implementations.

Because of the changes to the base Data Annotation Validation interfaces, this is a breaking change.
Locally, all tests pass.
