### PR TITLE
Issue with RequestStream switching behavior on OSX.

### DIFF
--- a/src/Nancy.Hosting.Self/NancyHost.cs
+++ b/src/Nancy.Hosting.Self/NancyHost.cs
@@ -279,7 +279,7 @@
             return new Request(
                 request.HttpMethod,
                 nancyUrl,
-                RequestStream.FromStream(request.InputStream, expectedRequestLength, false),
+                RequestStream.FromStream(request.InputStream, expectedRequestLength, true),
                 request.Headers.ToDictionary(), 
                 (request.RemoteEndPoint != null) ? request.RemoteEndPoint.Address.ToString() : null,
                 certificate,


### PR DESCRIPTION
Disabling streamSwitching for HTTP request body data, this appears to cause problems when the body size is larger than the switching threshold
on OSX.

See issue: https://github.com/OmniSharp/omnisharp-sublime/issues/149