### PR TITLE
Nancy testing default user agent

### DIFF
--- a/src/Nancy.Testing.Tests/BrowserFixture.cs
+++ b/src/Nancy.Testing.Tests/BrowserFixture.cs
@@ -1,4 +1,3 @@
-
 namespace Nancy.Testing.Tests
 {
     using System;
@@ -15,8 +14,6 @@ namespace Nancy.Testing.Tests
     using Xunit;
     using FakeItEasy;
     using Nancy.Authentication.Forms;
-
-    using Xunit.Extensions;
 
     public class BrowserFixture
     {
@@ -40,10 +37,10 @@ namespace Nancy.Testing.Tests
 
             // When
             var result = browser.Post("/", with =>
-                                           {
-                                               with.HttpRequest();
-                                               with.Body(thisIsMyRequestBody);
-                                           });
+            {
+                with.HttpRequest();
+                with.Body(thisIsMyRequestBody);
+            });
 
             // Then
             result.Body.AsString().ShouldEqual(thisIsMyRequestBody);
@@ -57,10 +54,10 @@ namespace Nancy.Testing.Tests
 
             // When
             var result = browser.Get("/userHostAddress", with =>
-                                                         {
-                                                             with.HttpRequest();
-                                                             with.UserHostAddress(userHostAddress);
-                                                         });
+            {
+                with.HttpRequest();
+                with.UserHostAddress(userHostAddress);
+            });
 
             // Then
             result.Body.AsString().ShouldEqual(userHostAddress);
@@ -74,11 +71,11 @@ namespace Nancy.Testing.Tests
 
             // When
             var result = browser.Get("/isLocal", with =>
-                    {
-                        with.HttpRequest();
-                        with.HostName("localhost");
-                        with.UserHostAddress(userHostAddress);
-                    });
+            {
+                with.HttpRequest();
+                with.HostName("localhost");
+                with.UserHostAddress(userHostAddress);
+            });
 
             // Then
             result.Body.AsString().ShouldEqual("local");
@@ -92,11 +89,11 @@ namespace Nancy.Testing.Tests
 
             // When
             var result = browser.Get("/isLocal", with =>
-                    {
-                        with.HttpRequest();
-                        with.HostName("localhost");
-                        with.UserHostAddress(userHostAddress);
-                    });
+            {
+                with.HttpRequest();
+                with.HostName("localhost");
+                with.UserHostAddress(userHostAddress);
+            });
 
             // Then
             result.Body.AsString().ShouldEqual("local");
@@ -110,11 +107,11 @@ namespace Nancy.Testing.Tests
 
             // When
             var result = browser.Get("/isLocal", with =>
-                    {
-                        with.HttpRequest();
-                        with.HostName("anotherhost");
-                        with.UserHostAddress(userHostAddress);
-                    });
+            {
+                with.HttpRequest();
+                with.HostName("anotherhost");
+                with.UserHostAddress(userHostAddress);
+            });
 
             // Then
             result.Body.AsString().ShouldEqual("not-local");
@@ -129,12 +126,13 @@ namespace Nancy.Testing.Tests
             var writer = new StreamWriter(stream);
             writer.Write(thisIsMyRequestBody);
             writer.Flush();
+
             // When
             var result = browser.Post("/", with =>
-                                           {
-                                               with.HttpRequest();
-                                               with.Body(stream, "text/plain");
-                                           });
+            {
+                with.HttpRequest();
+                with.Body(stream, "text/plain");
+            });
 
             // Then
             result.Body.AsString().ShouldEqual(thisIsMyRequestBody);
@@ -148,9 +146,9 @@ namespace Nancy.Testing.Tests
 
             // When
             var result = browser.Post("/", with =>
-                                            {
-                                                with.JsonBody(model);
-                                            });
+            {
+                with.JsonBody(model);
+            });
 
             // Then
             var actualModel = result.Body.DeserializeJson<EchoModel>();
