### PR TITLE
Fix TextResponse encoding

### DIFF
--- a/src/Nancy.Tests.Functional/Tests/BasicRouteInvocationsFixture.cs
+++ b/src/Nancy.Tests.Functional/Tests/BasicRouteInvocationsFixture.cs
@@ -22,7 +22,7 @@
 
             // Then
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal("text/html; charset=utf-8", response.ContentType);
+            Assert.Equal("text/plain; charset=utf-8", response.ContentType);
             Assert.Equal("Default get root", response.Body.AsString());
         }
 
@@ -46,7 +46,7 @@
 
             // Then
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal("text/html; charset=utf-8", response.ContentType);
+            Assert.Equal("text/plain; charset=utf-8", response.ContentType);
             Assert.Equal("Default delete root", response.Body.AsString());
         }
 
@@ -70,7 +70,7 @@
 
             // Then
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal("text/html; charset=utf-8", response.ContentType);
+            Assert.Equal("text/plain; charset=utf-8", response.ContentType);
             Assert.Equal("Default post root", response.Body.AsString());
         }
 
@@ -94,7 +94,7 @@
 
             // Then
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal("text/html; charset=utf-8", response.ContentType);
+            Assert.Equal("text/plain; charset=utf-8", response.ContentType);
             Assert.Equal("Default put root", response.Body.AsString());
         }
 
@@ -118,7 +118,7 @@
 
             // Then
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal("text/html; charset=utf-8", response.ContentType);
+            Assert.Equal("text/plain; charset=utf-8", response.ContentType);
             Assert.Equal(string.Empty, response.Body.AsString());
         }
 

--- a/src/Nancy.Tests.Functional/Tests/BasicRouteInvocationsFixture.cs
+++ b/src/Nancy.Tests.Functional/Tests/BasicRouteInvocationsFixture.cs
@@ -22,7 +22,7 @@
 
             // Then
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal("text/html", response.ContentType);
+            Assert.Equal("text/html; charset=utf-8", response.ContentType);
             Assert.Equal("Default get root", response.Body.AsString());
         }
 
@@ -46,7 +46,7 @@
 
             // Then
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal("text/html", response.ContentType);
+            Assert.Equal("text/html; charset=utf-8", response.ContentType);
             Assert.Equal("Default delete root", response.Body.AsString());
         }
 
@@ -70,7 +70,7 @@
 
             // Then
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal("text/html", response.ContentType);
+            Assert.Equal("text/html; charset=utf-8", response.ContentType);
             Assert.Equal("Default post root", response.Body.AsString());
         }
 
@@ -94,7 +94,7 @@
 
             // Then
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal("text/html", response.ContentType);
+            Assert.Equal("text/html; charset=utf-8", response.ContentType);
             Assert.Equal("Default put root", response.Body.AsString());
         }
 
@@ -118,7 +118,7 @@
 
             // Then
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal("text/html", response.ContentType);
+            Assert.Equal("text/html; charset=utf-8", response.ContentType);
             Assert.Equal(string.Empty, response.Body.AsString());
         }
 

--- a/src/Nancy.Tests/Unit/ResponseFixture.cs
+++ b/src/Nancy.Tests/Unit/ResponseFixture.cs
@@ -151,7 +151,7 @@
             Response response = value;
 
             // Then
-            response.ContentType.ShouldEqual("text/html");
+            response.ContentType.ShouldEqual("text/html; charset=utf-8");
         }
 
         [Fact]

--- a/src/Nancy.Tests/Unit/ResponseFixture.cs
+++ b/src/Nancy.Tests/Unit/ResponseFixture.cs
@@ -144,14 +144,14 @@
         }
 
         [Fact]
-        public void Should_set_content_type_to_text_html_when_implicitly_cast_from_string()
+        public void Should_set_content_type_to_text_plain_when_implicitly_cast_from_string()
         {
             // Given, When
             const string value = "test value";
             Response response = value;
 
             // Then
-            response.ContentType.ShouldEqual("text/html; charset=utf-8");
+            response.ContentType.ShouldEqual("text/plain; charset=utf-8");
         }
 
         [Fact]

--- a/src/Nancy.Tests/Unit/Responses/TextResponseFixture.cs
+++ b/src/Nancy.Tests/Unit/Responses/TextResponseFixture.cs
@@ -82,15 +82,14 @@
             response.Contents.Invoke(outputStream);
 
             // Then
