### PR TITLE
Changed the registration key for IDiagnosticsProvider implementations

### DIFF
--- a/src/Nancy/Diagnostics/DiagnosticsModuleCatalog.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsModuleCatalog.cs
@@ -55,7 +55,12 @@ namespace Nancy.Diagnostics
 
             foreach (var diagnosticsProvider in providers)
             {
-                diagContainer.Register<IDiagnosticsProvider>(diagnosticsProvider, diagnosticsProvider.GetType().FullName);
+                var key = string.Concat(
+                    diagnosticsProvider.GetType().FullName,
+                    "_",
+                    diagnosticsProvider.DiagnosticObject.GetType().FullName);
+                
+                diagContainer.Register<IDiagnosticsProvider>(diagnosticsProvider, key);
             }
 
             foreach (var moduleType in AppDomainAssemblyTypeScanner.TypesOf<DiagnosticModule>().ToArray())


### PR DESCRIPTION
Changed how `IDiagnosticsProvider` instances are registered in the container by the `DiagnosticsModuleCatalog`. It now created a composite key which includes the type of the diagnostics object as well. 

Background can be found in #1830