### PR TITLE
Fix xml comment

### DIFF
--- a/src/Nancy/Conventions/ViewLocationConventions.cs
+++ b/src/Nancy/Conventions/ViewLocationConventions.cs
@@ -7,7 +7,7 @@
 
     /// <summary>
     /// This is a wrapper around the type
-    /// 'IEnumerable<Func<string, object, ViewLocationContext, string>>' and its
+    /// <c>IEnumerable&lt;Func&lt;string, object, ViewLocationContext, string&gt;&gt;</c> and its
     /// only purpose is to make Ninject happy which was throwing an exception
     /// when constructor injecting this type.
     /// </summary>


### PR DESCRIPTION
Nancy.xml doesn't include the comment and instead says
```xml
<!-- Badly formed XML comment ignored for member "T:Nancy.Conventions.ViewLocationConventions" -->
```