### PR TITLE
Fix route dispatcher extension stripping behavior

### DIFF
--- a/src/Nancy.Tests/Unit/Routing/DefaultRequestDispatcherFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/DefaultRequestDispatcherFixture.cs
@@ -454,6 +454,48 @@ namespace Nancy.Tests.Unit.Routing
         }
 
         [Fact]
+        public void Should_invoke_route_resolver_with_extension_stripped_only_at_the_end_from_path_when_path_does_contain_file_extension_and_mapped_response_processor_exists()
+        {
+            // Given
+            var requestedPath = string.Empty;
+
+            var context =
+                new NancyContext
+                {
+                    Request = new FakeRequest("GET", "/directory.jsonfiles/user.json")
+                };
+
+            var processor =
+                A.Fake<IResponseProcessor>();
+
+            this.responseProcessors.Add(processor);
+
+            var mappings = new List<Tuple<string, MediaRange>>
+            {
+                { new Tuple<string, MediaRange>("json", "application/json") }
+            };
+
+            A.CallTo(() => processor.ExtensionMappings).Returns(mappings);
+
+            var resolvedRoute = new ResolveResult(
+               new FakeRoute(),
+               DynamicDictionary.Empty,
+               null,
+               null,
+               null);
+
+            A.CallTo(() => this.routeResolver.Resolve(context))
+                .Invokes(x => requestedPath = ((NancyContext)x.Arguments[0]).Request.Path)
+                .Returns(resolvedRoute);
+
+            // When
+            this.requestDispatcher.Dispatch(context, new CancellationToken());
+
+            // Then
+            requestedPath.ShouldEqual("/directory.jsonfiles/user");
+        }
+
+        [Fact]
         public void Should_invoke_route_resolver_with_path_containing_when_path_does_contain_file_extension_and_no_mapped_response_processor_exists()
         {
             // Given

--- a/src/Nancy/Routing/DefaultRequestDispatcher.cs
+++ b/src/Nancy/Routing/DefaultRequestDispatcher.cs
@@ -171,7 +171,7 @@ namespace Nancy.Routing
                         mappedMediaRanges.Where(x => !context.Request.Headers.Accept.Any(header => header.Equals(x)));
 
                     var modifiedRequestPath =
-                        context.Request.Path.Replace(extension, string.Empty);
+                        context.Request.Path.Remove (context.Request.Path.LastIndexOf (extension), extension.Length);
 
                     var match =
                         this.InvokeRouteResolver(context, modifiedRequestPath, newMediaRanges);


### PR DESCRIPTION
The negotiation process extension behavior is misbehaving.

With a such route : 

``` csharp
Get ["/{filename*}"] = parameters => {
                return parameters.filename;
           '};
```

When trying to get `/directory.xmls/file.xml` the route is rewritten to `/directorys/file` instead of `/directory.xmls/file`, this patch should fix this.
