### PR TITLE
Conventions don't get their dependencies wired up.

### DIFF
--- a/src/Nancy.Tests/Fakes/FakeConventionWithDependencies.cs
+++ b/src/Nancy.Tests/Fakes/FakeConventionWithDependencies.cs
@@ -1,0 +1,22 @@
+﻿namespace Nancy.Tests.Fakes
+{
+    using System;
+    using Nancy.Conventions;
+
+    /// <summary>
+    /// A do-nothing IConvention that demonstrates a bug in resolving conventions
+    /// </summary>
+    public class FakeConventionWithDependencies : IConvention {
+        private Person dependantUpon;
+        public FakeConventionWithDependencies(Person dependantUpon) {
+            this.dependantUpon = dependantUpon;
+        }
+
+        public void Initialise(NancyConventions conventions) {
+        }
+
+        public Tuple<bool, string> Validate(NancyConventions conventions) {
+            return Tuple.Create(true, (string)null);
+        }
+    }
+}

--- a/src/Nancy.Tests/Nancy.Tests.csproj
+++ b/src/Nancy.Tests/Nancy.Tests.csproj
@@ -109,6 +109,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Fakes\FakeConventionWithDependencies.cs" />
     <Compile Include="Fakes\PersonWithAgeField.cs" />
     <Compile Include="NoAppStartupsFixture.cs" />
     <Compile Include="Extensions\ResponseExtensions.cs" />


### PR DESCRIPTION
This PR is *not* ready for action. It's just a failing test.