### PR TITLE
Fixed a bug that prevented transmitting chunked content with Nancy SelfHost Library

### DIFF
--- a/src/Nancy.Hosting.Self/IgnoredHeaders.cs
+++ b/src/Nancy.Hosting.Self/IgnoredHeaders.cs
@@ -1,0 +1,35 @@
+﻿namespace Nancy.Hosting.Self
+{
+
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    ///     A helper class that checks for a header against a list of headers that should be ignored
+    ///     when populating the headers of an <see cref="T:System.Net.HttpListenerResponse"/> object.
+    /// </summary>
+    public static class IgnoredHeaders
+    {
+
+        private static readonly HashSet<string> knownHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "content-length",
+            "content-type",
+            "transfer-encoding",
+            "keep-alive"
+        };
+
+        /// <summary>
+        ///     Determines if a header is ignored when populating the headers of an an 
+        ///     <see cref="T:System.Net.HttpListenerResponse"/> object.
+        /// </summary>
+        /// <param name="headerName">The name of the header.</param>
+        /// <returns><c>true</c> if the header is ignored; otherwise, <c>false</c>.</returns>
+        public static bool IsIgnored(string headerName)
+        {
+            return knownHeaders.Contains(headerName);
+        }
+
+    }
+
+}

--- a/src/Nancy.Hosting.Self/Nancy.Hosting.Self.csproj
+++ b/src/Nancy.Hosting.Self/Nancy.Hosting.Self.csproj
@@ -105,6 +105,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="IgnoredHeaders.cs" />
     <Compile Include="UrlReservations.cs" />
     <Compile Include="UacHelper.cs" />
     <Compile Include="FileSystemRootPathProvider.cs" />

--- a/src/Nancy.Hosting.Self/NancyHost.cs
+++ b/src/Nancy.Hosting.Self/NancyHost.cs
@@ -283,7 +283,10 @@
         {
             foreach (var header in nancyResponse.Headers)
             {
-                response.AddHeader(header.Key, header.Value);
+                if (!IgnoredHeaders.IsIgnored(header.Key))
+                {
+                    response.AddHeader(header.Key, header.Value);
+                }
             }
 
             foreach (var nancyCookie in nancyResponse.Cookies)


### PR DESCRIPTION
With the latest 1.0 release, attempting to download static content caused an unhandled exception due to the Content-Length being incorrectly added as a header.

Updated the conversion between a Nancy response and an HttpListenerResponse to ignore certain headers that are defined as properties. 