@@ -442,6 +440,7 @@ namespace Nancy.Testing.Tests
         [Fact]
         public void Should_return_JSON_serialized_form()
         {
+            // Given
             var response = browser.Post("/serializedform", (with) =>
             {
                 with.HttpRequest();
@@ -451,8 +450,10 @@ namespace Nancy.Testing.Tests
                 with.FormValue("SomeBoolean", "true");
             });
 
+            // When
             var actualModel = response.Body.DeserializeJson<EchoModel>();
 
+            // Then
             Assert.Equal("Hi", actualModel.SomeString);
             Assert.Equal(1, actualModel.SomeInt);
             Assert.Equal(true, actualModel.SomeBoolean);
@@ -461,6 +462,7 @@ namespace Nancy.Testing.Tests
         [Fact]
         public void Should_return_JSON_serialized_querystring()
         {
+            // Given
             var response = browser.Get("/serializedquerystring", (with) =>
             {
                 with.HttpRequest();
@@ -470,8 +472,10 @@ namespace Nancy.Testing.Tests
                 with.Query("SomeBoolean", "true");
             });
 
+            // When
             var actualModel = response.Body.DeserializeJson<EchoModel>();
 
+            // Then
             Assert.Equal("Hi", actualModel.SomeString);
             Assert.Equal(1, actualModel.SomeInt);
             Assert.Equal(true, actualModel.SomeBoolean);

--- a/src/Nancy.Testing.Tests/BrowserFixture.cs
+++ b/src/Nancy.Testing.Tests/BrowserFixture.cs
@@ -509,6 +509,37 @@ namespace Nancy.Testing.Tests
             result.Body.AsString().ShouldEqual("john++");
         }
 
+        [Fact]
+        public void Should_add_nancy_testing_browser_header_as_default_user_agent()
+        {
+            // Given
+            const string expectedHeaderValue = "Nancy.Testing.Browser";
+
+            // When
+            var result = browser.Get("/useragent").Body.AsString();
+
+            // Then
+            result.ShouldEqual(expectedHeaderValue);
+        }
+
+        [Fact]
+        public void Should_override_default_user_agent_when_explicitly_defined()
+        {
+            // Given
+            const string expectedHeaderValue = "Custom.User.Agent";
+
+            // When
+            var result = browser.Get("/useragent", with =>
+            {
+                with.Header("User-Agent", expectedHeaderValue);    
+            });
+
+            var header = result.Body.AsString();
+
+            // Then
+            header.ShouldEqual(expectedHeaderValue);
+        }
+
         public class EchoModel
         {
             public string SomeString { get; set; }
@@ -568,6 +599,8 @@ namespace Nancy.Testing.Tests
 
                         return response;
                     };
+
+                Get["/useragent"] = _ => this.Request.Headers.UserAgent;
 
                 Get["/type"] = _ => this.Request.Url.Scheme.ToLower();
 

--- a/src/Nancy.Testing/Browser.cs
+++ b/src/Nancy.Testing/Browser.cs
@@ -41,7 +41,7 @@ namespace Nancy.Testing
             this.bootstrapper = bootstrapper;
             this.bootstrapper.Initialise();
             this.engine = this.bootstrapper.GetEngine();
-            this.defaultBrowserContext = defaults ?? this.DefaultBrowserContext;
+            this.defaultBrowserContext = defaults ?? DefaultBrowserContext;
         }
 
         /// <summary>
@@ -199,10 +199,18 @@ namespace Nancy.Testing
             return this.HandleRequest("PUT", url, browserContext);
         }
 
+        /// <summary>
+        /// Performs a request of the HTTP <paramref name="method"/>, on the given <paramref name="url"/>, using the
+        /// provided <paramref name="browserContext"/> configuration.
+        /// </summary>
+        /// <param name="method">HTTP method to send the request as.</param>
+        /// <param name="url">The URl of the request.</param>
+        /// <param name="browserContext">An closure for providing browser context for the request.</param>
+        /// <returns>An <see cref="BrowserResponse"/> instance of the executed request.</returns>
         public BrowserResponse HandleRequest(string method, Url url, Action<BrowserContext> browserContext)
         {
             var request =
-                CreateRequest(method, url, browserContext ?? (with => {}));
+                this.CreateRequest(method, url, browserContext ?? (with => {}));
 
             var response = new BrowserResponse(this.engine.HandleRequest(request), this);
 
@@ -211,16 +219,24 @@ namespace Nancy.Testing
             return response;
         }
 
+        /// <summary>
+        /// Performs a request of the HTTP <paramref name="method"/>, on the given <paramref name="path"/>, using the
+        /// provided <paramref name="browserContext"/> configuration.
+        /// </summary>
+        /// <param name="method">HTTP method to send the request as.</param>
+        /// <param name="path">The path that is being requested.</param>
+        /// <param name="browserContext">An closure for providing browser context for the request.</param>
+        /// <returns>An <see cref="BrowserResponse"/> instance of the executed request.</returns>
         public BrowserResponse HandleRequest(string method, string path, Action<BrowserContext> browserContext)
         {
-            var url = Uri.IsWellFormedUriString(path, UriKind.Relative)
-                          ? new Url {Path = path}
-                          : (Url)new Uri(path);
+            var url = Uri.IsWellFormedUriString(path, UriKind.Relative) ?
+                new Url { Path = path } :
+                (Url)new Uri(path);
 
-            return HandleRequest(method, url, browserContext);
+            return this.HandleRequest(method, url, browserContext);
         }
 
-        private void DefaultBrowserContext(BrowserContext context)
+        private static void DefaultBrowserContext(BrowserContext context)
         {
             context.HttpRequest();
         }
@@ -264,7 +280,7 @@ namespace Nancy.Testing
                 return;
             }
 
