### PR TITLE
Disable stream switching when self-hosting #1892

### DIFF
--- a/src/Nancy.Hosting.Aspnet/NancyHandler.cs
+++ b/src/Nancy.Hosting.Aspnet/NancyHandler.cs
@@ -99,7 +99,7 @@ namespace Nancy.Hosting.Aspnet
 
             if (expectedRequestLength != 0)
             {
-                body = RequestStream.FromStream(context.Request.InputStream, expectedRequestLength, true);
+                body = RequestStream.FromStream(context.Request.InputStream, expectedRequestLength, StaticConfiguration.DisableRequestStreamSwitching ?? true);
             }
 
             var protocolVersion = context.Request.ServerVariables["HTTP_VERSION"];

--- a/src/Nancy.Hosting.Self/NancyHost.cs
+++ b/src/Nancy.Hosting.Self/NancyHost.cs
@@ -279,7 +279,7 @@
             return new Request(
                 request.HttpMethod,
                 nancyUrl,
-                RequestStream.FromStream(request.InputStream, expectedRequestLength, false),
+                RequestStream.FromStream(request.InputStream, expectedRequestLength, StaticConfiguration.DisableRequestStreamSwitching ?? false),
                 request.Headers.ToDictionary(), 
                 (request.RemoteEndPoint != null) ? request.RemoteEndPoint.Address.ToString() : null,
                 certificate,

--- a/src/Nancy.Hosting.Wcf/NancyWcfGenericService.cs
+++ b/src/Nancy.Hosting.Wcf/NancyWcfGenericService.cs
@@ -126,7 +126,7 @@
             return new Request(
                 webRequest.Method,
                 nancyUrl,
-                RequestStream.FromStream(requestBody, expectedRequestLength, false),
+                RequestStream.FromStream(requestBody, expectedRequestLength, StaticConfiguration.DisableRequestStreamSwitching ?? false),
                 webRequest.Headers.ToDictionary(),
                 ip, 
                 certificate);

--- a/src/Nancy/Owin/NancyMiddleware.cs
+++ b/src/Nancy/Owin/NancyMiddleware.cs
@@ -84,7 +84,7 @@
 
                         var url = CreateUrl(owinRequestHost, owinRequestScheme, owinRequestPathBase, owinRequestPath, owinRequestQueryString);
 
-                        var nancyRequestStream = new RequestStream(owinRequestBody, ExpectedLength(owinRequestHeaders), false);
+                        var nancyRequestStream = new RequestStream(owinRequestBody, ExpectedLength(owinRequestHeaders), StaticConfiguration.DisableRequestStreamSwitching ?? false);
 
                         var nancyRequest = new Request(
                                 owinRequestMethod,

--- a/src/Nancy/StaticConfiguration.cs
+++ b/src/Nancy/StaticConfiguration.cs
@@ -100,6 +100,11 @@ namespace Nancy
         [Description("Enable request tracing.")]
         public static bool EnableRequestTracing { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether or not to disable request stream switching
+        /// </summary>
+        public static bool? DisableRequestStreamSwitching { get; set; }
+
         public static class Caching
         {
             private static bool? enableRuntimeViewDiscovery;


### PR DESCRIPTION
Hi,

I saw this open issue https://github.com/NancyFx/Nancy/issues/1892 and made the changes suggested by @khellang, with the only difference that the property used for the configuration is called "DisableRequestStreamSwitching" instead of "EnableRequestStreamSwitching" because of the semantics of the constructors in the  RequestStream class. 

 ```csharp
 public RequestStream(long expectedLength, long thresholdLength, bool disableStreamSwitching)
            : this(null, expectedLength, thresholdLength, disableStreamSwitching)
        {
        }
```

let me know if I'm missing something 

Thanks! (first contribution ever :+1:)
