### PR TITLE
Tweaked overloads of Dependency and Dependencies

### DIFF
--- a/src/Nancy.Testing.Tests/ConfigurableBootstrapperDependenciesTests.cs
+++ b/src/Nancy.Testing.Tests/ConfigurableBootstrapperDependenciesTests.cs
@@ -95,7 +95,7 @@
         class DisposableDependency : IIinterface, IDisposable
         {
             public bool Disposed { get; private set; }
-      
+
             public void Dispose()
             {
                 this.Disposed = true;
@@ -125,7 +125,7 @@
             var browser = new Browser(with =>
             {
                 with.Module<ModuleWithTwoDependencies>();
-                with.Dependencies(GetFakeDependency(), GetFakeDependency2());
+                with.Dependencies<object>(GetFakeDependency(), GetFakeDependency2());
             });
 
             // When

--- a/src/Nancy.Testing/ConfigurableBootstrapper.cs
+++ b/src/Nancy.Testing/ConfigurableBootstrapper.cs
@@ -696,32 +696,6 @@ namespace Nancy.Testing
             }
 
             /// <summary>
-            /// Configures the bootstrapper to register the specified type as a dependency.
-            /// </summary>
-            /// <typeparam name="T">The type that the dependencies should be registered as.</typeparam>
-            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
-            public ConfigurableBootstrapperConfigurator Dependency<T>(object instance)
-            {
-                this.bootstrapper.registeredInstances.Add(new InstanceRegistration(typeof(T), instance));
-                return this;
-            }
-
-            /// <summary>
-            /// Configures the bootstrapper to register the specified instances as a dependencies.
-            /// </summary>
-            /// <param name="dependencies">The instances of the dependencies that should be registered with the bootstrapper.</param>
-            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
-            public ConfigurableBootstrapperConfigurator Dependencies(params object[] dependencies)
-            {
-                foreach (var dependency in dependencies)
-                {
-                    this.Dependency(dependency);
-                }
-
-                return this;
-            }
-
-            /// <summary>
             /// Configures the bootstrapper to register the specified types and instances as a dependencies.
             /// </summary>
             /// <param name="dependencies">An array of maps between the interfaces and instances that should be registered with the bootstrapper.</param>
@@ -745,11 +719,11 @@ namespace Nancy.Testing
             /// <param name="dependencies">The instances of the dependencies that should be registered with the bootstrapper.</param>
             /// <typeparam name="T">The type that the dependencies should be registered as.</typeparam>
             /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
-            public ConfigurableBootstrapperConfigurator Dependencies<T>(params object[] dependencies)
+            public ConfigurableBootstrapperConfigurator Dependencies<T>(params T[] dependencies)
             {
                 foreach (var dependency in dependencies)
                 {
-                    this.Dependency<T>(dependency);
+                    this.Dependency(dependency);
                 }
 
                 return this;
@@ -1057,7 +1031,7 @@ namespace Nancy.Testing
                 return this;
             }
 
-            /// <summary> 
+            /// <summary>
             /// Configures the bootstrapper to use the provided instance of <see cref="IRootPathProvider"/>.
             /// </summary>
             /// <param name="rootPathProvider">The <see cref="IRootPathProvider"/> instance that should be used by the bootstrapper.</param>

--- a/src/Nancy.sln.DotSettings
+++ b/src/Nancy.sln.DotSettings
@@ -2,8 +2,10 @@
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=NancyStandard/@EntryIndexedValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;Profile name="NancyStandard"&gt;&lt;CSUseVar&gt;&lt;BehavourStyle&gt;CAN_CHANGE_TO_IMPLICIT&lt;/BehavourStyle&gt;&lt;LocalVariableStyle&gt;ALWAYS_IMPLICIT&lt;/LocalVariableStyle&gt;&lt;ForeachVariableStyle&gt;ALWAYS_IMPLICIT&lt;/ForeachVariableStyle&gt;&lt;/CSUseVar&gt;&lt;CSOptimizeUsings&gt;&lt;OptimizeUsings&gt;True&lt;/OptimizeUsings&gt;&lt;EmbraceInRegion&gt;False&lt;/EmbraceInRegion&gt;&lt;RegionName&gt;&lt;/RegionName&gt;&lt;/CSOptimizeUsings&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;CSShortenReferences&gt;True&lt;/CSShortenReferences&gt;&lt;CSReorderTypeMembers&gt;True&lt;/CSReorderTypeMembers&gt;&lt;CSMakeFieldReadonly&gt;True&lt;/CSMakeFieldReadonly&gt;&lt;/Profile&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/ThisQualifier/INSTANCE_MEMBERS_QUALIFY_MEMBERS/@EntryValue">All</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ANONYMOUS_METHOD_DECLARATION_BRACES/@EntryValue">NEXT_LINE</s:String>
-	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/BLANK_LINES_BETWEEN_USING_GROUPS/@EntryValue">1</s:Int64>
+	
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INITIALIZER_BRACES/@EntryValue">NEXT_LINE</s:String>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_CODE/@EntryValue">1</s:Int64>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_DECLARATIONS/@EntryValue">1</s:Int64>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/REDUNDANT_THIS_QUALIFIER_STYLE/@EntryValue">ALWAYS_USE</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AFTER_TYPECAST_PARENTHESES/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/AddImportsToDeepestScope/@EntryValue">True</s:Boolean>


### PR DESCRIPTION
Fixes #1909

The old `Dependencies` method took a `params object[] dependencies` argument, looped through them and called `this.Dependency<T>(dependency)` where `T` was inferred to `object` :confused: I can't see how this has ever worked.

This PR removes the overloads accepting `object` and `object[]` and force you to use an overload with an explicit (or inferred) generic type parameter.