-            var useFormValues = !String.IsNullOrEmpty(contextValues.FormValues);
+            var useFormValues = !string.IsNullOrEmpty(contextValues.FormValues);
             var bodyContents = useFormValues ? contextValues.FormValues : contextValues.BodyString;
             var bodyBytes = bodyContents != null ? Encoding.UTF8.GetBytes(bodyContents) : new byte[] { };
 
@@ -283,7 +299,7 @@ namespace Nancy.Testing
 
             this.SetCookies(context);
 
-            defaultBrowserContext.Invoke(context);
+            this.defaultBrowserContext.Invoke(context);
             browserContext.Invoke(context);
 
             var contextValues =

--- a/src/Nancy.Testing/Browser.cs
+++ b/src/Nancy.Testing/Browser.cs
@@ -239,6 +239,7 @@ namespace Nancy.Testing
         private static void DefaultBrowserContext(BrowserContext context)
         {
             context.HttpRequest();
+            context.Header("User-Agent", "Nancy.Testing.Browser");
         }
 
         private void SetCookies(BrowserContext context)

--- a/src/Nancy.Testing/Browser.cs
+++ b/src/Nancy.Testing/Browser.cs
@@ -239,7 +239,6 @@ namespace Nancy.Testing
         private static void DefaultBrowserContext(BrowserContext context)
         {
             context.HttpRequest();
-            context.Header("User-Agent", "Nancy.Testing.Browser");
         }
 
         private void SetCookies(BrowserContext context)
@@ -305,6 +304,11 @@ namespace Nancy.Testing
 
             var contextValues =
                 (IBrowserContextValues)context;
+
+            if (!contextValues.Headers.ContainsKey("user-agent"))
+            {
+                contextValues.Headers.Add("user-agent", new[] { "Nancy.Testing.Browser" });
+            }
 
             BuildRequestBody(contextValues);
 

--- a/src/Nancy.Testing/BrowserContext.cs
+++ b/src/Nancy.Testing/BrowserContext.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Configuration;
     using System.IO;
     using System.Reflection;
     using System.Security.Cryptography.X509Certificates;
@@ -20,11 +19,11 @@
         public BrowserContext()
         {
             this.Values.Headers = new Dictionary<string, IEnumerable<string>>();
-            this.Values.Protocol = String.Empty;
-            this.Values.QueryString = String.Empty;
-            this.Values.BodyString = String.Empty;
-            this.Values.FormValues = String.Empty;
-            this.Values.HostName = String.Empty;
+            this.Values.Protocol = string.Empty;
+            this.Values.QueryString = string.Empty;
+            this.Values.BodyString = string.Empty;
+            this.Values.FormValues = string.Empty;
+            this.Values.HostName = string.Empty;
         }
 
         /// <summary>
@@ -113,14 +112,14 @@
         /// <param name="value">The value of the form element.</param>
         public void FormValue(string key, string value)
         {
-            if (!String.IsNullOrEmpty(this.Values.BodyString))
+            if (!string.IsNullOrEmpty(this.Values.BodyString))
             {
                 throw new InvalidOperationException("Form value cannot be set as well as body string");
             }
 
-            this.Values.FormValues += String.Format(
+            this.Values.FormValues += string.Format(
                 "{0}{1}={2}",
-                this.Values.FormValues.Length == 0 ? String.Empty : "&",
+                this.Values.FormValues.Length == 0 ? string.Empty : "&",
                 key,
                 HttpUtility.UrlEncode(value));
         }
@@ -164,7 +163,7 @@
         /// </summary>
         public void Query(string key, string value)
         {
-            this.Values.QueryString += String.Format(
+            this.Values.QueryString += string.Format(
                 "{0}{1}={2}",
                 this.Values.QueryString.Length == 0 ? "?" : "&",
                 key,
@@ -245,9 +244,7 @@
 
             if (certificatesFound.Count <= 0)
             {
-                throw new InvalidOperationException(
-                    String.Format("No certificates found in {0} {1} with a {2} that looks like \"{3}\"", storeLocation,
-                                  storeName, findType, findBy));
+                throw new InvalidOperationException(string.Format("No certificates found in {0} {1} with a {2} that looks like \"{3}\"", storeLocation, storeName, findType, findBy));
             }
 
             this.Values.ClientCertificate = certificatesFound[0];

--- a/src/Nancy.Testing/BrowserContext.cs
+++ b/src/Nancy.Testing/BrowserContext.cs
@@ -18,7 +18,7 @@
         /// </summary>
         public BrowserContext()
         {
-            this.Values.Headers = new Dictionary<string, IEnumerable<string>>();
+            this.Values.Headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase);
             this.Values.Protocol = string.Empty;
             this.Values.QueryString = string.Empty;
             this.Values.BodyString = string.Empty;


### PR DESCRIPTION
Changes the `Nancy.Testing.Browser` to have a default `user-agent` header, with the value of `Nancy.Testing.Browser` unless explicitly set by the test code.

First reported in #1992 