### PR TITLE
SSVE - AttributeValuePathExpansionRegEx corrected ["|'] to ["']

### DIFF
--- a/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngine.cs
+++ b/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngine.cs
@@ -76,6 +76,7 @@ namespace Nancy.ViewEngines.SuperSimpleViewEngine
         /// Compiled RegEx for path expansion in attribute values
         /// </summary>
         private static readonly Regex AttributeValuePathExpansionRegEx = new Regex(@"(?<Attribute>[a-zA-Z]+)=(?<Quote>[""|'])(?<Path>~.+?)\k<Quote>", RegexOptions.Compiled);
+        private static readonly Regex AttributeValuePathExpansionRegEx = new Regex(@"(?<Attribute>[a-zA-Z]+)=(?<Quote>[""'])(?<Path>~.+?)\k<Quote>", RegexOptions.Compiled);
 
         /// <summary>
         /// Compiled RegEx for the CSRF anti forgery token

--- a/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngine.cs
+++ b/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngine.cs
@@ -75,7 +75,6 @@ namespace Nancy.ViewEngines.SuperSimpleViewEngine
         /// <summary>
         /// Compiled RegEx for path expansion in attribute values
         /// </summary>
-        private static readonly Regex AttributeValuePathExpansionRegEx = new Regex(@"(?<Attribute>[a-zA-Z]+)=(?<Quote>[""|'])(?<Path>~.+?)\k<Quote>", RegexOptions.Compiled);
         private static readonly Regex AttributeValuePathExpansionRegEx = new Regex(@"(?<Attribute>[a-zA-Z]+)=(?<Quote>[""'])(?<Path>~.+?)\k<Quote>", RegexOptions.Compiled);
 
         /// <summary>


### PR DESCRIPTION
AttributeValuePathExpansionRegEx allowed attributes like `attribute=|~path|`.
Fixed Regex typo `["|']` to `["']`.