### PR TITLE
fix exception & hang when request path contains invalid characters

### DIFF
--- a/src/Nancy/Routing/DefaultRequestDispatcher.cs
+++ b/src/Nancy/Routing/DefaultRequestDispatcher.cs
@@ -154,8 +154,8 @@ namespace Nancy.Routing
 
         private ResolveResult Resolve(NancyContext context)
         {
-            var extension =
-                Path.GetExtension(context.Request.Path);
+            var extension = context.Request.Path.IndexOfAny(Path.GetInvalidPathChars()) >= 0 ? null
+               : Path.GetExtension(context.Request.Path);
 
             var originalAcceptHeaders = context.Request.Headers.Accept;
             var originalRequestPath = context.Request.Path;


### PR DESCRIPTION
Currently Nancy will throw an exception and hang if the request path contains any character that is not a valid path character ( > < | * etc.) . The issue is present with any host that decodes the characters before invoking Nancy (tested with Owin & SelfHost, but probably all hosts are affected). 

This is similar to #1141 and the fix is similar to the fix in https://github.com/thecodejunkie/Nancy/commit/180cc73100fbf9099b4b5bc5f52da6c58810ef0c.

At the moment it is not possible to write an unit test for this as the Browser in Nancy.Testing will throw an exception if the path contains an invalid character. If the character is encoded the Browser will pass it to NancyEngine without decoding it. This is in contrast with the Hosts behavior, which is to decode the encoded characters before passing the request path to NancyEngine. 

To test, all you need to do is create a new NancyModule with a simple Get handler:

```csharp
Get["/test/{id}"] = p => Response.AsText((string)p.id);
```

Performing a GET request to /test/%3E results in an exception. ( ">" encoded is %3E )

The issue is in DefaultRequestDispatcher.Resolve(NancyContext context) where a call to Path.GetExtension(context.Request.Path) is made. 

The fix is to avoid calling Path.GetExtension if the request path contains any character from Path.GetInvalidPathChars().

Not sure of the severity of it, but I think this can be regarded as a security issue as an unhandled exception can be triggered and in some cases the request hangs consuming resources.