### PR TITLE
added Before hook to make Url https if forwarded header present

### DIFF
--- a/src/Nancy.Tests/Nancy.Tests.csproj
+++ b/src/Nancy.Tests/Nancy.Tests.csproj
@@ -232,6 +232,7 @@
     <Compile Include="Unit\Security\CsrfFixture.cs" />
     <Compile Include="Unit\Security\DefaultCsrfTokenValidatorFixture.cs" />
     <Compile Include="Unit\Security\ModuleSecurityFixture.cs" />
+    <Compile Include="Unit\Security\SSLProxyFixture.cs" />
     <Compile Include="Unit\Security\UserIdentityExtensionsFixture.cs" />
     <Compile Include="Unit\Sessions\CookieBasedSessionsConfigurationFixture.cs" />
     <Compile Include="Unit\Sessions\CookieBasedSessionsFixture.cs" />

--- a/src/Nancy.Tests/Unit/Security/SSLProxyFixture.cs
+++ b/src/Nancy.Tests/Unit/Security/SSLProxyFixture.cs
@@ -15,7 +15,7 @@
         {
             this.pipelines = new MockPipelines();
 
-            SSLProxy.MakeNancyUrlSecure(this.pipelines);
+            SSLProxy.RewriteSchemeUsingForwardedHeaders(this.pipelines);
         }
 
         [Fact]

--- a/src/Nancy.Tests/Unit/Security/SSLProxyFixture.cs
+++ b/src/Nancy.Tests/Unit/Security/SSLProxyFixture.cs
@@ -1,0 +1,47 @@
+﻿namespace Nancy.Tests.Unit.Security
+{
+    using Nancy.Bootstrapper;
+    using Nancy.Security;
+    using Nancy.Tests.Fakes;
+    using System.Collections.Generic;
+    using System.Threading;
+    using Xunit;
+
+    public class SSLProxyFixture
+    {
+        private readonly IPipelines pipelines;
+
+        public SSLProxyFixture()
+        {
+            this.pipelines = new MockPipelines();
+
+            SSLProxy.Enable(this.pipelines);
+        }
+
+        [Fact]
+        public void Should_set_url_scheme_to_https_if_X_Forwarded_Proto_header_exists()
+        {
+            var request = new FakeRequest("GET", "/",
+                new Dictionary<string, IEnumerable<string>> { { "X-Forwarded-Proto", new[] { "https" } } });
+
+            var context = new NancyContext { Request = request };
+
+            this.pipelines.BeforeRequest.Invoke(context, new CancellationToken());
+
+            request.Url.Scheme.ShouldEqual("https");
+        }
+
+        [Fact]
+        public void Should_set_url_scheme_to_https_if_Forwarded_header_exists()
+        {
+            var request = new FakeRequest("GET", "/",
+               new Dictionary<string, IEnumerable<string>> { { "Forwarded", new[] { "for=192.0.2.60", "proto=https", "by=203.0.113.43" } } });
+
+            var context = new NancyContext { Request = request };
+
+            this.pipelines.BeforeRequest.Invoke(context, new CancellationToken());
+
+            request.Url.Scheme.ShouldEqual("https");
+        }
+    }
+}

--- a/src/Nancy.Tests/Unit/Security/SSLProxyFixture.cs
+++ b/src/Nancy.Tests/Unit/Security/SSLProxyFixture.cs
@@ -15,7 +15,7 @@
         {
             this.pipelines = new MockPipelines();
 
-            SSLProxy.Enable(this.pipelines);
+            SSLProxy.MakeNancyUrlSecure(this.pipelines);
         }
 
         [Fact]

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -284,6 +284,7 @@
     <Compile Include="Routing\Trie\RouteResolverTrie.cs" />
     <Compile Include="Routing\Trie\SegmentMatch.cs" />
     <Compile Include="Routing\Trie\TrieNodeFactory.cs" />
+    <Compile Include="Security\SSLProxy.cs" />
     <Compile Include="Session\CookieBasedSessionsConfiguration.cs" />
     <Compile Include="StaticContent.cs" />
     <Compile Include="Conventions\ViewLocationConventions.cs" />

