### PR TITLE
Use Enumerable as intended

### DIFF
--- a/src/Nancy/Extensions/StringExtensions.cs
+++ b/src/Nancy/Extensions/StringExtensions.cs
@@ -33,15 +33,9 @@ namespace Nancy.Extensions
 
             var nameMatch = matches
                 .Cast<Match>()
-                .Select(x => x)
                 .ToList();
 
-            if (nameMatch.Any())
-            {
-                return nameMatch.Select(x => new ParameterSegmentInformation(x.Groups["name"].Value, x.Groups["default"].Value, x.Groups["default"].Success));
-            }
-
-            throw new FormatException("The segment did not contain any parameters.");
+            return nameMatch.Select(x => new ParameterSegmentInformation(x.Groups["name"].Value, x.Groups["default"].Value, x.Groups["default"].Success));
         }
 
         /// <summary>


### PR DESCRIPTION
StringExtensions.GetParameterDetails() returns `Enumerable<ParameterSegmentInformation>`.
If there is no parameter, it threw a `FormatException`.
IMHO there is no reason not to return an empty enumerable instead.

# Drawback of the old solution
With the exception approach using this function required to check if there is a parameter at all, which has been done by `IsParametrized` in the only "root" usage of the function (DefaultRoutePatternMatcher.cs line 107); on the other hand, `ParameterizeSegment`(DefaultRouteMatcher line 128) does not require the segment to contain at least one parameter, to function, so that check wouldn't even be required.

# Benefit of this change
The additional check is still possible, but not required to prevent throwing an exception.


(side note: removed Select-self statement (line 36)