### PR TITLE
Adding tuple deserialization support to JavaScriptSerializer.

### DIFF
--- a/src/Nancy.Tests/Nancy.Tests.csproj
+++ b/src/Nancy.Tests/Nancy.Tests.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Unit\Json\TestData.cs" />
     <Compile Include="Unit\Json\TestPrimitiveConverter.cs" />
     <Compile Include="Unit\Json\TestPrimitiveConverterType.cs" />
+    <Compile Include="Unit\Json\TypeWithTuple.cs" />
     <Compile Include="Unit\MimeTypesFixture.cs" />
     <Compile Include="Unit\ModelBinding\BindingMemberInfoFixture.cs" />
     <Compile Include="Unit\ModelBinding\ModelBindingExceptionFixture.cs" />

--- a/src/Nancy.Tests/Unit/Json/JavaScriptSerializerFixture.cs
+++ b/src/Nancy.Tests/Unit/Json/JavaScriptSerializerFixture.cs
@@ -1,134 +1,181 @@
 ﻿namespace Nancy.Tests.Unit.Json
 {
-	using System;
-	using System.Collections.Generic;
-	using System.IO;
-	using FakeItEasy;
-	using Nancy.IO;
-	using Nancy.Json;
-	using Xunit;
-	using Xunit.Extensions;
-	using Xunit.Sdk;
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using FakeItEasy;
+    using Nancy.IO;
+    using Nancy.Json;
+    using Nancy.Json.Converters;
 
-	public class JavaScriptSerializerFixture
-	{
-		[Fact]
-		public void Should_register_converters_when_asked()
-		{
-			// Given
-			JsonSettings.Converters.Add(new TestConverter());
-			JsonSettings.PrimitiveConverters.Add(new TestPrimitiveConverter());
+    using Xunit;
+    using Xunit.Extensions;
+    using Xunit.Sdk;
 
-			var defaultSerializer = new JavaScriptSerializer();
+    public class JavaScriptSerializerFixture
+    {
+        [Fact]
+        public void Should_register_converters_when_asked()
+        {
+            // Given
+            JsonSettings.Converters.Add(new TestConverter());
+            JsonSettings.PrimitiveConverters.Add(new TestPrimitiveConverter());
 
-			// When
-			var serializer = new JavaScriptSerializer(
-				registerConverters: true,
-				resolver: null,
-				maxJsonLength: defaultSerializer.MaxJsonLength,
-				recursionLimit: defaultSerializer.RecursionLimit,
-				retainCasing: defaultSerializer.RetainCasing,
-				iso8601DateFormat: defaultSerializer.ISO8601DateFormat);
+            var defaultSerializer = new JavaScriptSerializer();
 
-			var data =
-				new TestData()
-				{
-					ConverterData =
-						new TestConverterType()
-						{
-							Data = 42,
-						},
+            // When
+            var serializer = new JavaScriptSerializer(
+                registerConverters: true,
+                resolver: null,
+                maxJsonLength: defaultSerializer.MaxJsonLength,
+                recursionLimit: defaultSerializer.RecursionLimit,
+                retainCasing: defaultSerializer.RetainCasing,
+                iso8601DateFormat: defaultSerializer.ISO8601DateFormat);
 
-					PrimitiveConverterData =
-						new TestPrimitiveConverterType()
-						{
-							Data = 1701,
-						},
-				};
+            var data =
+                new TestData()
+                {
+                    ConverterData =
+                        new TestConverterType()
+                        {
+                            Data = 42,
+                        },
 
-			const string ExpectedJSON = @"{""converterData"":{""dataValue"":42},""primitiveConverterData"":1701}";
+                    PrimitiveConverterData =
+                        new TestPrimitiveConverterType()
+                        {
+                            Data = 1701,
+                        },
+                };
 
-			// Then
-			serializer.Serialize(data).ShouldEqual(ExpectedJSON);
+            const string ExpectedJSON = @"{""converterData"":{""dataValue"":42},""primitiveConverterData"":1701}";
 
-			serializer.Deserialize<TestData>(ExpectedJSON).ShouldEqual(data);
-		}
+            // Then
+            serializer.Serialize(data).ShouldEqual(ExpectedJSON);
 
-		[Fact]
-		public void Should_not_register_converters_when_not_asked()
-		{
-			// Given
-			JsonSettings.Converters.Add(new TestConverter());
-			JsonSettings.PrimitiveConverters.Add(new TestPrimitiveConverter());
+            serializer.Deserialize<TestData>(ExpectedJSON).ShouldEqual(data);
+        }
 
-			var defaultSerializer = new JavaScriptSerializer();
+        [Fact]
+        public void Should_not_register_converters_when_not_asked()
+        {
+            // Given
+            JsonSettings.Converters.Add(new TestConverter());
+            JsonSettings.PrimitiveConverters.Add(new TestPrimitiveConverter());
 
-			// When
-			var serializer = new JavaScriptSerializer(
-				registerConverters: false,
-				resolver: null,
-				maxJsonLength: defaultSerializer.MaxJsonLength,
-				recursionLimit: defaultSerializer.RecursionLimit,
-				retainCasing: defaultSerializer.RetainCasing,
-				iso8601DateFormat: defaultSerializer.ISO8601DateFormat);
+            var defaultSerializer = new JavaScriptSerializer();
 
-			var data =
-				new TestData()
-				{
-					ConverterData =
-						new TestConverterType()
-						{
-							Data = 42,
-						},
+            // When
+            var serializer = new JavaScriptSerializer(
+                registerConverters: false,
+                resolver: null,
+                maxJsonLength: defaultSerializer.MaxJsonLength,
+                recursionLimit: defaultSerializer.RecursionLimit,
+                retainCasing: defaultSerializer.RetainCasing,
+                iso8601DateFormat: defaultSerializer.ISO8601DateFormat);
 
-					PrimitiveConverterData =
-						new TestPrimitiveConverterType()
-						{
-							Data = 1701,
-						},
-				};
+            var data =
+                new TestData()
+                {
+                    ConverterData =
+                        new TestConverterType()
+                        {
+                            Data = 42,
+                        },
 
-			const string ExpectedJSON = @"{""converterData"":{""data"":42},""primitiveConverterData"":{""data"":1701}}";
+                    PrimitiveConverterData =
+                        new TestPrimitiveConverterType()
+                        {
+                            Data = 1701,
+                        },
+                };
 
-			// Then
-			serializer.Serialize(data).ShouldEqual(ExpectedJSON);
+            const string ExpectedJSON = @"{""converterData"":{""data"":42},""primitiveConverterData"":{""data"":1701}}";
 
-			serializer.Deserialize<TestData>(ExpectedJSON).ShouldEqual(data);
-		}
+            // Then
+            serializer.Serialize(data).ShouldEqual(ExpectedJSON);
 
-		[Fact]
-		public void Should_use_primitive_converter_when_available()
-		{
-			// When
-			var serializer = new JavaScriptSerializer();
+            serializer.Deserialize<TestData>(ExpectedJSON).ShouldEqual(data);
+        }
 
-			serializer.RegisterConverters(new JavaScriptPrimitiveConverter[] { new TestPrimitiveConverter() });
+        [Fact]
+        public void Should_use_primitive_converter_when_available()
+        {
+            // When
+            var serializer = new JavaScriptSerializer();
 
-			// Then
-			serializer.Serialize(new TestPrimitiveConverterType() { Data = 12345 }).ShouldEqual("12345");
+            serializer.RegisterConverters(new JavaScriptPrimitiveConverter[] { new TestPrimitiveConverter() });
 
-			serializer.Deserialize<TestPrimitiveConverterType>("12345").ShouldEqual(new TestPrimitiveConverterType() { Data = 12345 });
-		}
+            // Then
+            serializer.Serialize(new TestPrimitiveConverterType() { Data = 12345 }).ShouldEqual("12345");
 
-		[Fact]
-		public void Should_not_use_primitive_converter_for_wrong_type()
-		{
-			// When
-			var serializer = new JavaScriptSerializer();
+            serializer.Deserialize<TestPrimitiveConverterType>("12345").ShouldEqual(new TestPrimitiveConverterType() { Data = 12345 });
+        }
 
-			serializer.RegisterConverters(new JavaScriptPrimitiveConverter[] { new TestPrimitiveConverter() });
+        [Fact]
+        public void Should_not_use_primitive_converter_for_wrong_type()
+        {
+            // When
+            var serializer = new JavaScriptSerializer();
 
-			// Then
-			serializer.Serialize(new TestConverterType() { Data = 12345 }).ShouldEqual(@"{""data"":12345}");
+            serializer.RegisterConverters(new JavaScriptPrimitiveConverter[] { new TestPrimitiveConverter() });
 
-			serializer.Deserialize<TestConverterType>(@"{""data"":12345}").ShouldEqual(new TestConverterType() { Data = 12345 });
+            // Then
+            serializer.Serialize(new TestConverterType() { Data = 12345 }).ShouldEqual(@"{""data"":12345}");
 
-			try
-			{
-				serializer.Deserialize<TestConverterType>("12345");
-				throw new ThrowsException(typeof(InvalidCastException));
-			}
-			catch { }
-		}
-	}
+            serializer.Deserialize<TestConverterType>(@"{""data"":12345}").ShouldEqual(new TestConverterType() { Data = 12345 });
+
+            try
+            {
+                serializer.Deserialize<TestConverterType>("12345");
+                throw new ThrowsException(typeof(InvalidCastException));
+            }
+            catch { }
+        }
+
+        [Fact]
+        public void Should_serialize_tuples()
+        {
+            var serializer = new JavaScriptSerializer();
+            serializer.RegisterConverters(new[] { new TupleConverter() });
+
+            var tuple = Tuple.Create(10, 11);
+            serializer.Serialize(tuple).ShouldEqual(@"{""item1"":10,""item2"":11}");
+        }
+
+        [Fact]
+        public void Should_deserialize_tuple()
+        {
+            var serializer = new JavaScriptSerializer();
+            serializer.RegisterConverters(new[] { new TupleConverter() });
+
+            string body = @"{""item1"":10,""item2"":11}";
+            Tuple<int, int> result = serializer.Deserialize<Tuple<int, int>>(body);
+            result.ToString().ShouldEqual("(10, 11)");
+        }
+
+        [Fact]
+        public void Should_deserialize_string_tuple()
+        {
+            var serializer = new JavaScriptSerializer();
+            serializer.RegisterConverters(new[] { new TupleConverter() });
+
+            string body = @"{""item1"":""Hello"",""item2"":""World"",""item3"":42}";
+            var result = serializer.Deserialize<Tuple<string, string, int>>(body);
+            result.ToString().ShouldEqual("(Hello, World, 42)");
+        }
+
+        [Fact]
+        public void Should_deserialize_type_with_tuples()
+        {
+            // When
+            var serializer = new JavaScriptSerializer();
+            serializer.RegisterConverters(new[] { new TupleConverter() });
+
+            // Then
+            var typeWithTuple = serializer.Deserialize<TypeWithTuple>(@"{""value"":{""item1"":10,""item2"":11}}");
+            typeWithTuple.Value.Item1.ShouldEqual(10);
+            typeWithTuple.Value.Item2.ShouldEqual(11);
+        }
+    }
 }