--- a/src/Nancy/Security/SSLProxy.cs
+++ b/src/Nancy/Security/SSLProxy.cs
@@ -11,12 +11,12 @@
     public static class SSLProxy
     {
         /// <summary>
-        /// Checks for Forwarded or X-Forwarded-Proto header and if so makes curent url schemme https
+        /// Checks for Forwarded or X-Forwarded-Proto header and if so makes current url scheme https
         /// </summary>
-        /// <param name="pipelines"></param>
-        public static void MakeNancyUrlSecure(IPipelines pipelines)
+        /// <param name="pipelines">Application pipelines</param>
+        public static void RewriteSchemeUsingForwardedHeaders(IPipelines pipelines)
         {
-            pipelines.BeforeRequest += (ctx) =>
+            pipelines.BeforeRequest += ctx =>
             {
                 //X-Forwarded-Proto: https
                 if (ctx.Request.Headers.Keys.Any(x => x.Equals("X-Forwarded-Proto", StringComparison.OrdinalIgnoreCase)))

--- a/src/Nancy/Security/SSLProxy.cs
+++ b/src/Nancy/Security/SSLProxy.cs
@@ -10,7 +10,11 @@
     /// </summary>
     public class SSLProxy
     {
-        public static void Enable(IPipelines pipelines)
+        /// <summary>
+        /// Checks for Forwarded or X-Forwarded-Proto header and if so makes curent url schemme https
+        /// </summary>
+        /// <param name="pipelines"></param>
+        public static void MakeNancyUrlSecure(IPipelines pipelines)
         {
             pipelines.BeforeRequest += (ctx) =>
             {

--- a/src/Nancy/Security/SSLProxy.cs
+++ b/src/Nancy/Security/SSLProxy.cs
@@ -1,0 +1,38 @@
+﻿namespace Nancy.Security
+{
+    using System;
+    using System.Linq;
+
+    using Nancy.Bootstrapper;
+
+    /// <summary>
+    /// Allows a BeforeRequest hook to change Url to HTTPS if X-Forwarded-Proto header present
+    /// </summary>
+    public class SSLProxy
+    {
+        public static void Enable(IPipelines pipelines)
+        {
+            pipelines.BeforeRequest += (ctx) =>
+            {
+                //X-Forwarded-Proto: https
+                if (ctx.Request.Headers.Keys.Any(x => x.Equals("X-Forwarded-Proto", StringComparison.OrdinalIgnoreCase)))
+                {
+                    ctx.Request.Url.Scheme = "https";
+                }
+
+                //RFC7239
+                if (ctx.Request.Headers.Keys.Any(x => x.Equals("Forwarded", StringComparison.OrdinalIgnoreCase)))
+                {
+                    var forwardedHeader = ctx.Request.Headers["Forwarded"];
+                    var protoValue = forwardedHeader.FirstOrDefault(x => x.StartsWith("proto", StringComparison.OrdinalIgnoreCase));
+                    if (protoValue != null && protoValue.Equals("proto=https", StringComparison.OrdinalIgnoreCase))
+                    {
+                        ctx.Request.Url.Scheme = "https";
+                    }
+                }
+
+                return null;
+            };
+        }
+    }
+}

--- a/src/Nancy/Security/SSLProxy.cs
+++ b/src/Nancy/Security/SSLProxy.cs
@@ -8,7 +8,7 @@
     /// <summary>
     /// Allows a BeforeRequest hook to change Url to HTTPS if X-Forwarded-Proto header present
     /// </summary>
-    public class SSLProxy
+    public static class SSLProxy
     {
         /// <summary>
         /// Checks for Forwarded or X-Forwarded-Proto header and if so makes curent url schemme https


### PR DESCRIPTION
Added optional before hook to make url scheme https if `forwarded` header present

Usage : `SSLProxy. MakeNancyUrlSecure(pipelines)`

Addresses #1679 