### PR TITLE
Added IncludeInNancyAssemblyScanningAttribute

### DIFF
--- a/src/Nancy/IncludeInNancyAssemblyScanningAttribute.cs
+++ b/src/Nancy/IncludeInNancyAssemblyScanningAttribute.cs
@@ -1,0 +1,17 @@
+﻿namespace Nancy
+{
+    using System;
+
+    /// <summary>
+    /// Add this attribute to an assembly to make sure
+    /// it is included in Nancy's assembly scanning.
+    /// </summary>
+    /// <example>
+    /// Apply the attribute, typically in AssemblyInfo.(cs|fs|vb), as follows:
+    /// <code>[assembly: IncludeInNancyAssemblyScanning]</code>
+    /// </example>
+    [AttributeUsage(AttributeTargets.Assembly)]
+    public sealed class IncludeInNancyAssemblyScanningAttribute : Attribute
+    {
+    }
+}

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Diagnostics\DefaultDiagnostics.cs" />
     <Compile Include="Diagnostics\DiagnosticsViewRenderer.cs" />
     <Compile Include="Helpers\CacheHelpers.cs" />
+    <Compile Include="IncludeInNancyAssemblyScanningAttribute.cs" />
     <Compile Include="IStaticContentProvider.cs" />
     <Compile Include="Json\JavaScriptPrimitiveConverter.cs" />
     <Compile Include="Localization\TextResourceFinder.cs" />


### PR DESCRIPTION
This adds the `IncludeInNancyAssemblyScanningAttribute`. Let's do a final round on the name. Does anyone care much? :smile:

I also tried to make ADATS look for the attribute before checking an assembly's references, but failed to get it to work in reflection-only context :disappointed: 

Closes #1842