### PR TITLE
Get CSRF-tokens either from request header or form data (2)

### DIFF
--- a/src/Nancy.Tests/Unit/Security/CsrfFixture.cs
+++ b/src/Nancy.Tests/Unit/Security/CsrfFixture.cs
@@ -174,27 +174,36 @@
         [Fact]
         public void ValidateCsrfToken_gets_provided_token_from_form_data()
         {
+            // Given
             var token = Csrf.GenerateTokenString();
             var context = new NancyContext { Request = this.request };
+            var module = new FakeNancyModule { Context = context };
+            
+            // When
             context.Request.Form[CsrfToken.DEFAULT_CSRF_KEY] = token;
             context.Request.Cookies.Add(CsrfToken.DEFAULT_CSRF_KEY, HttpUtility.UrlEncode(token));
 
-            var module = new FakeNancyModule { Context = context };
+            // Then
             module.ValidateCsrfToken();
         }
 
         [Fact]
         public void ValidateCsrfToken_gets_provided_token_from_request_header_if_not_present_in_form_data()
         {
+            // Given
             var token = Csrf.GenerateTokenString();
-            var context = new NancyContext { Request = CreateRequestWithHeader(CsrfToken.DEFAULT_CSRF_KEY, token) };
+            var context = new NancyContext();
+            var module = new FakeNancyModule { Context = context };
+            
+            // When
+            context.Request = RequestWithHeader(CsrfToken.DEFAULT_CSRF_KEY, token);
             context.Request.Cookies.Add(CsrfToken.DEFAULT_CSRF_KEY, HttpUtility.UrlEncode(token));
 
-            var module = new FakeNancyModule { Context = context };
+            // Then
             module.ValidateCsrfToken();
         }
 
-        private static FakeRequest CreateRequestWithHeader(string header, string value)
+        private static FakeRequest RequestWithHeader(string header, string value)
         {
             return new FakeRequest("GET", "/", new Dictionary<string, IEnumerable<string>> { { header, new[] { value } } });
         }


### PR DESCRIPTION
New attempt for pull request #1873.
I screwed up somehow, so I created a new feature branch and a new pull request.

It would be nice to post CSRF-tokens either as form data or as a request header.

On validation Csrf.cs could look in both form data and request header for the provided token, before validating against the cookie token.

This would really make our day, especially when posting json-data from JavaScript, as we would not have to deal with the CSRF-token in the posted data at all.