### PR TITLE
Add support for expanding paths in attribute values

### DIFF
--- a/src/Nancy.Tests/Unit/ViewEngines/SuperSimpleViewEngineTests.cs
+++ b/src/Nancy.Tests/Unit/ViewEngines/SuperSimpleViewEngineTests.cs
@@ -925,6 +925,19 @@
         }
 
         [Fact]
+        public void Should_expand_paths_in_attribute_values()
+        {
+            const string input = @"<script src='~/scripts/test.js'></script> <link href=""~/stylesheets/style.css"" />";
+            var fakeViewEngineHost = new FakeViewEngineHost();
+            fakeViewEngineHost.ExpandPathCallBack = s => s.Replace("~/", "/BasePath/");
+
+            var result = viewEngine.Render(input, null, fakeViewEngineHost);
+
+            Assert.Equal(@"<script src='/BasePath/scripts/test.js'></script> <link href=""/BasePath/stylesheets/style.css"" />", result);
+        }
+
+
+        [Fact]
         public void Should_expand_anti_forgery_tokens()
         {
             const string input = "<html><body><form>@AntiForgeryToken</form><body></html>";

--- a/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngine.cs
+++ b/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngine.cs
@@ -73,6 +73,11 @@ namespace Nancy.ViewEngines.SuperSimpleViewEngine
         private static readonly Regex PathExpansionRegEx = new Regex(@"(?:@Path\[\'(?<Path>.+?)\'\]);?", RegexOptions.Compiled);
 
         /// <summary>
+        /// Compiled RegEx for path expansion in attribute values
+        /// </summary>
+        private static readonly Regex AttributeValuePathExpansionRegEx = new Regex(@"(?<Attribute>[a-zA-Z]+)=(?<Quote>[""|'])(?<Path>~.+?)\k<Quote>", RegexOptions.Compiled);
+
+        /// <summary>
         /// Compiled RegEx for the CSRF anti forgery token
         /// </summary>
         private static readonly Regex AntiForgeryTokenRegEx = new Regex(@"@AntiForgeryToken;?", RegexOptions.Compiled);
@@ -590,6 +595,19 @@ namespace Nancy.ViewEngines.SuperSimpleViewEngine
                     var path = m.Groups["Path"].Value;
 
                     return host.ExpandPath(path);
+                });
+
+            result = AttributeValuePathExpansionRegEx.Replace(
+                result, 
+                m =>
+                {
+                    var attribute = m.Groups["Attribute"];
+                    var quote = m.Groups["Quote"].Value;
+                    var path = m.Groups["Path"].Value;
+
+                    var expandedPath = host.ExpandPath(path);
+                
+                    return string.Format("{0}={1}{2}{1}", attribute, quote, expandedPath);
                 });
 
             return result;


### PR DESCRIPTION
With PR, `SuperSimpleViewEngine` learns how to expand `~/`-style paths in attribute values. 

Previously, only `@Path['~/...']` statements were expanded. Now any attribute that matches the `attribute='~/value'` pattern (with matching single or double quotes around "value") gets the same treatment.