### PR TITLE
Add Head route hook with static config to enable old behavior

### DIFF
--- a/src/Nancy.Tests.Functional/Tests/BasicRouteInvocationsFixture.cs
+++ b/src/Nancy.Tests.Functional/Tests/BasicRouteInvocationsFixture.cs
@@ -146,6 +146,11 @@
                     return "Default get root";
                 };
 
+                Head["/"] = parameters =>
+                {
+                    return "Default head root";
+                };
+
                 Post["/"] = parameters =>
                 {
                     return "Default post root";

--- a/src/Nancy.Tests.Functional/Tests/BasicRouteInvocationsFixture.cs
+++ b/src/Nancy.Tests.Functional/Tests/BasicRouteInvocationsFixture.cs
@@ -146,11 +146,6 @@
                     return "Default get root";
                 };
 
-                Head["/"] = parameters =>
-                {
-                    return "Default head root";
-                };
-
                 Post["/"] = parameters =>
                 {
                     return "Default post root";
@@ -162,7 +157,43 @@
                 };
             }
         }
+
+        public class BasicRouteInvocationsModuleWithHead : NancyModule
+        {
+            public BasicRouteInvocationsModuleWithHead()
+            {
+                Get["/"] = parameters =>
+                {
+                    return "Default get root";
+                };
+
+                Head["/"] = parameters =>
+                            {
+                                return new Response()
+                                {
+                                    StatusCode = HttpStatusCode.OK,
+                                    ReasonPhrase = "HEAD!"
+                                };
+                            };
+            }
+        }
+
+        [Fact]
+        public void Should_use_head_response_values_for_basic_head_request()
+        {
+            StaticConfiguration.EnableHeadRouting = true;
+            // Given
+            var browser = new Browser(with => with.Module<BasicRouteInvocationsModuleWithHead>());
+            // When
+            var response = browser.Head("/");
+
+            // Then
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("text/html", response.ContentType);
+            Assert.Equal(string.Empty, response.Body.AsString());
+            Assert.Equal("HEAD!", response.ReasonPhrase);
+
+            StaticConfiguration.EnableHeadRouting = false;
+        }
     }
-
-
 }

--- a/src/Nancy.Tests/Unit/Routing/DefaultRouteResolverFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/DefaultRouteResolverFixture.cs
@@ -430,8 +430,6 @@
             {
                 Get["/"] = _ => "Root";
 
-                Head["/"] = _ => "HeadRoot";
-
                 Post["/"] = _ => "PostRoot";
 
                 Get["/foo"] = _ => "SingleLiteral";

--- a/src/Nancy.Tests/Unit/Routing/DefaultRouteResolverFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/DefaultRouteResolverFixture.cs
@@ -430,6 +430,8 @@
             {
                 Get["/"] = _ => "Root";
 
+                Head["/"] = _ => "HeadRoot";
+
                 Post["/"] = _ => "PostRoot";
 
                 Get["/foo"] = _ => "SingleLiteral";

--- a/src/Nancy/HeadResponse.cs
+++ b/src/Nancy/HeadResponse.cs
@@ -23,6 +23,7 @@
             this.ContentType = response.ContentType;
             this.Headers = response.Headers;
             this.StatusCode = response.StatusCode;
+            this.ReasonPhrase = response.ReasonPhrase;
             this.CheckAndSetContentLength(response);
         }
 

--- a/src/Nancy/NancyModule.cs
+++ b/src/Nancy/NancyModule.cs
@@ -71,10 +71,25 @@ namespace Nancy
         /// Gets <see cref="RouteBuilder"/> for declaring actions for GET requests.
         /// </summary>
         /// <value>A <see cref="RouteBuilder"/> instance.</value>
-        /// <remarks>These actions will also be used when a HEAD request is received.</remarks>
         public RouteBuilder Get
         {
             get { return new RouteBuilder("GET", this); }
+        }
+
+        /// <summary>
+        /// Gets <see cref="RouteBuilder"/> for declaring actions for HEAD requests.
+        /// </summary>
+        /// <value>A <see cref="RouteBuilder"/> instance.</value>
+        public RouteBuilder Head
+        {
+            get
+            {
+                if (StaticConfiguration.DisableHeadRouting)
+                {
+                    throw new InvalidOperationException("HEAD routing is disabled");
+                }
+                return new RouteBuilder("HEAD", this);
+            }
         }
 
         /// <summary>

--- a/src/Nancy/NancyModule.cs
+++ b/src/Nancy/NancyModule.cs
@@ -84,7 +84,7 @@ namespace Nancy
         {
             get
             {
-                if (StaticConfiguration.DisableHeadRouting)
+                if (!StaticConfiguration.EnableHeadRouting)
                 {
                     throw new InvalidOperationException("HEAD routing is disabled");
                 }

--- a/src/Nancy/Routing/DefaultRouteResolver.cs
+++ b/src/Nancy/Routing/DefaultRouteResolver.cs
@@ -160,7 +160,7 @@
             var requestedMethod =
                 context.Request.Method;
 
-            if (StaticConfiguration.DisableHeadRouting)
+            if (!StaticConfiguration.EnableHeadRouting)
             {
                 return requestedMethod.Equals("HEAD", StringComparison.Ordinal) ?
                     "GET" :

--- a/src/Nancy/Routing/DefaultRouteResolver.cs
+++ b/src/Nancy/Routing/DefaultRouteResolver.cs
@@ -160,9 +160,13 @@
             var requestedMethod =
                 context.Request.Method;
 
-            return requestedMethod.Equals("HEAD", StringComparison.Ordinal) ?
-                "GET" :
-                requestedMethod;
+            if (StaticConfiguration.DisableHeadRouting)
+            {
+                return requestedMethod.Equals("HEAD", StringComparison.Ordinal) ?
+                    "GET" :
+                    requestedMethod;
+            }
+            return requestedMethod;
         }
     }
 }

--- a/src/Nancy/StaticConfiguration.cs
+++ b/src/Nancy/StaticConfiguration.cs
@@ -49,6 +49,12 @@ namespace Nancy
         public static bool CaseSensitive { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether or not to route HEAD requests separately
+        /// </summary>
+        [Description("Disables HEAD routing and uses GET for HEAD routes instead.")]
+        public static bool DisableHeadRouting { get; set; }
+
+        /// <summary>
         /// Gets a value indicating whether we are running in debug mode or not.
         /// Checks the entry assembly to see whether it has been built in debug mode.
         /// If anything goes wrong it returns false.

--- a/src/Nancy/StaticConfiguration.cs
+++ b/src/Nancy/StaticConfiguration.cs
@@ -51,8 +51,8 @@ namespace Nancy
         /// <summary>
         /// Gets or sets a value indicating whether or not to route HEAD requests separately
         /// </summary>
-        [Description("Disables HEAD routing and uses GET for HEAD routes instead.")]
-        public static bool DisableHeadRouting { get; set; }
+        [Description("Enables HEAD routing and disables the usage of GET routes for HEAD requests.")]
+        public static bool EnableHeadRouting { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether we are running in debug mode or not.


### PR DESCRIPTION
Hopefully the code fits guidelines.  It seems to cover and fix #1771 

I couldn't find a reason why the head verb isn't handled explicitly.

Can invert the static config.