### PR TITLE
Use FIPS-compliant hashing algorithm for etags in EmbeddedFileResponse

### DIFF
--- a/src/Nancy.Tests/Unit/Responses/EmbeddedFileResponseFixture.cs
+++ b/src/Nancy.Tests/Unit/Responses/EmbeddedFileResponseFixture.cs
@@ -14,7 +14,7 @@
                 new EmbeddedFileResponse(this.GetType().Assembly, "Nancy.Tests", "Resources.Views.staticviewresource.html");
 
             // Then
-            response.Headers["ETag"].ShouldEqual("\"5D6EFDFDB135DC90F16D57E05603DA1E\"");
+            response.Headers["ETag"].ShouldEqual("\"B9D9DC2B50ADFD0867749D4837C63556339080CE\"");
         }
 
         [Fact]
@@ -30,7 +30,7 @@
             response.Contents.Invoke(outputStream);
 
             // Then
-            response.Headers["ETag"].ShouldEqual("\"5D6EFDFDB135DC90F16D57E05603DA1E\"");
+            response.Headers["ETag"].ShouldEqual("\"B9D9DC2B50ADFD0867749D4837C63556339080CE\"");
         }
 
         [Fact]

--- a/src/Nancy/Responses/EmbeddedFileResponse.cs
+++ b/src/Nancy/Responses/EmbeddedFileResponse.cs
@@ -64,9 +64,9 @@
 
         private static string GenerateETag(Stream stream)
         {
-            using (var md5 = MD5.Create())
+            using (var sha1 = new SHA1CryptoServiceProvider())
             {
-                var hash = md5.ComputeHash(stream);
+                var hash = sha1.ComputeHash(stream);
                 return string.Concat("\"", ByteArrayToString(hash), "\"");
             }
         }


### PR DESCRIPTION
Got bitten by this in production, trying to use the embedded diagnostics dashboard at a financial client.