### PR TITLE
Set StatusCode before setting StatusDescription

### DIFF
--- a/src/Nancy.Hosting.Aspnet/NancyHandler.cs
+++ b/src/Nancy.Hosting.Aspnet/NancyHandler.cs
@@ -148,12 +148,13 @@ namespace Nancy.Hosting.Aspnet
                 context.Response.ContentType = response.ContentType;
             }
 
+            context.Response.StatusCode = (int) response.StatusCode;
+
             if (response.ReasonPhrase != null)
             {
                 context.Response.StatusDescription = response.ReasonPhrase;
             }
 
-            context.Response.StatusCode = (int)response.StatusCode;
             response.Contents.Invoke(context.Response.OutputStream);
         }
 


### PR DESCRIPTION
The `StatusCode` setter [sets `_statusDescription` to `null`](http://referencesource.microsoft.com/#System.Web/HttpResponse.cs,1460), which in turn makes the `StatusDescription` getter [return a default description for the current status code](http://referencesource.microsoft.com/#System.Web/HttpResponse.cs,1510).

This PR just changes the order we set the properties, to prevent the `StatusCode` setter from overwriting the `StatusDescription`.

Came across this in several SO questions, which led me to believe it was a bug on our end. I don't know for sure that they use the ASP.NET host, but I have a feeling...

http://stackoverflow.com/questions/24581634/nancy-negotiate-with-statuscode-and-reasonphrase
http://stackoverflow.com/questions/23352833/how-to-get-a-response-from-the-nancy-negotiator