### PR TITLE
Added ProtocolVersion to Request

### DIFF
--- a/src/Nancy.Hosting.Aspnet/NancyHandler.cs
+++ b/src/Nancy.Hosting.Aspnet/NancyHandler.cs
@@ -102,12 +102,15 @@ namespace Nancy.Hosting.Aspnet
                 body = RequestStream.FromStream(context.Request.InputStream, expectedRequestLength, true);
             }
 
+            var protocolVersion = context.Request.ServerVariables["HTTP_VERSION"];
+
             return new Request(context.Request.HttpMethod.ToUpperInvariant(), 
                 nancyUrl, 
                 body, 
                 incomingHeaders, 
                 context.Request.UserHostAddress, 
-                certificate);
+                certificate,
+                protocolVersion);
         }
 
         private static long GetExpectedRequestLength(IDictionary<string, IEnumerable<string>> incomingHeaders)

--- a/src/Nancy.Hosting.Self/NancyHost.cs
+++ b/src/Nancy.Hosting.Self/NancyHost.cs
@@ -270,8 +270,11 @@
                 }
             }
 
-            // TODO: Make sure this handles HTTP/2 (notice; not 2.0)
-            var protocolVersion = string.Format("HTTP/{0}", request.ProtocolVersion.ToString(2));
+            // NOTE: For HTTP/2 we want fieldCount = 1,
+            // otherwise (HTTP/1.0 and HTTP/1.1) we want fieldCount = 2
+            var fieldCount = request.ProtocolVersion.Major == 2 ? 1 : 2;
+
+            var protocolVersion = string.Format("HTTP/{0}", request.ProtocolVersion.ToString(fieldCount));
 
             return new Request(
                 request.HttpMethod,

--- a/src/Nancy.Hosting.Self/NancyHost.cs
+++ b/src/Nancy.Hosting.Self/NancyHost.cs
@@ -270,13 +270,17 @@
                 }
             }
 
+            // TODO: Make sure this handles HTTP/2 (notice; not 2.0)
+            var protocolVersion = string.Format("HTTP/{0}", request.ProtocolVersion.ToString(2));
+
             return new Request(
                 request.HttpMethod,
                 nancyUrl,
                 RequestStream.FromStream(request.InputStream, expectedRequestLength, false),
                 request.Headers.ToDictionary(), 
                 (request.RemoteEndPoint != null) ? request.RemoteEndPoint.Address.ToString() : null,
-                certificate);
+                certificate,
+                protocolVersion);
         }
 
         private void ConvertNancyResponseToResponse(Response nancyResponse, HttpListenerResponse response)

--- a/src/Nancy/Owin/NancyMiddleware.cs
+++ b/src/Nancy/Owin/NancyMiddleware.cs
@@ -69,6 +69,7 @@
                         var owinRequestPath = Get<string>(environment, "owin.RequestPath");
                         var owinRequestQueryString = Get<string>(environment, "owin.RequestQueryString");
                         var owinRequestBody = Get<Stream>(environment, "owin.RequestBody");
+                        var owinRequestProtocol = Get<string>(environment, "owin.RequestProtocol");
                         var owinCallCancelled = Get<CancellationToken>(environment, "owin.CallCancelled");
                         var owinRequestHost = GetHeader(owinRequestHeaders, "Host") ?? Dns.GetHostName();
 
@@ -91,7 +92,8 @@
                                 nancyRequestStream,
                                 owinRequestHeaders.ToDictionary(kv => kv.Key, kv => (IEnumerable<string>)kv.Value, StringComparer.OrdinalIgnoreCase),
                                 serverClientIp,
-                                certificate);
+                                certificate,
+                                owinRequestProtocol);
 
                         var tcs = new TaskCompletionSource<int>();
 

--- a/src/Nancy/Request.cs
+++ b/src/Nancy/Request.cs
@@ -42,7 +42,14 @@ namespace Nancy
         /// <param name="body">The <see cref="Stream"/> that represents the incoming HTTP body.</param>
         /// <param name="ip">The client's IP address</param>
         /// <param name="certificate">The client's certificate when present.</param>
-        public Request(string method, Url url, RequestStream body = null, IDictionary<string, IEnumerable<string>> headers = null, string ip = null, byte[] certificate = null)
+        /// <param name="protocolVersion">The HTTP protocol version.</param>
+        public Request(string method,
+            Url url,
+            RequestStream body = null,
+            IDictionary<string, IEnumerable<string>> headers = null,
+            string ip = null,
+            byte[] certificate = null,
+            string protocolVersion = null)
         {
             if (String.IsNullOrEmpty(method))
             {
@@ -83,6 +90,8 @@ namespace Nancy
                 this.ClientCertificate = new X509Certificate2(certificate);
             }
 
+            this.ProtocolVersion = protocolVersion ?? string.Empty;
+
             if (String.IsNullOrEmpty(this.Url.Path))
             {
                 this.Url.Path = "/";
@@ -96,6 +105,11 @@ namespace Nancy
         /// Gets the certificate sent by the client.
         /// </summary>
         public X509Certificate ClientCertificate { get; private set; }
+
+        /// <summary>
+        /// Gets the HTTP protocol version.
+        /// </summary>
+        public string ProtocolVersion { get; private set; }
 
         /// <summary>
         /// Gets the IP address of the client


### PR DESCRIPTION
Fixes #1772

As usual, the WCF host won't play nice. I can't find any way to access the underlying HTTP request to get a hold of the protocol version. Surely it must be there somewhere, I just don't know how to get it.
I've tried everything from custom message inspectors/formatters to message encoders :confused: I _really_ don't know WCF. The other hosts should be fine :smile:

IMO we should just drop the WCF service ASAP.