### PR TITLE
Parameterize `Csrf.GetFormToken`

### DIFF
--- a/src/Nancy/Security/Csrf.cs
+++ b/src/Nancy/Security/Csrf.cs
@@ -104,8 +104,9 @@
         /// <param name="module">Module object</param>
         /// <param name="validityPeriod">Optional validity period before it times out</param>
         /// <exception cref="CsrfValidationException">If validation fails</exception>
-        public static void ValidateCsrfToken(this INancyModule module, TimeSpan? validityPeriod = null)
+        public static void ValidateCsrfToken(this INancyModule module, TimeSpan? validityPeriod = null, Func<INancyModule, CsrfToken> getSentToken = null)
         {
+            getSentToken = getSentToken ?? new Func<INancyModule, CsrfToken>(GetFormToken);
             var request = module.Request;
 
             if (request == null)
@@ -114,9 +115,9 @@
             }
 
             var cookieToken = GetCookieToken(request);
-            var formToken = GetFormToken(request);
+            var sentToken = getSentToken(request);
 
-            var result = CsrfApplicationStartup.TokenValidator.Validate(cookieToken, formToken, validityPeriod);
+            var result = CsrfApplicationStartup.TokenValidator.Validate(cookieToken, sentToken, validityPeriod);
 
             if (result != CsrfTokenValidationResult.Ok)
             {


### PR DESCRIPTION
In many situations (esp. when using a lot of JSON) it is less convenient to send back CSRF tokens as form fields.

In those cases you may want to send back the plain-text token (not the encrypted cookie) in a cookie or custom Http Header.

This PR adds a (backward compatible) parameter to `ValidateCsrfToken` that allows you to specify how to fetch the plain text CSRF token.

It would be used like so:

```csharp
this.ValidateCsrfToken(getSentToken: (module) => {
    var tokenStr = module.Request.Headers["Csrf-Check"];
    return CsrfApplicationStartup.ObjectSerializer.Deserialize(tokenStr) as CsrfToken;
});
```