### PR TITLE
Allow GenericFileResponse to serve files without extension

### DIFF
--- a/src/Nancy/Responses/GenericFileResponse.cs
+++ b/src/Nancy/Responses/GenericFileResponse.cs
@@ -86,11 +86,6 @@ namespace Nancy.Responses
 
         static bool IsSafeFilePath(string rootPath, string filePath)
         {
-            if (!Path.HasExtension(filePath))
-            {
-                return false;
-            }
-
             if (!File.Exists(filePath))
             {
                 return false;


### PR DESCRIPTION
I don't see any reason to filter out files without extensions, serving application/octet-stream content should be fine.