### PR TITLE
Urlencodedcapturegroups

### DIFF
--- a/src/Nancy.Tests/Unit/Routing/DefaultRouteResolverFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/DefaultRouteResolverFixture.cs
@@ -72,6 +72,7 @@
             }
         }
 
+
         [Theory]
         [InlineData("/foo/testing/plop", true, "testing")]
         [InlineData("/foo/testing/plop", false, "testing")]
@@ -180,6 +181,22 @@
             {
               result.StatusCode.ShouldEqual(HttpStatusCode.NotFound);
             }
+        }
+
+        [Theory]
+        [InlineData("/bleh/this%2fis%2fsome%2fstuff/bar", "GreedyInMiddle", "this/is/some/stuff")]
+        [InlineData("/bleh/this%2Fis%2Fsome%2Fstuff/bar", "GreedyInMiddle", "this/is/some/stuff")]
+        [InlineData("/foo/double%252fencoded/plop", "Captured", "double%2fencoded")]
+        [InlineData("/foo/%61%62%63%31%32%33/plop", "Captured", "abc123")]
+        [InlineData("/foo/%21%23%24%26%27%28%29%2A%2B%2C%3A%3B%3D%3F%40%5B%5D/plop", "Captured", "!#$&'()*+,:;=?@[]")]
+        public void Should_url_decode_captures(string path, string captureType, string expected)
+        {
+            //Given, When
+            var browser = InitBrowser(true);
+            var result = browser.Get(path);
+
+            //Then
+            result.Body.AsString().ShouldEqual(captureType + " " + expected);
         }
 
         [Theory]

--- a/src/Nancy.Tests/Unit/Routing/DefaultRouteResolverFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/DefaultRouteResolverFixture.cs
@@ -184,6 +184,21 @@
         }
 
         [Theory]
+        [InlineData("/bleh/test%2fbar", "GreedyOnEnd", "test/bar")]
+        [InlineData("/foo/test%2ffuzz/plop", "Captured", "test/fuzz")]
+        [InlineData("/bleh/test%2f%2ffuzz/bar", "GreedyInMiddle", "test//fuzz")]
+        [InlineData("/foo/%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D/plop", "Captured", "!#$&'()*+,/:;=?@[]")]
+        public void Should_resolve_and_decode_capture_groups_with_encoded_forward_slashes(string path, string captureType, string expected)
+        {
+            //Given, When
+            var browser = InitBrowser(true);
+            var result = browser.Get(path);
+
+            //Then
+            result.Body.AsString().ShouldEqual(captureType + " " + expected);
+        }
+
+        [Theory]
         [InlineData("/bleh/this%2fis%2fsome%2fstuff/bar", "GreedyInMiddle", "this/is/some/stuff")]
         [InlineData("/bleh/this%2Fis%2Fsome%2Fstuff/bar", "GreedyInMiddle", "this/is/some/stuff")]
         [InlineData("/foo/double%252fencoded/plop", "Captured", "double%2fencoded")]

--- a/src/Nancy/Routing/DefaultRouteResolver.cs
+++ b/src/Nancy/Routing/DefaultRouteResolver.cs
@@ -45,15 +45,12 @@
         /// <returns>A <see cref="ResolveResult"/> containing the resolved route information.</returns>
         public ResolveResult Resolve(NancyContext context)
         {
-            var pathDecoded =
-                HttpUtility.UrlDecode(context.Request.Path);
-
-            var results = this.trie.GetMatches(GetMethod(context), pathDecoded, context);
+            var results = this.trie.GetMatches(GetMethod(context), context.Request.Path, context);
 
             if (!results.Any())
             {
                 var allowedMethods =
-                    this.trie.GetOptions(pathDecoded, context).ToArray();
+                    this.trie.GetOptions(context.Request.Path, context).ToArray();
 
                 if (IsOptionsRequest(context))
                 {

--- a/src/Nancy/Routing/Trie/RouteResolverTrie.cs
+++ b/src/Nancy/Routing/Trie/RouteResolverTrie.cs
@@ -4,6 +4,8 @@ namespace Nancy.Routing.Trie
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
+
+    using Nancy.Helpers;
     using Nodes;
 
     /// <summary>
@@ -73,8 +75,14 @@ namespace Nancy.Routing.Trie
                 return MatchResult.NoMatches;
             }
 
-            return this.routeTries[method].GetMatches(path.Split(splitSeparators, StringSplitOptions.RemoveEmptyEntries), context)
-                                          .ToArray();
+            string[] segments = path
+                .Split(splitSeparators, StringSplitOptions.RemoveEmptyEntries)
+                .Select(HttpUtility.UrlDecode)
+                .ToArray();
+
+            MatchResult[] matchResults = this.routeTries[method].GetMatches(segments, context)
+                .ToArray();
+            return matchResults;
         }
 
         /// <summary>


### PR DESCRIPTION
Currently Nancy url-decodes capture groups before identifying where the capture groups begin and end (i.e. splitting on "/")

This leads to odd behavior around encoded "/"s.

**Examples:**

With routes 

1. `"foo/{bar}/baz"`
2. `"foo/{fuzz}"`

* a request to `"foo/bar%2fbaz"` will resolve to route `"foo/{bar}/baz"`, despite the "/" having been encoded (and should therefore not be treated as a path separator).

* a request to `"foo/3-slashes-looks-like-"%2f%2f%2f"` resolves to `"foo/{fuzz*}"` (but not `"foo/{fuzz}"`) with a Fuzz parameter initialised to `"3-slashes-looks-like-"/""`, rather than the expected `"3-slashes-looks-like-"///""`


This merge introduces already passing tests around url decoding in the default route resolver fixture to confirm and preserve existing decoding behavior; then introduces tests that illustrate the incorrect behavior above.

The included fix is to delay url decoding until /after/ the path has been split on the "/" characters.