### PR TITLE
Adjust DynamicDictionaryValue TryParse method to allow more convertions

### DIFF
--- a/src/Nancy.Tests/Unit/DynamicDictionaryValueFixture.cs
+++ b/src/Nancy.Tests/Unit/DynamicDictionaryValueFixture.cs
@@ -898,6 +898,66 @@
         }
 
         [Fact]
+        public void Should_implicitly_convert_from_int_based_on_given_parameter_type_of_short ()
+        {
+            //Given
+            const int expected = 42;
+            const short notExpected = 100;
+            dynamic value = new DynamicDictionaryValue (expected);
+
+            //When
+            int actual = (int)value.TryParse<short> (notExpected);
+
+            //Then
+            Assert.Equal (expected, actual);
+        }
+
+        [Fact]
+        public void Should_implicitly_convert_from_int_based_on_given_parameter_type_of_long ()
+        {
+            //Given
+            const int expected = 42;
+            const long notExpected = 100;
+            dynamic value = new DynamicDictionaryValue (expected);
+
+            //When
+            int actual = (int)value.TryParse<long> (notExpected);
+
+            //Then
+            Assert.Equal (expected, actual);
+        }
+
+        [Fact]
+        public void Should_implicitly_convert_from_int_based_on_given_parameter_type_of_nullable_long ()
+        {
+            //Given
+            const int expected = 42;
+            long? notExpected = 100;
+            dynamic value = new DynamicDictionaryValue (expected);
+
+            //When
+            int actual = (int)value.TryParse<long?> (notExpected);
+
+            //Then
+            Assert.Equal (expected, actual);
+        }
+
+        [Fact]
+        public void Should_implicitly_convert_from_datetime_based_on_given_parameter_type_of_nullable_datetime ()
+        {
+            //Given
+            DateTime expected = DateTime.Parse ("13 December 2012");
+            DateTime? notExpected = expected.AddDays (10);
+            dynamic value = new DynamicDictionaryValue (expected);
+
+            //When
+            DateTime actual = (DateTime)value.TryParse<DateTime?> (notExpected);
+
+            //Then
+            Assert.Equal (expected, actual);
+        }
+
+        [Fact]
         public void Should_return_default_value_if_implicit_convert_fails_on_datetime()
         {
             //Given

--- a/src/Nancy.Tests/Unit/DynamicDictionaryValueFixture.cs
+++ b/src/Nancy.Tests/Unit/DynamicDictionaryValueFixture.cs
@@ -898,7 +898,7 @@
         }
 
         [Fact]
-        public void Should_implicitly_convert_from_int_based_on_given_parameter_type_of_short ()
+        public void Should_implicitly_convert_from_int_based_on_given_parameter_type_of_short()
         {
             //Given
             const int expected = 42;
@@ -913,7 +913,7 @@
         }
 
         [Fact]
-        public void Should_implicitly_convert_from_int_based_on_given_parameter_type_of_long ()
+        public void Should_implicitly_convert_from_int_based_on_given_parameter_type_of_long()
         {
             //Given
             const int expected = 42;
@@ -928,7 +928,7 @@
         }
 
         [Fact]
-        public void Should_implicitly_convert_from_int_based_on_given_parameter_type_of_nullable_long ()
+        public void Should_implicitly_convert_from_int_based_on_given_parameter_type_of_nullable_long()
         {
             //Given
             const int expected = 42;
@@ -943,7 +943,7 @@
         }
 
         [Fact]
-        public void Should_implicitly_convert_from_datetime_based_on_given_parameter_type_of_nullable_datetime ()
+        public void Should_implicitly_convert_from_datetime_based_on_given_parameter_type_of_nullable_datetime()
         {
             //Given
             DateTime expected = DateTime.Parse ("13 December 2012");

--- a/src/Nancy/DynamicDictionaryValue.cs
+++ b/src/Nancy/DynamicDictionaryValue.cs
@@ -78,16 +78,16 @@
                 try
                 {
                     var vType = value.GetType();
-                    var TType = typeof (T);
+                    var TType = typeof(T);
 
                     // check fo direct cast
-                    if (vType.IsAssignableFrom (TType))
+                    if (vType.IsAssignableFrom(TType))
                     {
                         return (T)value;
                     }                    
 
                     var stringValue = value as string;
-                    if (TType == typeof (DateTime))
+                    if (TType == typeof(DateTime))
                     {
                         DateTime result;
 
@@ -107,7 +107,7 @@
                     }
                     else
                     {
-                        var nullableType = Nullable.GetUnderlyingType (TType);
+                        var nullableType = Nullable.GetUnderlyingType(TType);
                         if (nullableType != null)
                             TType = nullableType;
                         return (T)Convert.ChangeType(value, TType, CultureInfo.InvariantCulture);

--- a/src/Nancy/DynamicDictionaryValue.cs
+++ b/src/Nancy/DynamicDictionaryValue.cs
@@ -77,12 +77,14 @@
             {
                 try
                 {
-                    if (value.GetType().IsAssignableFrom(typeof(T)))
+                    var vType = value.GetType();
+                    var TType = typeof (T);
+
+                    // check fo direct cast
+                    if (vType.IsAssignableFrom (TType))
                     {
                         return (T)value;
-                    }
-
-                    var TType = typeof (T);
+                    }                    
 
                     var stringValue = value as string;
                     if (TType == typeof (DateTime))
@@ -103,9 +105,13 @@
                             return (T) converter.ConvertFromInvariantString(stringValue);
                         }
                     }
-                    else if (TType == typeof (string))
+                    else if (Nullable.GetUnderlyingType(TType) == vType)
                     {
-                        return (T)Convert.ChangeType(value, TypeCode.String, CultureInfo.InvariantCulture);
+                        return (T)value;
+                    }
+                    else
+                    {
+                        return (T)Convert.ChangeType(value, TType, CultureInfo.InvariantCulture);
                     }
                 }
                 catch

--- a/src/Nancy/DynamicDictionaryValue.cs
+++ b/src/Nancy/DynamicDictionaryValue.cs
@@ -105,12 +105,11 @@
                             return (T) converter.ConvertFromInvariantString(stringValue);
                         }
                     }
-                    else if (Nullable.GetUnderlyingType(TType) == vType)
-                    {
-                        return (T)value;
-                    }
                     else
                     {
+                        var nullableType = Nullable.GetUnderlyingType (TType);
+                        if (nullableType != null)
+                            TType = nullableType;
                         return (T)Convert.ChangeType(value, TType, CultureInfo.InvariantCulture);
                     }
                 }


### PR DESCRIPTION
Adjust DynamicDictionaryValue TryParse method to allow more convertions.
. Convertions like Int64 to Int32 were ignored in the previous version,
since there was no ending else statement.
Now the last rule is to try a type convertion.
. Convertions to a nullable type were also ignored (like Int64 to
Int64?), now there is a test to check if a nullable type convertion is
possible.

Note that if the convertion fails any exception will be treated and the
default value returned.

Some test cases were created for these situations.

 