### PR TITLE
Do not register dependency twice by the same interface in cofigurable bootstrapper

### DIFF
--- a/src/Nancy.Testing.Tests/ConfigurableBootstrapperDependenciesTests.cs
+++ b/src/Nancy.Testing.Tests/ConfigurableBootstrapperDependenciesTests.cs
@@ -91,6 +91,32 @@
             Assert.Contains("Implemented ITestDependency", response.Body.AsString());
         }
 
+        interface IIinterface { }
+        class DisposableDependency : IIinterface, IDisposable
+        {
+            public bool Disposed { get; private set; }
+      
+            public void Dispose()
+            {
+                this.Disposed = true;
+            }
+        }
+
+        [Fact]
+        public void should_be_able_to_configure_disposbale_dependency_implementing_interface_by_interface()
+        {
+            // Given
+            var disposableDependency = new DisposableDependency();
+
+            // When
+            new Browser(with =>
+              with.Dependency<IIinterface>(disposableDependency)
+            );
+
+            // Then
+            Assert.False(disposableDependency.Disposed);
+        }
+
 
         [Fact]
         public void should_be_able_to_configure_dependencies_by_instances()

--- a/src/Nancy.Testing/ConfigurableBootstrapper.cs
+++ b/src/Nancy.Testing/ConfigurableBootstrapper.cs
@@ -681,7 +681,8 @@ namespace Nancy.Testing
             {
                 this.bootstrapper.registeredInstances.Add(new InstanceRegistration(typeof(T), instance));
 
-                foreach (var interfaceType in GetSafeInterfaces(instance.GetType()))
+                var interfacesToRegisterBy = GetSafeInterfaces(instance.GetType()).Where(i => !i.Equals(typeof(T)));
+                foreach (var interfaceType in interfacesToRegisterBy)
                 {
                     this.bootstrapper.registeredInstances.Add(new InstanceRegistration(interfaceType, instance));
                 }


### PR DESCRIPTION
If two instance dependencies are registered in TinyIoC by the same interface the first one is disposed if it implements `IDisposable`. Therefore registering an instance that implements `IDisposable` twice by the same interface means it will be disposed. The configurable bootstrapper did that.

Fixes #1802.