### PR TITLE
Perform case-insensitive lookups in EmbeddedFileResource

### DIFF
--- a/src/Nancy.Embedded.Tests/Unit/EmbeddedStaticContentConventionBuilderFixture.cs
+++ b/src/Nancy.Embedded.Tests/Unit/EmbeddedStaticContentConventionBuilderFixture.cs
@@ -58,7 +58,7 @@
             result.ShouldEqual("Embedded Text");
         }
 
-        private static string GetEmbeddedStaticContent(string virtualDirectory, string requestedFilename, string root = null)
+        private static string GetEmbeddedStaticContent(string virtualDirectory, string requestedFilename, string contentPath = null)
         {
             var resource =
                 string.Format("/{0}/{1}", virtualDirectory, requestedFilename);

--- a/src/Nancy.Embedded.Tests/Unit/EmbeddedStaticContentConventionBuilderFixture.cs
+++ b/src/Nancy.Embedded.Tests/Unit/EmbeddedStaticContentConventionBuilderFixture.cs
@@ -58,6 +58,17 @@
             result.ShouldEqual("Embedded Text");
         }
 
+        [Fact]
+        public void Should_retrieve_static_content_ignoring_casing()
+        {
+            // Given
+            // When
+            var result = GetEmbeddedStaticContent("Foo", "Subfolder/embedded2.txt", "resources");
+
+            // Then
+            result.ShouldEqual("Embedded2 Text");
+        }
+
         private static string GetEmbeddedStaticContent(string virtualDirectory, string requestedFilename, string contentPath = null)
         {
             var resource =

--- a/src/Nancy.Embedded.Tests/Unit/EmbeddedStaticContentConventionBuilderFixture.cs
+++ b/src/Nancy.Embedded.Tests/Unit/EmbeddedStaticContentConventionBuilderFixture.cs
@@ -77,7 +77,7 @@
                 Assembly.GetExecutingAssembly();
 
             var resolver =
-                EmbeddedStaticContentConventionBuilder.AddDirectory(virtualDirectory, assembly, "Resources");
+                EmbeddedStaticContentConventionBuilder.AddDirectory(virtualDirectory, assembly, contentPath ?? "Resources");
 
             var response =
                 resolver.Invoke(context, null) as EmbeddedFileResponse;

--- a/src/Nancy.Tests/Unit/Responses/EmbeddedFileResponseFixture.cs
+++ b/src/Nancy.Tests/Unit/Responses/EmbeddedFileResponseFixture.cs
@@ -59,5 +59,16 @@
             // Then
             response.Headers.ContainsKey("ETag").ShouldBeFalse();
         }
+
+        [Fact]
+        public void Should_ignore_casing_in_resource_name_if_embedded_resource_exists()
+        {
+            // Given, when
+            var response =
+                new EmbeddedFileResponse(this.GetType().Assembly, "nancy.tests", "Resources.Views.staticviewresource.html");
+
+            // Then
+            response.Headers["ETag"].ShouldEqual("\"B9D9DC2B50ADFD0867749D4837C63556339080CE\"");
+        }
     }
 }

--- a/src/Nancy/Responses/EmbeddedFileResponse.cs
+++ b/src/Nancy/Responses/EmbeddedFileResponse.cs
@@ -48,12 +48,10 @@
         {
             var resourceName = assembly
                 .GetManifestResourceNames()
-                .Where(x => GetFileNameFromResourceName(resourcePath, x).Equals(name, StringComparison.OrdinalIgnoreCase))
-                .Select(x => GetFileNameFromResourceName(resourcePath, x))
-                .FirstOrDefault();
+                .FirstOrDefault(x => GetFileNameFromResourceName(resourcePath, x).Equals(name, StringComparison.OrdinalIgnoreCase));
 
-            resourceName =
-                string.Concat(resourcePath, ".", resourceName);
+            if (resourceName == null)
+                return null;
 
             return assembly.GetManifestResourceStream(resourceName);
         }

--- a/src/Nancy/Responses/EmbeddedFileResponse.cs
+++ b/src/Nancy/Responses/EmbeddedFileResponse.cs
@@ -6,6 +6,7 @@
     using System.Reflection;
     using System.Security.Cryptography;
     using System.Text;
+    using System.Text.RegularExpressions;
 
     public class EmbeddedFileResponse : Response
     {
@@ -59,7 +60,7 @@
 
         private static string GetFileNameFromResourceName(string resourcePath, string resourceName)
         {
-            return resourceName.Replace(resourcePath, string.Empty).Substring(1);
+            return Regex.Replace(resourceName, resourcePath, string.Empty, RegexOptions.IgnoreCase).Substring(1);
         }
 
         private static string GenerateETag(Stream stream)


### PR DESCRIPTION
Perform case-insensitive lookups in EmbeddedFileResource

Previously, `EmbeddedFileResource` was overly picky with regards to embedded resource name casing. Particularly, this was causing problems when `AddDirectory()` on `EmbeddedStaticContentConventionBuilder` was given an incorrectly-capitalized `contentPath` argument, i.e.:

    _.AddDirectory("content", GetType().Assembly, contentPath: "content"));

Provided that embedded resources were under "Foo.Content", all requests to `/content/...` would fail.

With this PR, `EmbeddedFileResource` becomes much less picky about casing, which it has been all along nevertheless, except for a couple places.