-            response.ContentType.ShouldEqual("text/plain");
+            response.ContentType.ShouldEqual("text/plain; charset=utf-8");
         }
 
         [Fact]
         public void Should_override_content_type()
         {
             // Given
-            string text =
-                "sample text";
+            const string text = "sample text";
 
             var response =
                 new TextResponse(text, "text/cache-manifest");
@@ -101,7 +100,26 @@
             response.Contents.Invoke(outputStream);
 
             // Then
-            response.ContentType.ShouldEqual("text/cache-manifest");
+            response.ContentType.ShouldEqual("text/cache-manifest; charset=utf-8");
+        }
+
+        [Fact]
+        public void Should_include_webname_for_custom_encoding()
+        {
+            // Given
+            string text =
+                "sample text";
+
+            var response =
+                new TextResponse(text, encoding: Encoding.Unicode);
+
+            var outputStream = new MemoryStream();
+
+            // When
+            response.Contents.Invoke(outputStream);
+
+            // Then
+            response.ContentType.ShouldEqual("text/plain; charset=utf-16");
         }
     }
 }

--- a/src/Nancy.Tests/Unit/TextFormatterFixture.cs
+++ b/src/Nancy.Tests/Unit/TextFormatterFixture.cs
@@ -21,7 +21,7 @@
         [Fact]
         public void Should_return_a_response_with_content_type_text_plain()
         {
-            response.ContentType.ShouldEqual("text/plain");
+            response.ContentType.ShouldEqual("text/plain; charset=utf-8");
         }
 
         [Fact]
@@ -48,7 +48,7 @@
             using (var stream = new MemoryStream())
             {
                 response.Contents(stream);
-                response.ContentType.ShouldEqual("text/cache-manifest");
+                response.ContentType.ShouldEqual("text/cache-manifest; charset=utf-8");
             }
         }
     }

--- a/src/Nancy/FormatterExtensions.cs
+++ b/src/Nancy/FormatterExtensions.cs
@@ -3,40 +3,99 @@ namespace Nancy
     using System;
     using System.IO;
     using System.Text;
-    using Nancy.Extensions;
-    using Nancy.Responses;
+    using Extensions;
+    using Responses;
 
+    /// <summary>
+    /// Various extensions to return different responses form a <see cref="NancyModule"/>.
+    /// </summary>
     public static class FormatterExtensions
     {
         private static ISerializer jsonSerializer;
 
         private static ISerializer xmlSerializer;
 
+        /// <summary>
+        /// Sends the file at <paramref name="applicationRelativeFilePath"/> to the
+        /// agent, using <paramref name="contentType"/> for the <c>Content-Type</c> header.
+        /// </summary>
+        /// <param name="formatter">The formatter.</param>
+        /// <param name="applicationRelativeFilePath">The application relative file path.</param>
+        /// <param name="contentType">Value for the <c>Content-Type</c> header.</param>
         public static Response AsFile(this IResponseFormatter formatter, string applicationRelativeFilePath, string contentType)
         {
             return new GenericFileResponse(applicationRelativeFilePath, contentType);
         }
 
+        /// <summary>
+        /// Sends the file at <paramref name="applicationRelativeFilePath"/> to the
+        /// agent, using the file extension and <see cref="MimeTypes.GetMimeType"/>
+        /// to determine the <c>Content-Type</c> header.
+        /// </summary>
+        /// <param name="formatter">The formatter.</param>
+        /// <param name="applicationRelativeFilePath">The application relative file path.</param>
         public static Response AsFile(this IResponseFormatter formatter, string applicationRelativeFilePath)
         {
             return new GenericFileResponse(applicationRelativeFilePath);
         }
 
+        /// <summary>
+        /// Returns the <paramref name="contents"/> string to the
+        /// agent, using <paramref name="contentType"/> and <paramref name="encoding"/>
+        /// for the <c>Content-Type</c> header.
+        /// </summary>
+        /// <param name="formatter">The formatter.</param>
+        /// <param name="contents">The contents of the response.</param>
+        /// <param name="contentType">Value for the <c>Content-Type</c> header.</param>
+        /// <param name="encoding">The encoding to use.</param>
         public static Response AsText(this IResponseFormatter formatter, string contents, string contentType, Encoding encoding)
         {
             return new TextResponse(contents, contentType, encoding);
         }
 
+        /// <summary>
+        /// Returns the <paramref name="contents"/> string to the
+        /// agent, using <c>text/plain</c> and <paramref name="encoding"/>
+        /// for the <c>Content-Type</c> header.
+        /// </summary>
+        /// <param name="formatter">The formatter.</param>
+        /// <param name="contents">The contents of the response.</param>
+        /// <param name="encoding">The encoding to use.</param>
+        public static Response AsText(this IResponseFormatter formatter, string contents, Encoding encoding)
+        {
+            return new TextResponse(contents, encoding: encoding);
+        }
+
+        /// <summary>
+        /// Returns the <paramref name="contents"/> string to the
+        /// agent, using <paramref name="contentType"/> for the <c>Content-Type</c> header.
+        /// </summary>
+        /// <param name="formatter">The formatter.</param>
+        /// <param name="contents">The contents of the response.</param>
+        /// <param name="contentType">Value for the <c>Content-Type</c> header.</param>
         public static Response AsText(this IResponseFormatter formatter, string contents, string contentType)
         {
             return new TextResponse(contents, contentType);
         }
 
+        /// <summary>
+        /// Returns the <paramref name="contents"/> string as a <c>text/plain</c> response to the agent.
+        /// </summary>
+        /// <param name="formatter">The formatter.</param>
+        /// <param name="contents">The contents of the response.</param>
         public static Response AsText(this IResponseFormatter formatter, string contents)
         {
             return new TextResponse(contents);
         }
 
+        /// <summary>
+        /// Serializes the <paramref name="model"/> to JSON and returns it to the
+        /// agent, optionally using the <paramref name="statusCode"/>.
+        /// </summary>
+        /// <typeparam name="TModel">The type of the model.</typeparam>
+        /// <param name="formatter">The formatter.</param>
+        /// <param name="model">The model to serialize.</param>
+        /// <param name="statusCode">The HTTP status code. Defaults to <see cref="HttpStatusCode.OK"/>.</param>
         public static Response AsJson<TModel>(this IResponseFormatter formatter, TModel model, HttpStatusCode statusCode = HttpStatusCode.OK)
         {
             var serializer = jsonSerializer ?? (jsonSerializer = formatter.SerializerFactory.GetSerializer("application/json"));
@@ -47,23 +106,51 @@ namespace Nancy
             };
         }
 
