### PR TITLE
Async user mapper

### DIFF
--- a/src/Nancy.Authentication.Forms.Tests/FormsAuthenticationConfigurationFixture.cs
+++ b/src/Nancy.Authentication.Forms.Tests/FormsAuthenticationConfigurationFixture.cs
@@ -42,7 +42,7 @@ namespace Nancy.Authentication.Forms.Tests
         [Fact]
         public void Should_be_valid_with_all_properties_set_and_an_async_user_mapper()
         {
-            var result = asyncConfig.IsValid;
+            var result = this.asyncConfig.IsValid;
 
             result.ShouldBeTrue();
         }
@@ -81,7 +81,7 @@ namespace Nancy.Authentication.Forms.Tests
         [Fact]
         public void Should_not_be_valid_with_non_null_username_mapper_and_non_null_async_username_mapper()
         {
-            config.AsyncUserMapper = asyncConfig.AsyncUserMapper;
+            config.AsyncUserMapper = this.asyncConfig.AsyncUserMapper;
 
             var result = config.IsValid;
 

--- a/src/Nancy.Authentication.Forms.Tests/FormsAuthenticationConfigurationFixture.cs
+++ b/src/Nancy.Authentication.Forms.Tests/FormsAuthenticationConfigurationFixture.cs
@@ -9,6 +9,7 @@ namespace Nancy.Authentication.Forms.Tests
     public class FormsAuthenticationConfigurationFixture
     {
         private FormsAuthenticationConfiguration config;
+        private FormsAuthenticationConfiguration asyncConfig;
 
         public FormsAuthenticationConfigurationFixture()
         {
@@ -22,12 +23,26 @@ namespace Nancy.Authentication.Forms.Tests
                                   RedirectUrl = "/login",
                                   UserMapper = A.Fake<IUserMapper>(),
                               };
+            this.asyncConfig = new FormsAuthenticationConfiguration()
+                              {
+                                  CryptographyConfiguration = cryptographyConfiguration,
+                                  RedirectUrl = "/login",
+                                  AsyncUserMapper = A.Fake<IAsyncUserMapper>(),
+                              };
         }
 
         [Fact]
-        public void Should_be_valid_with_all_properties_set()
+        public void Should_be_valid_with_all_properties_set_and_a_non_async_user_mapper()
         {
             var result = config.IsValid;
+
+            result.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Should_be_valid_with_all_properties_set_and_an_async_user_mapper()
+        {
+            var result = asyncConfig.IsValid;
 
             result.ShouldBeTrue();
         }
@@ -54,9 +69,19 @@ namespace Nancy.Authentication.Forms.Tests
         }
 
         [Fact]
-        public void Should_not_be_valid_with_null_username_mapper()
+        public void Should_not_be_valid_with_null_username_mapper_and_null_async_username_mapper()
         {
             config.UserMapper = null;
+
+            var result = config.IsValid;
+
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_not_be_valid_with_non_null_username_mapper_and_non_null_async_username_mapper()
+        {
+            config.AsyncUserMapper = asyncConfig.AsyncUserMapper;
 
             var result = config.IsValid;
 

--- a/src/Nancy.Authentication.Forms/FormsAuthenticationConfiguration.cs
+++ b/src/Nancy.Authentication.Forms/FormsAuthenticationConfiguration.cs
@@ -84,7 +84,7 @@ namespace Nancy.Authentication.Forms
                     return false;
                 }
 
-                if (this.UserMapper == null ^ this.AsyncUserMapper == null)
+                if ((this.UserMapper == null) == (this.AsyncUserMapper == null))
                 {
                     return false;
                 }

--- a/src/Nancy.Authentication.Forms/FormsAuthenticationConfiguration.cs
+++ b/src/Nancy.Authentication.Forms/FormsAuthenticationConfiguration.cs
@@ -84,7 +84,7 @@ namespace Nancy.Authentication.Forms
                     return false;
                 }
 
-                if (this.UserMapper == null)
+                if (this.UserMapper == null ^ this.AsyncUserMapper == null)
                 {
                     return false;
                 }

--- a/src/Nancy.Authentication.Forms/FormsAuthenticationConfiguration.cs
+++ b/src/Nancy.Authentication.Forms/FormsAuthenticationConfiguration.cs
@@ -37,6 +37,11 @@ namespace Nancy.Authentication.Forms
         public string RedirectUrl { get; set; }
 
         /// <summary>
+        /// Gets or sets the asynchronous username/identifier mapper
+        /// </summary>
+        public IAsyncUserMapper AsyncUserMapper { get; set; }
+
+        /// <summary>
         /// Gets or sets the username/identifier mapper
         /// </summary>
         public IUserMapper UserMapper { get; set; }

--- a/src/Nancy.Authentication.Forms/IAsyncUserMapper.cs
+++ b/src/Nancy.Authentication.Forms/IAsyncUserMapper.cs
@@ -1,0 +1,30 @@
+﻿namespace Nancy.Authentication.Forms
+{
+    using Nancy.Security;
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Provides an asynchronous mapping between forms auth guid identifiers
+    /// and real usernames
+    /// </summary>
+    public interface IAsyncUserMapper
+    {
+        /// <summary>
+        /// Get the real username from an identifier
+        /// </summary>
+        /// <param name="identifier">
+        /// User identifier
+        /// </param>
+        /// <param name="context">
+        /// The current NancyFx context
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A cancellation token that can be used by other objects or threads to
+        /// receive notice of cancellation.
+        /// </param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        Task<IUserIdentity> GetUserFromIdentifierAsync(Guid identifier, NancyContext context, CancellationToken cancellationToken);
+    }
+}

--- a/src/Nancy.Authentication.Forms/Nancy.Authentication.Forms.csproj
+++ b/src/Nancy.Authentication.Forms/Nancy.Authentication.Forms.csproj
@@ -108,6 +108,7 @@
     </Compile>
     <Compile Include="FormsAuthentication.cs" />
     <Compile Include="FormsAuthenticationConfiguration.cs" />
+    <Compile Include="IAsyncUserMapper.cs" />
     <Compile Include="IUserMapper.cs" />
     <Compile Include="ModuleExtensions.cs" />
   </ItemGroup>


### PR DESCRIPTION
Adds Tests For [PR 1643](https://github.com/NancyFx/Nancy/pull/1643).  Also "Nancy-ifies" the code to keep it stylistically similar to the rest of Nancy. (Only one small change). It fixes a bug in the otherwise excellent implementation provided by @ExUltima (the UserMapper was still required even if an Async one existed).