### PR TITLE
add missing null parameter checks

### DIFF
--- a/src/Nancy/NancyEngine.cs
+++ b/src/Nancy/NancyEngine.cs
@@ -56,6 +56,16 @@
                 throw new ArgumentNullException("statusCodeHandlers");
             }
 
+            if (requestTracing == null)
+            {
+                throw new ArgumentNullException("requestTracing");
+            }
+
+            if (staticContentProvider == null)
+            {
+                throw new ArgumentNullException("staticContentProvider");
+            }
+
             this.dispatcher = dispatcher;
             this.contextFactory = contextFactory;
             this.statusCodeHandlers = statusCodeHandlers;


### PR DESCRIPTION
Hello, I'm working on a static analysis tool that looks for missing null checks.  It suggested you add these.  The fields are readonly so assigning null to them doesn't seem useful.

Also, I don't see anywhere that NancyEngine.diagnosticsConfiguration is used (at least according to "Find All References").