### PR TITLE
Updated string comparison methods

### DIFF
--- a/src/Nancy.Demo.Authentication.Forms.TestingDemo/LoginFixture.cs
+++ b/src/Nancy.Demo.Authentication.Forms.TestingDemo/LoginFixture.cs
@@ -41,7 +41,7 @@ namespace Nancy.Demo.Authentication.Forms.TestingDemo
             response.Body["#errorBox"]
                 .ShouldExistOnce()
                 .And.ShouldBeOfClass("floatingError")
-                .And.ShouldContain("invalid", StringComparison.InvariantCultureIgnoreCase);
+                .And.ShouldContain("invalid", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Nancy.Demo.Authentication/AuthenticationBootstrapper.cs
+++ b/src/Nancy.Demo.Authentication/AuthenticationBootstrapper.cs
@@ -54,7 +54,7 @@ namespace Nancy.Demo.Authentication
             var claims = new List<string>();
 
             // Only bob can have access to SuperSecure
-            if (String.Equals(userName, "bob", StringComparison.InvariantCultureIgnoreCase))
+            if (String.Equals(userName, "bob", StringComparison.OrdinalIgnoreCase))
             {
                 claims.Add("SuperSecure");
             }

--- a/src/Nancy.Hosting.Self/UriExtensions.cs
+++ b/src/Nancy.Hosting.Self/UriExtensions.cs
@@ -12,7 +12,7 @@ namespace Nancy.Hosting.Self
         public static bool IsCaseInsensitiveBaseOf(this Uri source, Uri value)
         {
             var uriComponents = source.Host == "localhost" ? (UriComponents.Port | UriComponents.Scheme) : (UriComponents.HostAndPort | UriComponents.Scheme);
-            if (Uri.Compare(source, value, uriComponents, UriFormat.Unescaped, StringComparison.InvariantCultureIgnoreCase) != 0)
+            if (Uri.Compare(source, value, uriComponents, UriFormat.Unescaped, StringComparison.OrdinalIgnoreCase) != 0)
             {
                 return false;
             }
@@ -40,7 +40,7 @@ namespace Nancy.Hosting.Self
 
         private static bool SegmentEquals(string segment1, string segment2)
         {
-            return String.Equals(AppendSlashIfNeeded(segment1), AppendSlashIfNeeded(segment2), StringComparison.InvariantCultureIgnoreCase);
+            return String.Equals(AppendSlashIfNeeded(segment1), AppendSlashIfNeeded(segment2), StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool ZipCompare(this IEnumerable<string> source1, IEnumerable<string> source2, Func<string, string, bool> comparison)

--- a/src/Nancy.Testing.Tests/AssertExtensionsTests.cs
+++ b/src/Nancy.Testing.Tests/AssertExtensionsTests.cs
@@ -223,7 +223,7 @@ namespace Nancy.Testing.Tests
             var htmlNode = this.query["#testId"].First();
 
             // When
-            var result = Record.Exception(() => htmlNode.ShouldContain("test", StringComparison.InvariantCultureIgnoreCase));
+            var result = Record.Exception(() => htmlNode.ShouldContain("test", StringComparison.OrdinalIgnoreCase));
 
             // Then
             Assert.Null(result);

--- a/src/Nancy.Testing/AssertExtensions.cs
+++ b/src/Nancy.Testing/AssertExtensions.cs
@@ -91,7 +91,7 @@ namespace Nancy.Testing
         /// <summary>
         /// Asserts that a node contains the specified text
         /// </summary>
-        public static AndConnector<NodeWrapper> ShouldContain(this NodeWrapper node, string contents, StringComparison comparisonType = StringComparison.InvariantCulture)
+        public static AndConnector<NodeWrapper> ShouldContain(this NodeWrapper node, string contents, StringComparison comparisonType = StringComparison.Ordinal)
         {
             Asserts.Contains(contents, node.InnerText, comparisonType);
 
@@ -102,7 +102,7 @@ namespace Nancy.Testing
         /// Asserts that every node contains the specified text
         /// </summary>
         [Obsolete("This method has a ambiguous name and will be removed. Use AllShouldContain instead.")]
-        public static AndConnector<QueryWrapper> ShouldContain(this QueryWrapper query, string contents, StringComparison comparisonType = StringComparison.InvariantCulture)
+        public static AndConnector<QueryWrapper> ShouldContain(this QueryWrapper query, string contents, StringComparison comparisonType = StringComparison.Ordinal)
         {
             return query.AllShouldContain(contents, comparisonType);
         }
@@ -110,7 +110,7 @@ namespace Nancy.Testing
         /// <summary>
         /// Asserts that every node contains the specified text
         /// </summary>
-        public static AndConnector<QueryWrapper> AllShouldContain(this QueryWrapper query, string contents, StringComparison comparisonType = StringComparison.InvariantCulture)
+        public static AndConnector<QueryWrapper> AllShouldContain(this QueryWrapper query, string contents, StringComparison comparisonType = StringComparison.Ordinal)
         {
             query.ShouldExist();
 
@@ -122,7 +122,7 @@ namespace Nancy.Testing
         /// <summary>
         /// Asserts that any node contains the specified text
         /// </summary>
-        public static AndConnector<QueryWrapper> AnyShouldContain(this QueryWrapper query, string contents, StringComparison comparisonType = StringComparison.InvariantCulture)
+        public static AndConnector<QueryWrapper> AnyShouldContain(this QueryWrapper query, string contents, StringComparison comparisonType = StringComparison.Ordinal)
         {
             query.ShouldExist();
 
@@ -144,7 +144,7 @@ namespace Nancy.Testing
         /// <summary>
         /// Asserts that an element has a specific attribute with a specified value
         /// </summary>
-        public static AndConnector<NodeWrapper> ShouldContainAttribute(this NodeWrapper node, string name, string value, StringComparison comparisonType = StringComparison.InvariantCulture)
+        public static AndConnector<NodeWrapper> ShouldContainAttribute(this NodeWrapper node, string name, string value, StringComparison comparisonType = StringComparison.Ordinal)
         {
             Asserts.Equal(value, node.Attributes[name], comparisonType);
 
@@ -169,7 +169,7 @@ namespace Nancy.Testing
         /// <summary>
         /// Asserts that an element has a specific attribute with a specified value
         /// </summary>
-        public static AndConnector<QueryWrapper> ShouldContainAttribute(this QueryWrapper query, string name, string value, StringComparison comparisonType = StringComparison.InvariantCulture)
+        public static AndConnector<QueryWrapper> ShouldContainAttribute(this QueryWrapper query, string name, string value, StringComparison comparisonType = StringComparison.Ordinal)
         {
             query.ShouldExist();
 

--- a/src/Nancy.Testing/Asserts.cs
+++ b/src/Nancy.Testing/Asserts.cs
@@ -61,7 +61,7 @@
             }
         }
 
-        public static void Equal(string expected, string actual, StringComparison comparisonType = StringComparison.InvariantCulture)
+        public static void Equal(string expected, string actual, StringComparison comparisonType = StringComparison.Ordinal)
         {
             if (!String.Equals(expected, actual, comparisonType))
             {

--- a/src/Nancy.Testing/BrowserResponseExtensions.cs
+++ b/src/Nancy.Testing/BrowserResponseExtensions.cs
@@ -15,8 +15,8 @@ namespace Nancy.Testing
         /// </summary>
         /// <param name="response">The <see cref="BrowserResponse"/> that the assert should be made on.</param>
         /// <param name="location">The location that should have been redirected to.</param>
-        /// <param name="stringComparer">The string comparer that should be used by the assertion. The default value is <see cref="StringComparison.InvariantCulture"/>.</param>
-        public static void ShouldHaveRedirectedTo(this BrowserResponse response, string location, StringComparison stringComparer = StringComparison.InvariantCulture)
+        /// <param name="stringComparer">The string comparer that should be used by the assertion. The default value is <see cref="StringComparison.Ordinal"/>.</param>
+        public static void ShouldHaveRedirectedTo(this BrowserResponse response, string location, StringComparison stringComparer = StringComparison.Ordinal)
         {
             var validRedirectStatuses = new[]
             {

--- a/src/Nancy.Tests/Unit/RequestFixture.cs
+++ b/src/Nancy.Tests/Unit/RequestFixture.cs
@@ -309,7 +309,7 @@ namespace Nancy.Tests.Unit
             // Given
             StaticConfiguration.CaseSensitive = false;
             var memory =
-                new MemoryStream(BuildMultipartFormValues(new Dictionary<string, string>(StringComparer.InvariantCulture)
+                new MemoryStream(BuildMultipartFormValues(new Dictionary<string, string>(StringComparer.Ordinal)
                 {
                     { "key", "value" },
                     { "KEY", "VALUE" }
@@ -335,7 +335,7 @@ namespace Nancy.Tests.Unit
             // Given
             StaticConfiguration.CaseSensitive = true;
             var memory =
-                new MemoryStream(BuildMultipartFormValues(new Dictionary<string, string>(StringComparer.InvariantCulture)
+                new MemoryStream(BuildMultipartFormValues(new Dictionary<string, string>(StringComparer.Ordinal)
                 {
                     { "key", "value" },
                     { "KEY", "VALUE" }

--- a/src/Nancy.ViewEngines.DotLiquid/DynamicDrop.cs
+++ b/src/Nancy.ViewEngines.DotLiquid/DynamicDrop.cs
@@ -81,7 +81,7 @@ namespace Nancy.ViewEngines.DotLiquid
             }
 
             return model.GetType().Equals(typeof(ExpandoObject))
-                ? new Dictionary<string, object>(model, StaticConfiguration.CaseSensitive ? StringComparer.InvariantCulture : StringComparer.InvariantCultureIgnoreCase)
+                ? new Dictionary<string, object>(model, StaticConfiguration.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase)
                 : model;
         }
     }

--- a/src/Nancy/AsyncNamedPipelineBase.cs
+++ b/src/Nancy/AsyncNamedPipelineBase.cs
@@ -217,7 +217,7 @@
         public virtual void InsertBefore(string name, PipelineItem<TAsyncDelegate> item)
         {
             var existingIndex =
-                this.pipelineItems.FindIndex(i => String.Equals(name, i.Name, StringComparison.InvariantCulture));
+                this.pipelineItems.FindIndex(i => String.Equals(name, i.Name, StringComparison.Ordinal));
 
             if (existingIndex == -1)
             {
@@ -269,7 +269,7 @@
         public virtual void InsertAfter(string name, PipelineItem<TAsyncDelegate> item)
         {
             var existingIndex =
-                this.pipelineItems.FindIndex(i => String.Equals(name, i.Name, StringComparison.InvariantCulture));
+                this.pipelineItems.FindIndex(i => String.Equals(name, i.Name, StringComparison.Ordinal));
 
             if (existingIndex == -1)
             {
@@ -312,7 +312,7 @@
             }
 
             var existingIndex =
-                this.pipelineItems.FindIndex(i => String.Equals(name, i.Name, StringComparison.InvariantCulture));
+                this.pipelineItems.FindIndex(i => String.Equals(name, i.Name, StringComparison.Ordinal));
 
             if (existingIndex != -1)
             {

--- a/src/Nancy/Bootstrapper/AppDomainAssemblyTypeScanner.cs
+++ b/src/Nancy/Bootstrapper/AppDomainAssemblyTypeScanner.cs
@@ -172,7 +172,7 @@ namespace Nancy.Bootstrapper
 
             var unloadedAssemblies =
                 Directory.GetFiles(containingDirectory, wildcardFilename).Where(
-                    f => !existingAssemblyPaths.Contains(f, StringComparer.InvariantCultureIgnoreCase)).ToArray();
+                    f => !existingAssemblyPaths.Contains(f, StringComparer.OrdinalIgnoreCase)).ToArray();
 
 
             foreach (var unloadedAssembly in unloadedAssemblies)
@@ -228,7 +228,7 @@ namespace Nancy.Bootstrapper
             {
                 var unloadedAssemblies = Directory
                     .GetFiles(directory, "*.dll")
-                    .Where(f => !existingAssemblyPaths.Contains(f, StringComparer.InvariantCultureIgnoreCase)).ToArray();
+                    .Where(f => !existingAssemblyPaths.Contains(f, StringComparer.OrdinalIgnoreCase)).ToArray();
 
                 foreach (var unloadedAssembly in unloadedAssemblies)
                 {

--- a/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
+++ b/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
@@ -288,7 +288,7 @@
                             return null;
                         }
 
-                        if (String.Equals(ctx.Request.Path, "/favicon.ico", StringComparison.InvariantCultureIgnoreCase))
+                        if (String.Equals(ctx.Request.Path, "/favicon.ico", StringComparison.OrdinalIgnoreCase))
                         {
                             var response = new Response
                                 {

--- a/src/Nancy/Conventions/BuiltInAcceptHeaderCoercions.cs
+++ b/src/Nancy/Conventions/BuiltInAcceptHeaderCoercions.cs
@@ -54,7 +54,7 @@ namespace Nancy.Conventions
         {
             var current = currentAcceptHeaders as Tuple<string, decimal>[] ?? currentAcceptHeaders.ToArray();
 
-            var html = current.FirstOrDefault(h => string.Equals(h.Item1, HtmlContentType, StringComparison.InvariantCultureIgnoreCase) && h.Item2 < 1.0m);
+            var html = current.FirstOrDefault(h => string.Equals(h.Item1, HtmlContentType, StringComparison.OrdinalIgnoreCase) && h.Item2 < 1.0m);
 
             if (html == null)
             {
@@ -84,7 +84,7 @@ namespace Nancy.Conventions
             var maxScore = current.First().Item2;
 
             if (IsPotentiallyBrokenBrowser(context.Request.Headers.UserAgent)
-                && !current.Any(h => h.Item2 == maxScore && string.Equals(HtmlContentType, h.Item1, StringComparison.InvariantCultureIgnoreCase)))
+                && !current.Any(h => h.Item2 == maxScore && string.Equals(HtmlContentType, h.Item1, StringComparison.OrdinalIgnoreCase)))
             {
                 return true;
             }

--- a/src/Nancy/DefaultNancyBootstrapper.cs
+++ b/src/Nancy/DefaultNancyBootstrapper.cs
@@ -19,21 +19,21 @@ namespace Nancy
         /// </summary>
         public static IEnumerable<Func<Assembly, bool>> DefaultAutoRegisterIgnoredAssemblies = new Func<Assembly, bool>[]
             {
-                asm => asm.FullName.StartsWith("Microsoft.", StringComparison.InvariantCulture),
-                asm => asm.FullName.StartsWith("System.", StringComparison.InvariantCulture),
-                asm => asm.FullName.StartsWith("System,", StringComparison.InvariantCulture),
-                asm => asm.FullName.StartsWith("CR_ExtUnitTest", StringComparison.InvariantCulture),
-                asm => asm.FullName.StartsWith("mscorlib,", StringComparison.InvariantCulture),
-                asm => asm.FullName.StartsWith("CR_VSTest", StringComparison.InvariantCulture),
-                asm => asm.FullName.StartsWith("DevExpress.CodeRush", StringComparison.InvariantCulture),
-                asm => asm.FullName.StartsWith("IronPython", StringComparison.InvariantCulture),
-                asm => asm.FullName.StartsWith("IronRuby", StringComparison.InvariantCulture),
-                asm => asm.FullName.StartsWith("xunit", StringComparison.InvariantCulture),
-                asm => asm.FullName.StartsWith("Nancy.Testing", StringComparison.InvariantCulture),
-                asm => asm.FullName.StartsWith("MonoDevelop.NUnit", StringComparison.InvariantCulture),
-                asm => asm.FullName.StartsWith("SMDiagnostics", StringComparison.InvariantCulture),
-                asm => asm.FullName.StartsWith("CppCodeProvider", StringComparison.InvariantCulture),
-                asm => asm.FullName.StartsWith("WebDev.WebHost40", StringComparison.InvariantCulture),
+                asm => asm.FullName.StartsWith("Microsoft.", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("System.", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("System,", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("CR_ExtUnitTest", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("mscorlib,", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("CR_VSTest", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("DevExpress.CodeRush", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("IronPython", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("IronRuby", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("xunit", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("Nancy.Testing", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("MonoDevelop.NUnit", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("SMDiagnostics", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("CppCodeProvider", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("WebDev.WebHost40", StringComparison.Ordinal),
             };
 
         /// <summary>

--- a/src/Nancy/DynamicDictionary.cs
+++ b/src/Nancy/DynamicDictionary.cs
@@ -11,7 +11,7 @@
     public class DynamicDictionary : DynamicObject, IEquatable<DynamicDictionary>, IHideObjectMembers, IEnumerable<string>, IDictionary<string, object>
     {
         private readonly IDictionary<string, dynamic> dictionary =
-            new Dictionary<string, dynamic>(StaticConfiguration.CaseSensitive ? StringComparer.InvariantCulture : StringComparer.InvariantCultureIgnoreCase);
+            new Dictionary<string, dynamic>(StaticConfiguration.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
 
 
         /// <summary>

--- a/src/Nancy/Extensions/CollectionExtensions.cs
+++ b/src/Nancy/Extensions/CollectionExtensions.cs
@@ -48,7 +48,7 @@
         public static IDictionary<string, string> Merge(this IEnumerable<IDictionary<string, string>> dictionaries)
         {
             var output =
-                new Dictionary<string, string>(StaticConfiguration.CaseSensitive ? StringComparer.InvariantCulture : StringComparer.InvariantCultureIgnoreCase);
+                new Dictionary<string, string>(StaticConfiguration.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
 
             foreach (var dictionary in dictionaries.Where(d => d != null))
             {

--- a/src/Nancy/Helpers/HttpUtility.cs
+++ b/src/Nancy/Helpers/HttpUtility.cs
@@ -48,7 +48,7 @@ namespace Nancy.Helpers
             }
 
             public HttpQSCollection(bool caseSensitive)
-                : base(caseSensitive ? StringComparer.InvariantCulture : StringComparer.InvariantCultureIgnoreCase)
+                : base(caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase)
             {
             }
 

--- a/src/Nancy/HttpMultipartBoundary.cs
+++ b/src/Nancy/HttpMultipartBoundary.cs
@@ -67,7 +67,7 @@ namespace Nancy
                     this.Filename = Regex.Match(header, @"filename=""?(?<filename>[^\""]*)", RegexOptions.IgnoreCase).Groups["filename"].Value;
                 }
 
-                if (header.StartsWith("Content-Type", StringComparison.InvariantCultureIgnoreCase))
+                if (header.StartsWith("Content-Type", StringComparison.OrdinalIgnoreCase))
                 {
                     this.ContentType = header.Split(new[] { ' ' }).Last().Trim();
                 }

--- a/src/Nancy/Json/Json.cs
+++ b/src/Nancy/Json/Json.cs
@@ -117,11 +117,11 @@ namespace Nancy.Json
 
             var contentMimeType = contentType.Split(';')[0];
 
-            return contentMimeType.Equals("application/json", StringComparison.InvariantCultureIgnoreCase) ||
-                   contentMimeType.StartsWith("application/json-", StringComparison.InvariantCultureIgnoreCase) ||
-                   contentMimeType.Equals("text/json", StringComparison.InvariantCultureIgnoreCase) ||
-                  (contentMimeType.StartsWith("application/vnd", StringComparison.InvariantCultureIgnoreCase) &&
-                   contentMimeType.EndsWith("+json", StringComparison.InvariantCultureIgnoreCase));
+            return contentMimeType.Equals("application/json", StringComparison.OrdinalIgnoreCase) ||
+                   contentMimeType.StartsWith("application/json-", StringComparison.OrdinalIgnoreCase) ||
+                   contentMimeType.Equals("text/json", StringComparison.OrdinalIgnoreCase) ||
+                  (contentMimeType.StartsWith("application/vnd", StringComparison.OrdinalIgnoreCase) &&
+                   contentMimeType.EndsWith("+json", StringComparison.OrdinalIgnoreCase));
         }
 	}
 }

--- a/src/Nancy/Localization/ResourceBasedTextResource.cs
+++ b/src/Nancy/Localization/ResourceBasedTextResource.cs
@@ -83,7 +83,7 @@ namespace Nancy.Localization
         private static Tuple<string, string> GetKeyComponents(string key)
         {
             var index =
-                key.LastIndexOf(".", StringComparison.InvariantCulture);
+                key.LastIndexOf(".", StringComparison.Ordinal);
 
             if (index == -1)
             {

--- a/src/Nancy/ModelBinding/DefaultBinder.cs
+++ b/src/Nancy/ModelBinding/DefaultBinder.cs
@@ -408,7 +408,7 @@ namespace Nancy.ModelBinding
 
         private static IEnumerable<BindingMemberInfo> GetBindingMembers(Type modelType, Type genericType, IEnumerable<string> blackList)
         {
-            var blackListHash = new HashSet<string>(blackList, StringComparer.InvariantCulture);
+            var blackListHash = new HashSet<string>(blackList, StringComparer.Ordinal);
 
             return BindingMemberInfo.Collect(genericType ?? modelType)
                 .Where(member => !blackListHash.Contains(member.Name));

--- a/src/Nancy/ModelBinding/DefaultBodyDeserializers/XmlBodyDeserializer.cs
+++ b/src/Nancy/ModelBinding/DefaultBodyDeserializers/XmlBodyDeserializer.cs
@@ -24,10 +24,10 @@ namespace Nancy.ModelBinding.DefaultBodyDeserializers
 
             var contentMimeType = contentType.Split(';')[0];
 
-            return contentMimeType.Equals("application/xml", StringComparison.InvariantCultureIgnoreCase) ||
-                   contentMimeType.Equals("text/xml", StringComparison.InvariantCultureIgnoreCase) ||
-                  (contentMimeType.StartsWith("application/vnd", StringComparison.InvariantCultureIgnoreCase) &&
-                   contentMimeType.EndsWith("+xml", StringComparison.InvariantCultureIgnoreCase));
+            return contentMimeType.Equals("application/xml", StringComparison.OrdinalIgnoreCase) ||
+                   contentMimeType.Equals("text/xml", StringComparison.OrdinalIgnoreCase) ||
+                  (contentMimeType.StartsWith("application/vnd", StringComparison.OrdinalIgnoreCase) &&
+                   contentMimeType.EndsWith("+xml", StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>

--- a/src/Nancy/NamedPipelineBase.cs
+++ b/src/Nancy/NamedPipelineBase.cs
@@ -140,7 +140,7 @@ namespace Nancy
         public virtual void InsertBefore(string name, PipelineItem<TDelegate> item)
         {
             var existingIndex =
-                this.pipelineItems.FindIndex(i => String.Equals(name, i.Name, StringComparison.InvariantCulture));
+                this.pipelineItems.FindIndex(i => String.Equals(name, i.Name, StringComparison.Ordinal));
 
             if (existingIndex == -1)
             {
@@ -170,7 +170,7 @@ namespace Nancy
         public virtual void InsertAfter(string name, PipelineItem<TDelegate> item)
         {
             var existingIndex =
-                this.pipelineItems.FindIndex(i => String.Equals(name, i.Name, StringComparison.InvariantCulture));
+                this.pipelineItems.FindIndex(i => String.Equals(name, i.Name, StringComparison.Ordinal));
 
             if (existingIndex == -1)
             {
@@ -202,7 +202,7 @@ namespace Nancy
             }
 
             var existingIndex =
-                this.pipelineItems.FindIndex(i => String.Equals(name, i.Name, StringComparison.InvariantCulture));
+                this.pipelineItems.FindIndex(i => String.Equals(name, i.Name, StringComparison.Ordinal));
 
             if (existingIndex != -1)
             {

--- a/src/Nancy/NegotiatorExtensions.cs
+++ b/src/Nancy/NegotiatorExtensions.cs
@@ -252,11 +252,11 @@
                                    .ToArray();
 
             var headerProperty = properties
-                                    .Where(p => string.Equals(p.Name, "Header", StringComparison.InvariantCultureIgnoreCase))
+                                    .Where(p => string.Equals(p.Name, "Header", StringComparison.OrdinalIgnoreCase))
                                     .FirstOrDefault();
 
             var valueProperty = properties
-                                    .Where(p => string.Equals(p.Name, "Value", StringComparison.InvariantCultureIgnoreCase))
+                                    .Where(p => string.Equals(p.Name, "Value", StringComparison.OrdinalIgnoreCase))
                                     .FirstOrDefault();
 
             if (headerProperty == null || valueProperty == null)

--- a/src/Nancy/Request.cs
+++ b/src/Nancy/Request.cs
@@ -255,7 +255,7 @@ namespace Nancy
             var multipart = new HttpMultipart(this.Body, boundary);
 
             var formValues =
-                new NameValueCollection(StaticConfiguration.CaseSensitive ? StringComparer.InvariantCulture : StringComparer.InvariantCultureIgnoreCase);
+                new NameValueCollection(StaticConfiguration.CaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
 
             foreach (var httpMultipartBoundary in multipart.GetBoundaries())
             {

--- a/src/Nancy/ResponseExtensions.cs
+++ b/src/Nancy/ResponseExtensions.cs
@@ -186,11 +186,11 @@ namespace Nancy
                                    .ToArray();
 
             var headerProperty = properties
-                                    .Where(p => string.Equals(p.Name, "Header", StringComparison.InvariantCultureIgnoreCase))
+                                    .Where(p => string.Equals(p.Name, "Header", StringComparison.OrdinalIgnoreCase))
                                     .FirstOrDefault();
 
             var valueProperty = properties
-                                    .Where(p => string.Equals(p.Name, "Value", StringComparison.InvariantCultureIgnoreCase))
+                                    .Where(p => string.Equals(p.Name, "Value", StringComparison.OrdinalIgnoreCase))
                                     .FirstOrDefault();
 
             if (headerProperty == null || valueProperty == null)

--- a/src/Nancy/Responses/DefaultJsonSerializer.cs
+++ b/src/Nancy/Responses/DefaultJsonSerializer.cs
@@ -91,11 +91,11 @@
 
             var contentMimeType = contentType.Split(';')[0];
 
-            return contentMimeType.Equals("application/json", StringComparison.InvariantCultureIgnoreCase) ||
-                   contentMimeType.StartsWith("application/json-", StringComparison.InvariantCultureIgnoreCase) ||
-                   contentMimeType.Equals("text/json", StringComparison.InvariantCultureIgnoreCase) ||
-                  (contentMimeType.StartsWith("application/vnd", StringComparison.InvariantCultureIgnoreCase) &&
-                   contentMimeType.EndsWith("+json", StringComparison.InvariantCultureIgnoreCase));
+            return contentMimeType.Equals("application/json", StringComparison.OrdinalIgnoreCase) ||
+                   contentMimeType.StartsWith("application/json-", StringComparison.OrdinalIgnoreCase) ||
+                   contentMimeType.Equals("text/json", StringComparison.OrdinalIgnoreCase) ||
+                  (contentMimeType.StartsWith("application/vnd", StringComparison.OrdinalIgnoreCase) &&
+                   contentMimeType.EndsWith("+json", StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/Nancy/Responses/DefaultXmlSerializer.cs
+++ b/src/Nancy/Responses/DefaultXmlSerializer.cs
@@ -58,10 +58,10 @@
 
             var contentMimeType = contentType.Split(';')[0];
 
-            return contentMimeType.Equals("application/xml", StringComparison.InvariantCultureIgnoreCase) ||
-                   contentMimeType.Equals("text/xml", StringComparison.InvariantCultureIgnoreCase) ||
-                  (contentMimeType.StartsWith("application/vnd", StringComparison.InvariantCultureIgnoreCase) &&
-                   contentMimeType.EndsWith("+xml", StringComparison.InvariantCultureIgnoreCase));
+            return contentMimeType.Equals("application/xml", StringComparison.OrdinalIgnoreCase) ||
+                   contentMimeType.Equals("text/xml", StringComparison.OrdinalIgnoreCase) ||
+                  (contentMimeType.StartsWith("application/vnd", StringComparison.OrdinalIgnoreCase) &&
+                   contentMimeType.EndsWith("+xml", StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/Nancy/Responses/Negotiation/JsonProcessor.cs
+++ b/src/Nancy/Responses/Negotiation/JsonProcessor.cs
@@ -91,7 +91,7 @@
 
         private static bool IsWildcardJsonContentType(MediaRange requestedContentType)
         {
-            if (!requestedContentType.Type.IsWildcard && !string.Equals("application", requestedContentType.Type, StringComparison.InvariantCultureIgnoreCase))
+            if (!requestedContentType.Type.IsWildcard && !string.Equals("application", requestedContentType.Type, StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
@@ -103,8 +103,8 @@
 
             var subtypeString = requestedContentType.Subtype.ToString();
 
-            return (subtypeString.StartsWith("vnd", StringComparison.InvariantCultureIgnoreCase) &&
-                    subtypeString.EndsWith("+json", StringComparison.InvariantCultureIgnoreCase));
+            return (subtypeString.StartsWith("vnd", StringComparison.OrdinalIgnoreCase) &&
+                    subtypeString.EndsWith("+json", StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/Nancy/Responses/Negotiation/MediaType.cs
+++ b/src/Nancy/Responses/Negotiation/MediaType.cs
@@ -39,7 +39,7 @@ namespace Nancy.Responses.Negotiation
         {
             return this.IsWildcard ||
                    other.IsWildcard ||
-                   this.type.Equals(other.type, StringComparison.InvariantCultureIgnoreCase);
+                   this.type.Equals(other.type, StringComparison.OrdinalIgnoreCase);
         }
 
         public static implicit operator MediaType(string inputString)

--- a/src/Nancy/Responses/Negotiation/XmlProcessor.cs
+++ b/src/Nancy/Responses/Negotiation/XmlProcessor.cs
@@ -101,7 +101,7 @@
 
         private static bool IsWildcardXmlContentType(MediaRange requestedContentType)
         {
-            if (!requestedContentType.Type.IsWildcard && !string.Equals("application", requestedContentType.Type, StringComparison.InvariantCultureIgnoreCase))
+            if (!requestedContentType.Type.IsWildcard && !string.Equals("application", requestedContentType.Type, StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
@@ -113,8 +113,8 @@
 
             var subtypeString = requestedContentType.Subtype.ToString();
 
-            return (subtypeString.StartsWith("vnd", StringComparison.InvariantCultureIgnoreCase) &&
-                    subtypeString.EndsWith("+xml", StringComparison.InvariantCultureIgnoreCase));
+            return (subtypeString.StartsWith("vnd", StringComparison.OrdinalIgnoreCase) &&
+                    subtypeString.EndsWith("+xml", StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/Nancy/ViewEngines/DefaultViewFactory.cs
+++ b/src/Nancy/ViewEngines/DefaultViewFactory.cs
@@ -150,7 +150,7 @@
 
             var matchingViewEngines =
                 from viewEngine in this.viewEngines
-                where viewEngine.Extensions.Any(x => x.Equals(viewLocationResult.Extension, StringComparison.InvariantCultureIgnoreCase))
+                where viewEngine.Extensions.Any(x => x.Equals(viewLocationResult.Extension, StringComparison.OrdinalIgnoreCase))
                 select viewEngine;
 
             return matchingViewEngines.FirstOrDefault();

--- a/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngine.cs
+++ b/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngine.cs
@@ -208,7 +208,7 @@ namespace Nancy.ViewEngines.SuperSimpleViewEngine
             var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
 
             var property =
-                properties.Where(p => string.Equals(p.Name, propertyName, StringComparison.InvariantCulture)).
+                properties.Where(p => string.Equals(p.Name, propertyName, StringComparison.Ordinal)).
                 FirstOrDefault();
 
             if (property != null)
@@ -219,7 +219,7 @@ namespace Nancy.ViewEngines.SuperSimpleViewEngine
             var fields = type.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static);
 
             var field =
-                fields.Where(p => string.Equals(p.Name, propertyName, StringComparison.InvariantCulture)).
+                fields.Where(p => string.Equals(p.Name, propertyName, StringComparison.Ordinal)).
                 FirstOrDefault();
 
             return field == null ? new Tuple<bool, object>(false, null) : new Tuple<bool, object>(true, field.GetValue(model));


### PR DESCRIPTION
Updated all usages of

* `StringComparison.InvariantCultureIgnoreCase`
* `StringComparison.InvariantCulture`
* `StringComparer.InvariantCultureIgnoreCase`
* `StringComparer.InvariantCulture`

To use

* `.Ordinal`
* `.OrdinalIgnoreCare`

Instead. This was a bulk update. All tests pass.

Can you think of a reason why this is a bad idea? =)

A reference to #1254