### PR TITLE
Preventing user code from closing the response stream while testing

### DIFF
--- a/src/Nancy.Testing/BrowserResponseBodyWrapper.cs
+++ b/src/Nancy.Testing/BrowserResponseBodyWrapper.cs
@@ -3,6 +3,7 @@ namespace Nancy.Testing
     using System.Collections;
     using System.Collections.Generic;
     using System.IO;
+    using Nancy.IO;
 
     /// <summary>
     /// Wrapper for the HTTP response body that is used by the <see cref="BrowserResponse"/> class.
@@ -13,24 +14,35 @@ namespace Nancy.Testing
         private readonly string contentType;
         private DocumentWrapper responseDocument;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BrowserResponseBodyWrapper"/> class.
+        /// </summary>
+        /// <param name="response">The <see cref="Response"/> to wrap.</param>
         public BrowserResponseBodyWrapper(Response response)
         {
             var contentStream = GetContentStream(response);
 
-            this.responseBytes = contentStream.ToArray();
+            this.responseBytes = ((MemoryStream)contentStream.BaseStream).ToArray();
             this.contentType = response.ContentType;
         }
 
-        internal string ContentType
+        /// <summary>
+        /// Gets the content type of the wrapped response.
+        /// </summary>
+        /// <returns>A string containing the content type.</returns>
+        public string ContentType
         {
             get { return this.contentType; }
         }
 
-        private static MemoryStream GetContentStream(Response response)
+        private static UnclosableStreamWrapper GetContentStream(Response response)
         {
-            var contentsStream = new MemoryStream();
+            var contentsStream = 
+                new UnclosableStreamWrapper(new MemoryStream());
+            
             response.Contents.Invoke(contentsStream);
             contentsStream.Position = 0;
+            
             return contentsStream;
         }
 

--- a/src/Nancy.Testing/BrowserResponseBodyWrapper.cs
+++ b/src/Nancy.Testing/BrowserResponseBodyWrapper.cs
@@ -22,7 +22,7 @@ namespace Nancy.Testing
         {
             var contentStream = GetContentStream(response);
 
-            this.responseBytes = ((MemoryStream)contentStream.BaseStream).ToArray();
+            this.responseBytes = contentStream.ToArray();
             this.contentType = response.ContentType;
         }
 
@@ -35,14 +35,15 @@ namespace Nancy.Testing
             get { return this.contentType; }
         }
 
-        private static UnclosableStreamWrapper GetContentStream(Response response)
+        private static MemoryStream GetContentStream(Response response)
         {
-            var contentsStream = 
-                new UnclosableStreamWrapper(new MemoryStream());
-            
-            response.Contents.Invoke(contentsStream);
+            var contentsStream = new MemoryStream();
+
+            var unclosableStream = new UnclosableStreamWrapper(contentsStream);
+
+            response.Contents.Invoke(unclosableStream);
             contentsStream.Position = 0;
-            
+
             return contentsStream;
         }
 


### PR DESCRIPTION
Wraps the underlaying `MemoryStream`, in `BrowserResponseBodyWrapper`, in an `UnclosableStreamWrapper` to prevent users from closing the underlaying stream by mistake (hint: you should never close a stream you do not own) :-D

Related to #1837 and #2011 