### PR TITLE
Removing specific beta4 build and fixing assembly loading issue on vnext

### DIFF
--- a/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
+++ b/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
@@ -245,6 +245,8 @@
 
             this.ConfigureApplicationContainer(this.ApplicationContainer);
 
+            AppDomainAssemblyTypeScanner.UpdateTypes();
+
             var typeRegistrations = this.InternalConfiguration.GetTypeRegistations()
                                         .Concat(this.GetAdditionalTypes());
 

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 ﻿{
     "projects": [ "src" ],
     "sdk": {
-        "version": "1.0.0-beta4-11566"
+        "version": "1.0.0-beta4"
     }
 }


### PR DESCRIPTION
Prevents error for people who don't have 11566. 