### PR TITLE
added AllowFileStreamUploadAsync for file uploads on mono

### DIFF
--- a/src/Nancy/IO/RequestStream.cs
+++ b/src/Nancy/IO/RequestStream.cs
@@ -78,7 +78,7 @@
 
                 if (task.IsFaulted)
                 {
-                   throw new InvalidOperationException("Unable to copy stream", task.Exception);
+                    throw new InvalidOperationException("Unable to copy stream", task.Exception);
                 }
             }
 
@@ -359,7 +359,7 @@
         {
             var filePath = Path.GetTempFileName();
 
-            return new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 8192, true);
+            return new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 8192, StaticConfiguration.AllowFileStreamUploadAsync);
         }
 
         private Stream CreateDefaultMemoryStream(long expectedLength)

--- a/src/Nancy/StaticConfiguration.cs
+++ b/src/Nancy/StaticConfiguration.cs
@@ -106,6 +106,11 @@ namespace Nancy
         /// </summary>
         public static bool? DisableRequestStreamSwitching { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="Nancy.StaticConfiguration"/> allow file stream
+        /// upload async due to mono issues before v4.  Uploads of over 80mb would result in extra padded chars to the filestream corrupting the file.
+        /// </summary>
+        /// <value><c>true</c> if allow file stream upload async; otherwise, <c>false</c>.</value>
         public static bool AllowFileStreamUploadAsync { get; set; }
 
         public static class Caching

--- a/src/Nancy/StaticConfiguration.cs
+++ b/src/Nancy/StaticConfiguration.cs
@@ -18,6 +18,7 @@ namespace Nancy
             disableErrorTraces = !(disableCaches = IsRunningDebug);
             CaseSensitive = false;
             RequestQueryFormMultipartLimit = 1000;
+            AllowFileStreamUploadAsync = true;
         }
 
         /// <summary>
@@ -104,6 +105,8 @@ namespace Nancy
         /// Gets or sets a value indicating whether or not to disable request stream switching
         /// </summary>
         public static bool? DisableRequestStreamSwitching { get; set; }
+
+        public static bool AllowFileStreamUploadAsync { get; set; }
 
         public static class Caching
         {


### PR DESCRIPTION
This adds AllowFileStreamUploadAsync in StaticConfiguration.  This is due to a bug in Mono.  When an upload occurs on a large file it pads bytes to the file for some reason.  This issue is fixed in Mono 4 but Mono 4 is unstable.  For those on 3.12 or less this feature will be very handy. Mainly because this just bit my ass in production.

Calling all @NancyFx/most-valued-minions 