### PR TITLE
Allow more succinct `Requires`

### DIFF
--- a/src/Nancy/Security/ModuleSecurity.cs
+++ b/src/Nancy/Security/ModuleSecurity.cs
@@ -38,7 +38,7 @@ namespace Nancy.Security
         /// <param name="requiredClaims">Claim(s) required</param>
         public static void RequiresClaims(this INancyModule module, params string[] requiredClaims)
         {
-            module.RequiresClaims((IEnumerable<string>)requiredClaims);
+            module.RequiresClaims(requiredClaims.AsEnumerable());
         }
         
         /// <summary>
@@ -59,7 +59,7 @@ namespace Nancy.Security
         /// <param name="requiredClaims">Claim(s) required</param>
         public static void RequiresAnyClaim(this INancyModule module, params string[] requiredClaims)
         {
-            module.RequiresAnyClaim((IEnumerable<string>)requiredClaims);
+            module.RequiresAnyClaim(requiredClaims.AsEnumerable());
         }
 
         /// <summary>

--- a/src/Nancy/Security/ModuleSecurity.cs
+++ b/src/Nancy/Security/ModuleSecurity.cs
@@ -32,6 +32,16 @@ namespace Nancy.Security
         }
 
         /// <summary>
+        /// This module requires authentication and certain claims to be present.
+        /// </summary>
+        /// <param name="module">Module to enable</param>
+        /// <param name="requiredClaims">Claim(s) required</param>
+        public static void RequiresClaims(this INancyModule module, params string[] requiredClaims)
+        {
+            module.RequiresClaims((IEnumerable<string>)requiredClaims);
+        }
+        
+        /// <summary>
         /// This module requires authentication and any one of certain claims to be present.
         /// </summary>
         /// <param name="module">Module to enable</param>
@@ -40,6 +50,16 @@ namespace Nancy.Security
         {
             module.AddBeforeHookOrExecute(SecurityHooks.RequiresAuthentication(), "Requires Authentication");
             module.AddBeforeHookOrExecute(SecurityHooks.RequiresAnyClaim(requiredClaims), "Requires Any Claim");
+        }
+        
+        /// <summary>
+        /// This module requires authentication and any one of certain claims to be present.
+        /// </summary>
+        /// <param name="module">Module to enable</param>
+        /// <param name="requiredClaims">Claim(s) required</param>
+        public static void RequiresAnyClaim(this INancyModule module, params string[] requiredClaims)
+        {
+            module.RequiresAnyClaim((IEnumerable<string>)requiredClaims);
         }
 
         /// <summary>

--- a/src/Nancy/Security/ModuleSecurity.cs
+++ b/src/Nancy/Security/ModuleSecurity.cs
@@ -2,6 +2,7 @@ namespace Nancy.Security
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     using Nancy.Extensions;
     using Nancy.Responses;


### PR DESCRIPTION
It's bugged me for a long time that I can't list my claims out like so:

    this.RequiresClaims("Claim One", "Claim Two");
    this.RequiresAnyClaim("Claim One", "Claim Two");

If this gets merged in I *will* be able to do that.