### PR TITLE
Razor throws error when a layout cannot be found

### DIFF
--- a/src/Nancy.ViewEngines.Razor/RazorViewEngine.cs
+++ b/src/Nancy.ViewEngines.Razor/RazorViewEngine.cs
@@ -115,7 +115,15 @@
 
                 while (!root)
                 {
-                    view = this.GetViewInstance(renderContext.LocateView(layout, model), renderContext, referencingAssembly, model);
+                    var viewLocation =
+                        renderContext.LocateView(layout, model);
+
+                    if (viewLocation == null)
+                    {
+                        throw new InvalidOperationException("Unable to locate layout: " + layout);
+                    }
+
+                    view = this.GetViewInstance(viewLocation, renderContext, referencingAssembly, model);
 
                     view.ExecuteView(body, sectionContents);
 


### PR DESCRIPTION
Nancy will throw an `InvalidOperationException` when a layout file could not be located. It will specify the name of the layout that failed to be located

Resolved #1397