### PR TITLE
Pass NancyContext to CreateRequestContainer

### DIFF
--- a/src/Nancy.Testing/ConfigurableBootstrapper.cs
+++ b/src/Nancy.Testing/ConfigurableBootstrapper.cs
@@ -321,8 +321,9 @@ namespace Nancy.Testing
         /// <summary>
         /// Creates a per request child/nested container
         /// </summary>
+        /// <param name="context">Current context</param>
         /// <returns>Request container instance</returns>
-        protected override TinyIoCContainer CreateRequestContainer()
+        protected override TinyIoCContainer CreateRequestContainer(NancyContext context)
         {
             return this.ApplicationContainer.GetChildContainer();
         }

--- a/src/Nancy.Tests/Unit/Bootstrapper/NancyBootstrapperWithRequestContainerBaseFixture.cs
+++ b/src/Nancy.Tests/Unit/Bootstrapper/NancyBootstrapperWithRequestContainerBaseFixture.cs
@@ -330,7 +330,7 @@
                 }
             }
 
-            protected override FakeContainer CreateRequestContainer()
+            protected override FakeContainer CreateRequestContainer(NancyContext context)
             {
                 return new FakeContainer(this.ApplicationContainer);
             }

--- a/src/Nancy/Bootstrapper/NancyBootstrapperWithRequestContainerBase.cs
+++ b/src/Nancy/Bootstrapper/NancyBootstrapperWithRequestContainerBase.cs
@@ -2,6 +2,7 @@ namespace Nancy.Bootstrapper
 {
     using System;
     using System.Collections.Generic;
+    using System.ComponentModel;
     using System.Linq;
 
     /// <summary>
@@ -153,7 +154,7 @@ namespace Nancy.Bootstrapper
 
             if (requestContainer == null)
             {
-                requestContainer = this.CreateRequestContainer();
+                requestContainer = this.CreateRequestContainer(context);
 
                 context.Items[this.ContextKey] = requestContainer;
 
@@ -188,8 +189,9 @@ namespace Nancy.Bootstrapper
         /// <summary>
         /// Creates a per request child/nested container
         /// </summary>
+        /// <param name="context">Current context</param>
         /// <returns>Request container instance</returns>
-        protected abstract TContainer CreateRequestContainer();
+        protected abstract TContainer CreateRequestContainer(NancyContext context);
 
         /// <summary>
         /// Register the given module types into the request container

--- a/src/Nancy/DefaultNancyBootstrapper.cs
+++ b/src/Nancy/DefaultNancyBootstrapper.cs
@@ -176,8 +176,9 @@ namespace Nancy
         /// <summary>
         /// Creates a per request child/nested container
         /// </summary>
+        /// <param name="context">Current context</param>
         /// <returns>Request container instance</returns>
-        protected override sealed TinyIoCContainer CreateRequestContainer()
+        protected override TinyIoCContainer CreateRequestContainer(NancyContext context)
         {
             return this.ApplicationContainer.GetChildContainer();
         }


### PR DESCRIPTION
This will allow you to get a request-scoped container from the OWIN pipeline by accessing the OWIN environment dictionary.

Will update the bootstrappers after this is merged.