### PR TITLE
AppDomainAssemblyTypeScanner exception handling

### DIFF
--- a/src/Nancy/Bootstrapper/AppDomainAssemblyTypeScanner.cs
+++ b/src/Nancy/Bootstrapper/AppDomainAssemblyTypeScanner.cs
@@ -241,6 +241,10 @@ namespace Nancy.Bootstrapper
                     {
                         //the assembly maybe it's not managed code
                     }
+                    catch (FileLoadException)
+                    {
+                        //the assembly might already be loaded
+                    }
 
                     if (inspectedAssembly != null && inspectedAssembly.GetReferencedAssemblies().Any(r => r.Name.StartsWith("Nancy", StringComparison.OrdinalIgnoreCase)))
                     {


### PR DESCRIPTION
When loading assemblies in `AppDomainAssemblyTypeScanner` also catch `FileLoadExceptions` along with `BadImageFormatExceptions`. A `FileLoadException` could occur if an assembly with the same identity was previously loaded from a different path.

The motivation behind this is that in my project I have a somewhat exotic assembly loading process that uses multiple directories; to ease deployment the same assembly may exist in multiple directories. My application only ever uses `Assembly.Load(string)` and therefore the same one copy of any duplicate assemblies is always loaded. Nancy breaks this by using `Assembly.ReflectionOnlyLoadFrom(string)` on a specific path. This path happens to not be the copy of the assembly previously loaded which results in the following exception:

```
The type initializer for 'Nancy.Bootstrapper.AppDomainAssemblyTypeScanner' threw an exception. --->
System.IO.FileLoadException:
API restriction: The assembly '<path-to-assembly>' has already loaded from a different location. It cannot be loaded from a new location within the same app domain.
```
This makes it so that `FileLoadExceptions` are ignored as with `BadImageFormatExceptions`.
