### PR TITLE
Fix #812 - allow to return a struct as a model for a route

### DIFF
--- a/src/Nancy.Tests/Fakes/StructModel.cs
+++ b/src/Nancy.Tests/Fakes/StructModel.cs
@@ -1,0 +1,6 @@
+﻿namespace Nancy.Tests.Fakes
+{
+    public struct StructModel
+    {
+    }
+}

--- a/src/Nancy.Tests/Nancy.Tests.csproj
+++ b/src/Nancy.Tests/Nancy.Tests.csproj
@@ -110,6 +110,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Fakes\PersonWithAgeField.cs" />
+    <Compile Include="Fakes\StructModel.cs" />
     <Compile Include="NoAppStartupsFixture.cs" />
     <Compile Include="Extensions\ResponseExtensions.cs" />
     <Compile Include="Fakes\FakeNancyModuleNoRoutes.cs" />

--- a/src/Nancy.Tests/Unit/Routing/DefaultRouteInvokerFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/DefaultRouteInvokerFixture.cs
@@ -90,10 +90,29 @@
         }
 
         [Fact]
-        public void Should_invoke_response_negotiator()
+        public void Should_invoke_response_negotiator_for_reference_model()
         {
             // Given
             var model = new Person { FirstName = "First", LastName = "Last" };
+            var route = new FakeRoute(model);
+            var parameters = new DynamicDictionary();
+            var context = new NancyContext
+            {
+                Trace = new DefaultRequestTrace()
+            };
+
+            // When
+            var result = this.invoker.Invoke(route, new CancellationToken(), parameters, context).Result;
+
+            // Then
+            A.CallTo(() => this.responseNegotiator.NegotiateResponse(model, context)).MustHaveHappened();
+        }
+
+        [Fact]
+        public void Should_invoke_response_negotiator_for_value_type_model()
+        {
+            // Given
+            var model = new StructModel();
             var route = new FakeRoute(model);
             var parameters = new DynamicDictionary();
             var context = new NancyContext

--- a/src/Nancy/Routing/DefaultRouteInvoker.cs
+++ b/src/Nancy/Routing/DefaultRouteInvoker.cs
@@ -43,7 +43,7 @@ namespace Nancy.Routing
                 completedTask =>
                 {
                     var returnResult = completedTask.Result;
-                    if (returnResult == null)
+                    if (!(returnResult is ValueType) && returnResult == null)
                     {
                         context.WriteTraceLog(
                             sb => sb.AppendLine("[DefaultRouteInvoker] Invocation of route returned null"));


### PR DESCRIPTION
Just need to check if return is a value type before testing against null. Fix #812.
Then, you can use embedded JsonSerializer or JSON.NET one without any problem.
Thanks
