### PR TITLE
Add DNX demo project

### DIFF
--- a/src/Nancy.Demo.Hosting.Dnx/Nancy.Demo.Hosting.Dnx.xproj
+++ b/src/Nancy.Demo.Hosting.Dnx/Nancy.Demo.Hosting.Dnx.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>86a7a5f3-71aa-4c37-b308-528ae4492a63</ProjectGuid>
+    <RootNamespace>Nancy.Demo.Hosting.Dnx</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+    <DevelopmentServerPort>1699</DevelopmentServerPort>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Nancy.Demo.Hosting.Dnx/Startup.cs
+++ b/src/Nancy.Demo.Hosting.Dnx/Startup.cs
@@ -1,0 +1,16 @@
+﻿
+namespace Nancy.Demo.Hosting.Dnx
+{
+    using Microsoft.AspNet.Builder;
+    using Microsoft.Framework.DependencyInjection;
+
+    using Nancy.Owin;
+
+    public class Startup
+    {
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseOwin().UseNancy();
+        }
+    }
+}

--- a/src/Nancy.Demo.Hosting.Dnx/TestModule.cs
+++ b/src/Nancy.Demo.Hosting.Dnx/TestModule.cs
@@ -1,0 +1,10 @@
+﻿namespace Nancy.Demo.Hosting.Dnx
+{
+    public class TestModule : NancyModule
+    {
+        public TestModule()
+        {
+            Get["/"] = _ => "YO!";  
+        }
+    }
+}

--- a/src/Nancy.Demo.Hosting.Dnx/project.json
+++ b/src/Nancy.Demo.Hosting.Dnx/project.json
@@ -1,0 +1,35 @@
+﻿{
+    "webroot": "wwwroot",
+    "version": "1.0.0-*",
+
+    "dependencies": {
+        "Nancy": "1.0.0-*",
+        "Microsoft.AspNet.Owin":  "1.0.0-beta5",
+        "Kestrel": "1.0.0-beta5",
+        "Microsoft.AspNet.Server.IIS": "1.0.0-beta5",
+        "Microsoft.AspNet.Server.WebListener": "1.0.0-beta5"
+    },
+
+    "commands": {
+        "web": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.WebListener --server.urls http://localhost:5000",
+        "kestrel": "Microsoft.AspNet.Hosting --server Kestrel --server.urls http://localhost:5004"
+    },
+
+    "frameworks": {
+        "dnx451": { },
+        "dnxcore50": { }
+    },
+
+    "publishExclude": [
+        "node_modules",
+        "bower_components",
+        "**.xproj",
+        "**.user",
+        "**.vspscc"
+    ],
+    "exclude": [
+        "wwwroot",
+        "node_modules",
+        "bower_components"
+    ]
+}

--- a/src/Nancy.sln
+++ b/src/Nancy.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
+VisualStudioVersion = 14.0.23023.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{CC729377-1503-48DA-8C1E-CDD535974A2F}"
 EndProject
@@ -131,6 +131,8 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Nancy.Demo.SuperSimpleViewEngine", "Nancy.Demo.SuperSimpleViewEngine\Nancy.Demo.SuperSimpleViewEngine.xproj", "{D105180A-C55F-41AD-9E45-0B98436BCA08}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Nancy.Demo.Validation", "Nancy.Demo.Validation\Nancy.Demo.Validation.xproj", "{D38C430B-9A7C-492D-B754-5B3C4D9D2925}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Nancy.Demo.Hosting.Dnx", "Nancy.Demo.Hosting.Dnx\Nancy.Demo.Hosting.Dnx.xproj", "{86A7A5F3-71AA-4C37-B308-528AE4492A63}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -612,6 +614,14 @@ Global
 		{D38C430B-9A7C-492D-B754-5B3C4D9D2925}.MonoRelease|Any CPU.Build.0 = Release|Any CPU
 		{D38C430B-9A7C-492D-B754-5B3C4D9D2925}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D38C430B-9A7C-492D-B754-5B3C4D9D2925}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86A7A5F3-71AA-4C37-B308-528AE4492A63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86A7A5F3-71AA-4C37-B308-528AE4492A63}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86A7A5F3-71AA-4C37-B308-528AE4492A63}.MonoDebug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86A7A5F3-71AA-4C37-B308-528AE4492A63}.MonoDebug|Any CPU.Build.0 = Debug|Any CPU
+		{86A7A5F3-71AA-4C37-B308-528AE4492A63}.MonoRelease|Any CPU.ActiveCfg = Release|Any CPU
+		{86A7A5F3-71AA-4C37-B308-528AE4492A63}.MonoRelease|Any CPU.Build.0 = Release|Any CPU
+		{86A7A5F3-71AA-4C37-B308-528AE4492A63}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86A7A5F3-71AA-4C37-B308-528AE4492A63}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -676,6 +686,7 @@ Global
 		{FAAC075A-DB9F-47E4-B243-4C4B53196C17} = {913E80D6-6EE0-47BC-B3B6-0D0A769B461A}
 		{D105180A-C55F-41AD-9E45-0B98436BCA08} = {913E80D6-6EE0-47BC-B3B6-0D0A769B461A}
 		{D38C430B-9A7C-492D-B754-5B3C4D9D2925} = {913E80D6-6EE0-47BC-B3B6-0D0A769B461A}
+		{86A7A5F3-71AA-4C37-B308-528AE4492A63} = {913E80D6-6EE0-47BC-B3B6-0D0A769B461A}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = Nancy.Demo.Hosting.Aspnet\Nancy.Demo.Hosting.Aspnet.csproj


### PR DESCRIPTION
The demo project has a `WebListener` and `Kestrel` command and can run a super simple Nancy module on either. 
Right now it only works on `dnx451`, but when the Nancy package compiles on `dnxcore50` this should run there too.