### PR TITLE
corrected typo in license owner

### DIFF
--- a/favicon.license.txt
+++ b/favicon.license.txt
@@ -1,1 +1,1 @@
-The Nancy logo is copyright ©2011 by Andreas Håkansson and Steven Robbings. Please consult the usage guidelines in the Nancy.Portfolio repository (https://github.com/NancyFx/Nancy.Portfolio) for information on how it may be used.
+The Nancy logo is copyright ©2011 by Andreas Håkansson and Steven Robbins. Please consult the usage guidelines in the Nancy.Portfolio repository (https://github.com/NancyFx/Nancy.Portfolio) for information on how it may be used.


### PR DESCRIPTION
I *think* I've got @grumpydev's name right here.