+        /// <summary>
+        /// Returns a redirect response to the agent.
+        /// </summary>
+        /// <param name="formatter">The formatter.</param>
+        /// <param name="location">The location to redirect to.</param>
+        /// <param name="type">The redirect type. See <see cref="RedirectResponse.RedirectType"/>.</param>
         public static Response AsRedirect(this IResponseFormatter formatter, string location, RedirectResponse.RedirectType type = RedirectResponse.RedirectType.SeeOther)
         {
             return new RedirectResponse(formatter.Context.ToFullPath(location), type);
         }
 
-        public static Response AsXml<TModel>(this IResponseFormatter formatter, TModel model)
+        /// <summary>
+        /// Serializes the <paramref name="model"/> to XML and returns it to the
+        /// agent, optionally using the <paramref name="statusCode"/>.
+        /// </summary>
+        /// <typeparam name="TModel">The type of the model.</typeparam>
+        /// <param name="formatter">The formatter.</param>
+        /// <param name="model">The model to serialize.</param>
+        /// <param name="statusCode">The HTTP status code. Defaults to <see cref="HttpStatusCode.OK"/>.</param>
+        public static Response AsXml<TModel>(this IResponseFormatter formatter, TModel model, HttpStatusCode statusCode = HttpStatusCode.OK)
         {
             var serializer = xmlSerializer ?? (xmlSerializer = formatter.SerializerFactory.GetSerializer("application/xml"));
 
             return new XmlResponse<TModel>(model, serializer);
         }
 
+        /// <summary>
+        /// Writes the data from the given <paramref name="stream"/> to the
+        /// agent, using <paramref name="contentType"/> for the <c>Content-Type</c> header.
+        /// </summary>
+        /// <param name="formatter">The formatter.</param>
+        /// <param name="stream">The stream to copy from.</param>
+        /// <param name="contentType">Value for the <c>Content-Type</c> header.</param>
         public static Response FromStream(this IResponseFormatter formatter, Stream stream, string contentType)
         {
             return new StreamResponse(() => stream, contentType);
         }
 
+        /// <summary>
+        /// Invokes the given <paramref name="streamDelegate"/> to write the stream data to the
+        /// agent, using <paramref name="contentType"/> for the <c>Content-Type</c> header.
+        /// </summary>
+        /// <param name="formatter">The formatter.</param>
+        /// <param name="streamDelegate">A delegate returning a stream to copy from.</param>
+        /// <param name="contentType">Value for the <c>Content-Type</c> header.</param>
         public static Response FromStream(this IResponseFormatter formatter, Func<Stream> streamDelegate, string contentType)
         {
             return new StreamResponse(streamDelegate, contentType);

--- a/src/Nancy/FormatterExtensions.cs
+++ b/src/Nancy/FormatterExtensions.cs
@@ -37,11 +37,6 @@ namespace Nancy
             return new TextResponse(contents);
         }
 
