### PR TITLE
Allow binding to models with non public no args ctors

### DIFF
--- a/src/Nancy.Tests/Unit/ModelBinding/DefaultBinderFixture.cs
+++ b/src/Nancy.Tests/Unit/ModelBinding/DefaultBinderFixture.cs
@@ -1442,6 +1442,20 @@ namespace Nancy.Tests.Unit.ModelBinding
             result.ShouldEqualSequence(new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 });
         }
 
+        [Fact]
+        public void Should_bind_to_model_with_non_public_default_constructor()
+        {
+            var binder = this.GetBinder();
+
+            var context = CreateContextWithHeader("Content-Type", new[] { "application/json" });
+            context.Request.Form["IntProperty"] = "10";
+
+            var result = (TestModelWithHiddenDefaultConstructor)binder.Bind(context, typeof (TestModelWithHiddenDefaultConstructor), null, BindingConfig.Default);
+
+            result.ShouldNotBeNull();
+            result.IntProperty.ShouldEqual(10);
+        }
+
         private IBinder GetBinder(IEnumerable<ITypeConverter> typeConverters = null, IEnumerable<IBodyDeserializer> bodyDeserializers = null, IFieldNameConverter nameConverter = null, BindingDefaults bindingDefaults = null)
         {
             var converters = typeConverters ?? new ITypeConverter[] { new DateTimeConverter(), new NumericConverter(), new FallbackConverter() };
@@ -1553,6 +1567,13 @@ namespace Nancy.Tests.Unit.ModelBinding
             public string NestedStringField;
             public int NestedIntField;
             public double NestedDoubleField;
+        }
+
+        public class TestModelWithHiddenDefaultConstructor
+        {
+            public int IntProperty { get; private set; }
+
+            private TestModelWithHiddenDefaultConstructor() { }
         }
     }
 

--- a/src/Nancy/ModelBinding/DefaultBinder.cs
+++ b/src/Nancy/ModelBinding/DefaultBinder.cs
@@ -429,11 +429,11 @@ namespace Nancy.ModelBinding
 
             if (instance == null)
             {
-                return Activator.CreateInstance(modelType);
+                return Activator.CreateInstance(modelType, true);
             }
 
             return !modelType.IsInstanceOfType(instance) ?
-                Activator.CreateInstance(modelType) :
+                Activator.CreateInstance(modelType, true) :
                 instance;
         }
 


### PR DESCRIPTION
Since my issue #1938 seems to be getting no attention, I went ahead and fixed it in my fork.

This resolves some issues for me when model binding directly to 'domain' commands, since I don't want to promote newing them up in an inconsistent manner I've hidden the no args constructor.