### PR TITLE
Update how to build instructions with missing prerequisites

### DIFF
--- a/how_to_build.txt
+++ b/how_to_build.txt
@@ -6,19 +6,17 @@ How to build Nancy
 Prerequisites
 -------------
 
-1. Download and install Ruby 1.8.7+ from http://www.ruby-lang.org/en/downloads
+1. Download and install Ruby 1.9.3 from http://www.ruby-lang.org/en/downloads
 2. At the command prompt run the following to update RubyGems to the latest version: 
 
 	gem update --system
 
 3. You will need the albacore gem, install this at the command prompt with:
 
-	gem install albacore
+	gem install albacore --version "1.0.0.rc2"
 
-If you have already installed albacore, please update to the lastest version (0.2.6+):
-
-	gem update albacore
-
+4. If you don't have Visual Studio 2010 installed you'll need to download and install Visual Studio 2010 Shell from http://www.microsoft.com/en-us/download/details.aspx?id=1366
+5. Download and install the Windows 8.1 SDK from https://msdn.microsoft.com/en-us/windows/desktop/bg162891.aspx (or the appropriate version for your OS)
 
 Building Nancy
 --------------


### PR DESCRIPTION
The rake build is not compatible with the latest version of albacore, it's only compatible with v1.0.0.rc2. If you don't have Visual Studio 2010 installed then you'll need to install the Visual Studio 2010 shell in order to build projects that reference Microsoft.WebApplication.targets. The Windows SDK is required because Microsoft.Common.targets reference AL.exe using the SdkToolsPath. These prerequisites were confirmed on a bare Windows 8.1 install with Visual Studio 2015. This PR resolves [issue 2043](https://github.com/NancyFx/Nancy/issues/2043).