-        public static Response AsImage(this IResponseFormatter formatter, string applicationRelativeFilePath)
-        {
-            return AsFile(formatter, applicationRelativeFilePath);
-        }
-
         public static Response AsJson<TModel>(this IResponseFormatter formatter, TModel model, HttpStatusCode statusCode = HttpStatusCode.OK)
         {
             var serializer = jsonSerializer ?? (jsonSerializer = formatter.SerializerFactory.GetSerializer("application/json"));

--- a/src/Nancy/FormatterExtensions.cs
+++ b/src/Nancy/FormatterExtensions.cs
@@ -2,7 +2,7 @@ namespace Nancy
 {
     using System;
     using System.IO;
-
+    using System.Text;
     using Nancy.Extensions;
     using Nancy.Responses;
 
@@ -20,6 +20,11 @@ namespace Nancy
         public static Response AsFile(this IResponseFormatter formatter, string applicationRelativeFilePath)
         {
             return new GenericFileResponse(applicationRelativeFilePath);
+        }
+
+        public static Response AsText(this IResponseFormatter formatter, string contents, string contentType, Encoding encoding)
+        {
+            return new TextResponse(contents, contentType, encoding);
         }
 
         public static Response AsText(this IResponseFormatter formatter, string contents, string contentType)

--- a/src/Nancy/Response.cs
+++ b/src/Nancy/Response.cs
@@ -9,6 +9,7 @@ namespace Nancy
 
     using Nancy.Cookies;
     using Nancy.Helpers;
+    using Nancy.Responses;
 
     /// <summary>
     /// Encapsulates HTTP-response information from an Nancy operation.
@@ -118,7 +119,7 @@ namespace Nancy
         /// <returns>A <see cref="Response"/> instance.</returns>
         public static implicit operator Response(string contents)
         {
-            return new Response { Contents = GetStringContents(contents) };
+            return new TextResponse(contents);
         }
 
         /// <summary>

--- a/src/Nancy/Responses/TextResponse.cs
+++ b/src/Nancy/Responses/TextResponse.cs
@@ -10,29 +10,36 @@
     /// </summary>
     public class TextResponse : Response
     {
+        private const string TextPlainContentType = "text/plain";
+
         /// <summary>
         /// Creates a new instance of the TextResponse class
         /// </summary>
         /// <param name="contents">Text content - defaults to empty if null</param>
         /// <param name="contentType">Content Type - defaults to text/plain</param>
         /// <param name="encoding">String encoding - UTF8 if null</param>
-        public TextResponse(string contents, string contentType = "text/plain", Encoding encoding = null)
+        public TextResponse(string contents, string contentType = null, Encoding encoding = null)
         {
             if (encoding == null)
             {
                 encoding = Encoding.UTF8;
             }
 
-            this.ContentType = contentType;
+            if (string.IsNullOrEmpty(contentType))
+            {
+                contentType = TextPlainContentType;
+            }
+
+            this.ContentType = GetContentType(contentType, encoding);
             this.StatusCode = HttpStatusCode.OK;
 
             if (contents != null)
             {
                 this.Contents = stream =>
-                                {
-                                    var data = encoding.GetBytes(contents);
-                                    stream.Write(data, 0, data.Length);
-                                };
+                {
+                    var data = encoding.GetBytes(contents);
+                    stream.Write(data, 0, data.Length);
+                };
             }
         }
 
@@ -51,7 +58,7 @@
                 encoding = Encoding.UTF8;
             }
 
-            this.ContentType = "text/plain";
+            this.ContentType = GetContentType(TextPlainContentType, encoding);
             this.StatusCode = statusCode;
 
             if (contents != null)
@@ -75,6 +82,13 @@
                     this.Cookies.Add(nancyCookie);
                 }
             }
+        }
+
+        private static string GetContentType(string contentType, Encoding encoding)
+        {
+            return !contentType.Contains("charset") 
+                ? string.Concat(contentType, "; charset=", encoding.WebName)
+                : contentType;
         }
     }
 }


### PR DESCRIPTION
Fixes #2018 

### Breaking Change

This is a breaking change because it adds `; charset={encoding}` to the `Content-Type` header of `TextResponse`.
It also changes `Response`'s implicit operator from `string` to use `TextResponse`, which in turn changes the `Content-Type` from `text/html` to `text/plain`.

This means that if you have tests currently asserting on, or anything else relying on the format of the `ContentType` property of a `TextResponse`, it might break.

### Fix

The fix is trivial; change `text/html` to `text/plain; charset=utf-8` (or if you use other encodings, use it's `WebName` property, i.e. `Encoding.Unicode.WebName`, or simply `utf-16`).