### PR TITLE
Debugger friendly context

### DIFF
--- a/src/Nancy/DynamicDictionary.cs
+++ b/src/Nancy/DynamicDictionary.cs
@@ -11,7 +11,7 @@
     /// <summary>
     /// A dictionary that supports dynamic access.
     /// </summary>
-    [DebuggerDisplay("{DebuggerDisplay}")]
+    [DebuggerDisplay("{DebuggerDisplay, nq}")]
     public class DynamicDictionary : DynamicObject, IEquatable<DynamicDictionary>, IHideObjectMembers, IEnumerable<string>, IDictionary<string, object>
     {
         private readonly IDictionary<string, dynamic> dictionary =

--- a/src/Nancy/DynamicDictionary.cs
+++ b/src/Nancy/DynamicDictionary.cs
@@ -3,11 +3,15 @@
     using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Dynamic;
+    using System.Linq;
+    using System.Text;
 
     /// <summary>
     /// A dictionary that supports dynamic access.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay}")]
     public class DynamicDictionary : DynamicObject, IEquatable<DynamicDictionary>, IHideObjectMembers, IEnumerable<string>, IDictionary<string, object>
     {
         private readonly IDictionary<string, dynamic> dictionary =
@@ -342,6 +346,28 @@
             }
 
             return data;
+        }
+
+        private string DebuggerDisplay
+        {
+            get
+            {
+                var sb = new StringBuilder();
+                sb.Append("{");
+                var maxItens = Math.Min(this.dictionary.Count, 5);
+                for (var i = 0; i < maxItens; i++)
+                {
+                    var item = this.dictionary.ElementAt(i);
+                    sb.AppendFormat(" {0} = {1}{2}", item.Key, item.Value, i < maxItens - 1 ? "," : String.Empty);
+                }
+                if (maxItens < this.dictionary.Count)
+                {
+                    sb.Append("...");
+                }
+                sb.Append(" }");
+
+                return sb.ToString();
+            }
         }
     }
 }

--- a/src/Nancy/DynamicDictionary.cs
+++ b/src/Nancy/DynamicDictionary.cs
@@ -352,21 +352,26 @@
         {
             get
             {
-                var sb = new StringBuilder();
-                sb.Append("{");
-                var maxItens = Math.Min(this.dictionary.Count, 5);
-                for (var i = 0; i < maxItens; i++)
+                var builder = new StringBuilder();
+                var maxItems = Math.Min(this.dictionary.Count, 5);
+
+                builder.Append("{");
+
+                for (var i = 0; i < maxItems; i++)
                 {
                     var item = this.dictionary.ElementAt(i);
-                    sb.AppendFormat(" {0} = {1}{2}", item.Key, item.Value, i < maxItens - 1 ? "," : String.Empty);
+                    
+                    builder.AppendFormat(" {0} = {1}{2}", item.Key, item.Value, i < maxItems - 1 ? "," : string.Empty);
                 }
-                if (maxItens < this.dictionary.Count)
-                {
-                    sb.Append("...");
-                }
-                sb.Append(" }");
 
-                return sb.ToString();
+                if (maxItems < this.dictionary.Count)
+                {
+                    builder.Append("...");
+                }
+
+                builder.Append(" }");
+
+                return builder.ToString();
             }
         }
     }

--- a/src/Nancy/Request.cs
+++ b/src/Nancy/Request.cs
@@ -321,10 +321,7 @@ namespace Nancy
 
         private string DebuggerDisplay
         {
-            get
-            {
-                return String.Format("{0} {1}", this.Method, this.Url);
-            }
+            get { return string.Format("{0} {1} {2}", this.Method, this.Url, this.ProtocolVersion).Trim(); }
         }
     }
 }

--- a/src/Nancy/Request.cs
+++ b/src/Nancy/Request.cs
@@ -16,7 +16,7 @@ namespace Nancy
     /// <summary>
     /// Encapsulates HTTP-request information to an Nancy application.
     /// </summary>
-    [DebuggerDisplay("{DebuggerDisplay}")]
+    [DebuggerDisplay("{DebuggerDisplay, nq}")]
     public class Request : IDisposable
     {
         private readonly List<HttpFile> files = new List<HttpFile>();

--- a/src/Nancy/Request.cs
+++ b/src/Nancy/Request.cs
@@ -3,6 +3,7 @@ namespace Nancy
     using System;
     using System.Collections.Generic;
     using System.Collections.Specialized;
+    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Text.RegularExpressions;
@@ -15,6 +16,7 @@ namespace Nancy
     /// <summary>
     /// Encapsulates HTTP-request information to an Nancy application.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay}")]
     public class Request : IDisposable
     {
         private readonly List<HttpFile> files = new List<HttpFile>();
@@ -315,6 +317,14 @@ namespace Nancy
             }
 
             this.Method = providedOverride.Single().Item2;
+        }
+
+        private string DebuggerDisplay
+        {
+            get
+            {
+                return String.Format("{0} {1}", this.Method, this.Url);
+            }
         }
     }
 }

