### PR TITLE
Remove unneeded/bad IModelValidator registrations

### DIFF
--- a/src/Nancy.Validation.DataAnnotations/DataAnnotationsRegistrations.cs
+++ b/src/Nancy.Validation.DataAnnotations/DataAnnotationsRegistrations.cs
@@ -13,7 +13,6 @@ namespace Nancy.Validation.DataAnnotations
         /// </summary>
         public DataAnnotationsRegistrations()
         {
-            this.Register<IModelValidator>(typeof(DataAnnotationsValidator));
             this.RegisterAll<IDataAnnotationsValidatorAdapter>();
             this.RegisterWithDefault<IPropertyValidatorFactory>(typeof(DefaultPropertyValidatorFactory));
             this.RegisterWithDefault<IValidatableObjectAdapter>(typeof(DefaultValidatableObjectAdapter));

--- a/src/Nancy.Validation.FluentValidation/FluentValidationRegistrations.cs
+++ b/src/Nancy.Validation.FluentValidation/FluentValidationRegistrations.cs
@@ -15,7 +15,6 @@ namespace Nancy.Validation.FluentValidation
         /// </summary>
         public FluentValidationRegistrations()
         {
-            this.Register<IModelValidator>(typeof(FluentValidationValidator));
             this.Register<IFluentAdapterFactory>(typeof(DefaultFluentAdapterFactory));
             this.RegisterAll<IFluentAdapter>();
             this.RegisterAll<IValidator>();


### PR DESCRIPTION
Short: As these classes are never resolved from the container, but are created with "new" in the factories, there is no need for the registrations to exist at all.

Long:

These 2 registrations are incomplete, as their ctors expect Type as parameter. This causes IoC container diagnostics to fail (example, Windsor reports missing dependencies).

I have a test which validates if after bootstraper.Initialize() the container is in a consistent state, and that's how I found the problem.