### PR TITLE
Fix xml comment

### DIFF
--- a/src/Nancy/Bootstrapper/ScanMode.cs
+++ b/src/Nancy/Bootstrapper/ScanMode.cs
@@ -20,7 +20,7 @@
         /// </summary>
         ExcludeNancy,
 
-        // <summary>
+        /// <summary>
         /// Only Namespaces that starts with 'Nancy'
         /// </summary>
         OnlyNancyNamespace,


### PR DESCRIPTION
Nancy.xml doesn't include the comment and instead says
```xml
<!-- Badly formed XML comment ignored for member "F:Nancy.Bootstrapper.ScanMode.OnlyNancyNamespace" -->
```