### PR TITLE
Fixes TypeLoadException from static constructor in AppDomainAssemblyT…

### DIFF
--- a/src/Nancy/Extensions/AssemblyExtensions.cs
+++ b/src/Nancy/Extensions/AssemblyExtensions.cs
@@ -31,7 +31,10 @@ namespace Nancy.Extensions
             {
                 types = new Type[] { };
             }
-
+            catch (FileLoadException) {
+                // probably assembly version conflict
+                types = new Type[] { };
+            }
             return types;
         }
     }


### PR DESCRIPTION
Hi,

I've got a ```System.TypeInitializationException``` while trying to test a NancyFx project.
The test project referenced:
- Nancy
- Nancy.Testing
- Nancy.Owin
- Nancy.Bootstrappers.Windsor (reference to Castle.Windsor 3.**2**.0.0)
- Castle.Windsor (3.**3**.0.0)
- Castle.Core (3.3.3.0)

The problematic component was Nancy.Bootstrappers.Windsor (that requires an older version of Castle.Windsor).

Unfortunately the type initializer of ```Nancy.Bootstrapper.AppDomainAssemblyTypeScanner``` dies with a ```System.IO.FileLoadException``` for "Castle.Windsor, Version=3.2.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc" when trying to acquire ```assembly.GetExportedTypes()```.