--- a/src/Nancy/Response.cs
+++ b/src/Nancy/Response.cs
@@ -2,6 +2,7 @@ namespace Nancy
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
@@ -13,6 +14,7 @@ namespace Nancy
     /// <summary>
     /// Encapsulates HTTP-response information from an Nancy operation.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay, nq}")]
     public class Response: IDisposable
     {
         /// <summary>
@@ -214,6 +216,11 @@ namespace Nancy
         /// <remarks>This method can be overridden in sub-classes to dispose of response specific resources.</remarks>
         public virtual void Dispose()
         {
+        }
+
+        private string DebuggerDisplay
+        {
+            get { return string.Join(" ", new string[] { this.StatusCode.ToString(), this.ReasonPhrase, this.ContentType }.Where(x => !string.IsNullOrEmpty(x)).ToArray()); }
         }
     }
 }

--- a/src/Nancy/Routing/Route.cs
+++ b/src/Nancy/Routing/Route.cs
@@ -1,12 +1,14 @@
 ﻿namespace Nancy.Routing
 {
     using System;
+    using System.Diagnostics;
     using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
     /// Stores information about a declared route in Nancy.
     /// </summary>
+    [DebuggerDisplay("{Description.DebuggerDisplay}")]
     public class Route
     {
         /// <summary>

--- a/src/Nancy/Routing/Route.cs
+++ b/src/Nancy/Routing/Route.cs
@@ -8,7 +8,7 @@
     /// <summary>
     /// Stores information about a declared route in Nancy.
     /// </summary>
-    [DebuggerDisplay("{Description.DebuggerDisplay}")]
+    [DebuggerDisplay("{Description.DebuggerDisplay, nq}")]
     public class Route
     {
         /// <summary>

--- a/src/Nancy/Routing/RouteDescription.cs
+++ b/src/Nancy/Routing/RouteDescription.cs
@@ -9,7 +9,7 @@ namespace Nancy.Routing
     /// <summary>
     /// Represents the various parts of a route lambda.
     /// </summary>
-    [DebuggerDisplay("{DebuggerDisplay}")]
+    [DebuggerDisplay("{DebuggerDisplay, nq}")]
     public sealed class RouteDescription
     {
         /// <summary>

--- a/src/Nancy/Routing/RouteDescription.cs
+++ b/src/Nancy/Routing/RouteDescription.cs
@@ -2,10 +2,14 @@ namespace Nancy.Routing
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Text;
 
     /// <summary>
     /// Represents the various parts of a route lambda.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay}")]
     public sealed class RouteDescription
     {
         /// <summary>
@@ -73,5 +77,14 @@ namespace Nancy.Routing
         /// </summary>
         /// <value>An <see cref="IEnumerable{T}"/>, containing the segments for the route.</value>
         public IEnumerable<string> Segments { get; set; }
+
+        private string DebuggerDisplay
+        {
+            get
+            {
+                var fields = new[] {this.Name, this.Method, this.Path}.Where(x => !String.IsNullOrEmpty(x)).ToArray();
+                return String.Join(" - ", fields);
+            }
+        }
     }
 }

--- a/src/Nancy/Routing/RouteDescription.cs
+++ b/src/Nancy/Routing/RouteDescription.cs
@@ -82,8 +82,16 @@ namespace Nancy.Routing
         {
             get
             {
-                var fields = new[] {this.Name, this.Method, this.Path}.Where(x => !String.IsNullOrEmpty(x)).ToArray();
-                return String.Join(" - ", fields);
+                var builder = new StringBuilder();
+
+                if (!string.IsNullOrEmpty(this.Name))
+                {
+                    builder.AppendFormat("{0} - ", this.Name);
+                }
+
+                builder.AppendFormat("{0} {1}", this.Method, this.Path);
+
+                return builder.ToString();
             }
         }
     }

--- a/src/Nancy/Validation/ModelValidationResult.cs
+++ b/src/Nancy/Validation/ModelValidationResult.cs
@@ -2,11 +2,13 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
 
     /// <summary>
     /// Represents the result of a model validation.
     /// </summary>
+    [DebuggerDisplay("IsValid = {IsValid}")]
     public class ModelValidationResult
     {
         /// <summary>


### PR DESCRIPTION
An attempt to fix #1950 .

To prevent some kind of performance problem I'm limiting the  enumeration of DynamicDictionary to five items since this seems sensible. I tried to follow the guidelines at http://blogs.msdn.com/b/jaredpar/archive/2011/03/18/debuggerdisplay-attribute-best-practices.aspx

Right now it outputs is like:
<img width="477" alt="screen shot 2015-08-25 at 12 07 31" src="https://cloud.githubusercontent.com/assets/167921/9470346/f562bf12-4b21-11e5-8c0b-b8c0628884e1.png">

## TODO

- [x] Response
- [x] NegotiationContext
- [x] DefaultRequestTrace