### PR TITLE
Is any real reason for contentsStream.Position=0?

### DIFF
--- a/src/Nancy.Testing/BrowserResponseBodyWrapper.cs
+++ b/src/Nancy.Testing/BrowserResponseBodyWrapper.cs
@@ -30,7 +30,7 @@ namespace Nancy.Testing
         {
             var contentsStream = new MemoryStream();
             response.Contents.Invoke(contentsStream);
-            contentsStream.Position = 0;
+            //contentsStream.Position = 0;
             return contentsStream;
         }
 


### PR DESCRIPTION
contentsStream.Position = 0;
- fails when response's stream is closed already, i.e. something like:

```csharp
var response = new Response();
response.ContentType = file.ContentType;
response.Contents = s =>
{
    using (var bw = new System.IO.BinaryWriter(s))
    using (var inputStream = new System.IO.FileStream(file.PhisicalFilePath, System.IO.FileMode.Open))
    using (var br = new System.IO.BinaryReader(inputStream))
    {
        var bufferMaxLength = 1048576; // 1Mb
        var bufferLength = file.Size;
        if (bufferLength > bufferMaxLength) bufferLength = bufferMaxLength;

        while (br.BaseStream.Position < br.BaseStream.Length)
        {
            var cnt = br.BaseStream.Length - br.BaseStream.Position;
            if (cnt > bufferLength) cnt = bufferLength;
            if (cnt > 0)
            {
                var buffer = br.ReadBytes((int)cnt);
                bw.Write(buffer);
             }
             else
             {
                 break;
              }
              bw.Flush();
          }
      }
};
```