--- a/src/Nancy.Tests/Unit/Json/TypeWithTuple.cs
+++ b/src/Nancy.Tests/Unit/Json/TypeWithTuple.cs
@@ -1,0 +1,9 @@
+namespace Nancy.Tests.Unit.Json
+{
+    using System;
+
+    public class TypeWithTuple
+    {
+        public Tuple<int, int> Value { get; set; }
+    }
+}

--- a/src/Nancy/Json/Converters/TupleConverter.cs
+++ b/src/Nancy/Json/Converters/TupleConverter.cs
@@ -1,0 +1,37 @@
+﻿namespace Nancy.Json.Converters
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+
+    public class TupleConverter : JavaScriptConverter
+    {
+        public override IEnumerable<Type> SupportedTypes
+        {
+            get
+            {
+                yield return typeof(Tuple<>);
+                yield return typeof(Tuple<,>);
+                yield return typeof(Tuple<,,>);
+                yield return typeof(Tuple<,,,>);
+                yield return typeof(Tuple<,,,,>);
+                yield return typeof(Tuple<,,,,,>);
+                yield return typeof(Tuple<,,,,,,>);
+                yield return typeof(Tuple<,,,,,,,>);
+            }
+        }
+
+        public override object Deserialize(IDictionary<string, object> dictionary, Type type, JavaScriptSerializer serializer)
+        {
+            var ctor = type.GetConstructors().First();
+            object instance = ctor.Invoke(dictionary.Values.ToArray());
+            return instance;
+        }
+
+        public override IDictionary<string, object> Serialize(object obj, JavaScriptSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Nancy/Json/JavaScriptSerializer.cs
+++ b/src/Nancy/Json/JavaScriptSerializer.cs
@@ -339,6 +339,14 @@ namespace Nancy.Json
 
                     isDictionaryWithGuidKey = arguments[0] == typeof(Guid);
                 }
+                else
+                {
+                    var converter = GetConverter(genericTypeDefinition);
+                    if (converter != null)
+                        return converter.Deserialize(
+                            EvaluateDictionary(dict),
+                            type, this);
+                }
             }
             else if (type.IsAssignableFrom(typeof(IDictionary)))
                 type = typeof(Dictionary<string, object>);

--- a/src/Nancy/Json/JsonSettings.cs
+++ b/src/Nancy/Json/JsonSettings.cs
@@ -48,6 +48,7 @@ namespace Nancy.Json
             Converters = new List<JavaScriptConverter>
                              {
                                  new TimeSpanConverter(),
+                                 new TupleConverter()
                              };
             PrimitiveConverters = new List<JavaScriptPrimitiveConverter>();
             RetainCasing = false;

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -175,6 +175,7 @@
     <Compile Include="Helpers\CacheHelpers.cs" />
     <Compile Include="IncludeInNancyAssemblyScanningAttribute.cs" />
     <Compile Include="IStaticContentProvider.cs" />
+    <Compile Include="Json\Converters\TupleConverter.cs" />
     <Compile Include="Json\JavaScriptPrimitiveConverter.cs" />
     <Compile Include="Localization\TextResourceFinder.cs" />
     <Compile Include="Helpers\TaskHelpers.cs" />


### PR DESCRIPTION
Right now, the built-in json serializer doesn't deserialize tuples: this error will be thrown when attempting to deserialize a type with a tuple property:
`System.MissingMethodException : No parameterless constructor defined for this object.`

This pull request adds a `TupleConverter` to convert the dictionary items into a valid tuple.