### PR TITLE
Fix for #1881

### DIFF
--- a/src/Nancy.Tests.Functional/Tests/ViewBagTests.cs
+++ b/src/Nancy.Tests.Functional/Tests/ViewBagTests.cs
@@ -71,6 +71,17 @@
             Assert.Equal("Bob", model.Name);
         }
 
+        [Fact]
+        public void Should_return_200_on_head()
+        {
+            // Given
+            // When
+            var response = browser.Head(@"/razor-viewbag");
+
+            // Then
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
         public class ViewBagModel
         {
             public string Name { get; set; }

--- a/src/Nancy.Tests/Unit/HeadResponseFixture.cs
+++ b/src/Nancy.Tests/Unit/HeadResponseFixture.cs
@@ -1,6 +1,10 @@
 namespace Nancy.Tests.Unit
 {
     using System.Collections.Generic;
+    using System.IO;
+
+    using FakeItEasy;
+
     using Tests.Extensions;
     using Xunit;
 
@@ -11,6 +15,7 @@ namespace Nancy.Tests.Unit
 
         public HeadResponseFixture()
         {
+            // Given
             this.headers = new Dictionary<string, string> { { "Test", "Value " } };
             this.response = "This is the content";
 
@@ -19,12 +24,20 @@ namespace Nancy.Tests.Unit
             this.response.StatusCode = HttpStatusCode.ResetContent;
         }
 
+        private HeadResponse CreateHeadResponse()
+        {
+            var head = new HeadResponse(this.response);
+            head.PreExecute(A.Dummy<NancyContext>());
+            head.Contents(new MemoryStream());
+            return head;
+        }
+
         [Fact]
         public void Should_set_status_property_to_that_of_decorated_response()
         {
-            // Given, When
-            var head = new HeadResponse(this.response);
-
+            //When
+            var head = this.CreateHeadResponse();
+            
             // Then
             head.StatusCode.ShouldEqual(this.response.StatusCode);
         }
@@ -32,8 +45,8 @@ namespace Nancy.Tests.Unit
         [Fact]
         public void Should_set_headers_property_to_that_of_decorated_response()
         {
-            // Given, When
-            var head = new HeadResponse(this.response);
+            //When
+            var head = this.CreateHeadResponse();
 
             // Then
             head.Headers.ShouldBeSameAs(this.headers);
@@ -42,8 +55,8 @@ namespace Nancy.Tests.Unit
         [Fact]
         public void Should_set_content_type_property_to_that_of_decorated_response()
         {
-            // Given, When
-            var head = new HeadResponse(this.response);
+            //When
+            var head = this.CreateHeadResponse();
 
             // Then
             head.ContentType.ShouldEqual(this.response.ContentType);
@@ -52,8 +65,8 @@ namespace Nancy.Tests.Unit
         [Fact]
         public void Should_set_empty_content()
         {
-            // Given, When
-            var head = new HeadResponse(this.response);
+            //When
+            var head = this.CreateHeadResponse();
 
             // Then
             head.GetStringContentsFromResponse().ShouldBeEmpty();
@@ -62,9 +75,9 @@ namespace Nancy.Tests.Unit
         [Fact]
         public void Should_set_content_length()
         {
-            // Given, When
-            var head = new HeadResponse(this.response);
-            
+            //When
+            var head = this.CreateHeadResponse();
+
             // Then
             head.Headers.ContainsKey("Content-Length").ShouldBeTrue();
             head.Headers["Content-Length"].ShouldNotEqual("0");
@@ -75,7 +88,7 @@ namespace Nancy.Tests.Unit
         {
             // Given, When
             this.response.Headers.Add("Content-Length", "foo");
-            var head = new HeadResponse(this.response);
+            var head = this.CreateHeadResponse();
 
             // Then
             head.Headers.ContainsKey("Content-Length").ShouldBeTrue();

--- a/src/Nancy/HeadResponse.cs
+++ b/src/Nancy/HeadResponse.cs
@@ -3,13 +3,15 @@
     using System;
     using System.Globalization;
     using System.IO;
+    using System.Threading.Tasks;
 
-    /// <summary>
+ 	  /// <summary>
     /// Represents a HEAD only response.
     /// </summary>
-	public class HeadResponse : Response
-	{
+    public class HeadResponse : Response
+    {
         private const string ContentLength = "Content-Length";
+        private readonly Response innerResponse;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HeadResponse"/> class.
@@ -19,12 +21,21 @@
         /// </param>
         public HeadResponse(Response response)
         {
-            this.Contents = GetStringContents(string.Empty);
+            this.innerResponse = response;
+            this.Contents = stream =>
+            {
+                this.CheckAndSetContentLength(this.innerResponse);
+                GetStringContents(string.Empty)(stream);
+            };
             this.ContentType = response.ContentType;
             this.Headers = response.Headers;
             this.StatusCode = response.StatusCode;
             this.ReasonPhrase = response.ReasonPhrase;
-            this.CheckAndSetContentLength(response);
+        }
+
+        public override Task PreExecute(NancyContext context)
+        {
+            return this.innerResponse.PreExecute(context);
         }
 
         private void CheckAndSetContentLength(Response response)


### PR DESCRIPTION
When making a `HEAD` request for a route returning a `MaterialisingResponse` a `NullReferenceExpception` was thrown in the content delegate.

`HeadResponse` now defers the access to the inner responses content till the content delegate is executed.

Fixes #1881 