### PR TITLE
Added optional fallback base uri matching for port forwarded self host situations (such as azure)

### DIFF
--- a/src/Nancy.Hosting.Self/HostConfiguration.cs
+++ b/src/Nancy.Hosting.Self/HostConfiguration.cs
@@ -46,6 +46,14 @@
         /// </summary>
         public bool EnableClientCertificates { get; set; }
 
+        /// <summary>
+        /// Gets or sets a property determining if base uri matching can fall back to just
+        /// using Authority (Schema + Host + Port) as base uri if it cannot match anything in
+        /// the known list. This should only be set to True if you have issues with port forwarding
+        /// (e.g. on Azure).
+        /// </summary>
+        public bool AllowAuthorityFallback { get; set; }
+
         public HostConfiguration()
         {
             this.RewriteLocalhost = true;

--- a/src/Nancy.Hosting.Self/NancyHost.cs
+++ b/src/Nancy.Hosting.Self/NancyHost.cs
@@ -236,7 +236,7 @@
 
         private Request ConvertRequestToNancyRequest(HttpListenerRequest request)
         {
-            var baseUri = this.baseUriList.FirstOrDefault(uri => uri.IsCaseInsensitiveBaseOf(request.Url));
+            var baseUri = this.GetBaseUri(request);
 
             if (baseUri == null)
             {
@@ -277,6 +277,23 @@
                 request.Headers.ToDictionary(), 
                 (request.RemoteEndPoint != null) ? request.RemoteEndPoint.Address.ToString() : null,
                 certificate);
+        }
+
+        private Uri GetBaseUri(HttpListenerRequest request)
+        {
+            var result = this.baseUriList.FirstOrDefault(uri => uri.IsCaseInsensitiveBaseOf(request.Url));
+
+            if (result != null)
+            {
+                return result;
+            }
+
+            if (!this.configuration.AllowAuthorityFallback)
+            {
+                return null;
+            }
+
+            return new Uri(request.Url.GetLeftPart(UriPartial.Authority));
         }
 
         private void ConvertNancyResponseToResponse(Response nancyResponse, HttpListenerResponse response)


### PR DESCRIPTION
Workaround for #1724