### PR TITLE
ExceptionExtensions Flattens Incorrectly

### DIFF
--- a/src/Nancy.Tests/Helpers/ExceptionExtensionsFixture.cs
+++ b/src/Nancy.Tests/Helpers/ExceptionExtensionsFixture.cs
@@ -1,0 +1,41 @@
+﻿namespace Nancy.Tests.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using Nancy.Helpers;
+    using Xunit;
+
+    public class ExceptionExtensionsFixture
+    {
+        [Fact]
+        public void Should_return_exception_if_not_aggregate_exception()
+        {
+            var exception = new Exception("Not an aggregate exception.", new Exception("Inner exception."));
+            var result = exception.FlattenInnerExceptions();
+
+            Assert.Equal(exception, result);
+        }
+
+        [Fact]
+        public void Should_flatten_aggregate_exceptions()
+        {
+            var exception1 = new Exception("Exception 1", new Exception("Inner exception of exception 1"));
+            var exception2 = new Exception("Exception 2", new Exception("Inner exception of exception 2"));
+            var exception3 = new Exception("Exception 3", new Exception("Inner exception of exception 3"));
+            
+            // Aggregate exceptions nested three levels deep.
+            var aggregate3 = new AggregateException(exception3);
+            var aggregate2 = new AggregateException(aggregate3, exception2);
+            var aggregate1 = new AggregateException(aggregate2, exception1);
+
+            var result = aggregate1.FlattenInnerExceptions();
+
+            Assert.IsType<AggregateException>(result);
+
+            // Only the inner exceptions of any aggregates should be returned. The inner exception
+            // of a non-aggregate should not be flattened.
+            var expectedExceptions = new List<Exception>() { exception1, exception2, exception3 };
+            Assert.Equal(((AggregateException)result).InnerExceptions, expectedExceptions);
+        }
+    }
+}

--- a/src/Nancy.Tests/Helpers/ExceptionExtensionsFixture.cs
+++ b/src/Nancy.Tests/Helpers/ExceptionExtensionsFixture.cs
@@ -1,7 +1,6 @@
 ﻿namespace Nancy.Tests.Helpers
 {
     using System;
-    using System.Linq;
     using Nancy.Helpers;
     using Xunit;
 
@@ -37,7 +36,10 @@
             var innerExceptions = ((AggregateException)result).InnerExceptions;
             var expectedExceptions = new[] { exception1, exception2, exception3 };
 
-            Assert.True(innerExceptions.SequenceEqual(expectedExceptions));
+            Assert.Equal(3, innerExceptions.Count);
+
+            foreach (var exception in expectedExceptions)
+                Assert.True(innerExceptions.Contains(exception));
         }
     }
 }

--- a/src/Nancy.Tests/Helpers/ExceptionExtensionsFixture.cs
+++ b/src/Nancy.Tests/Helpers/ExceptionExtensionsFixture.cs
@@ -1,7 +1,7 @@
 ﻿namespace Nancy.Tests.Helpers
 {
     using System;
-    using System.Collections.Generic;
+    using System.Linq;
     using Nancy.Helpers;
     using Xunit;
 
@@ -34,8 +34,10 @@
 
             // Only the inner exceptions of any aggregates should be returned. The inner exception
             // of a non-aggregate should not be flattened.
-            var expectedExceptions = new List<Exception>() { exception1, exception2, exception3 };
-            Assert.Equal(((AggregateException)result).InnerExceptions, expectedExceptions);
+            var innerExceptions = ((AggregateException)result).InnerExceptions;
+            var expectedExceptions = new[] { exception1, exception2, exception3 };
+
+            Assert.True(innerExceptions.SequenceEqual(expectedExceptions));
         }
     }
 }

--- a/src/Nancy.Tests/Nancy.Tests.csproj
+++ b/src/Nancy.Tests/Nancy.Tests.csproj
@@ -112,6 +112,7 @@
     </Compile>
     <Compile Include="Fakes\PersonWithAgeField.cs" />
     <Compile Include="Fakes\StructModel.cs" />
+    <Compile Include="Helpers\ExceptionExtensionsFixture.cs" />
     <Compile Include="NoAppStartupsFixture.cs" />
     <Compile Include="Extensions\ResponseExtensions.cs" />
     <Compile Include="Fakes\FakeNancyModuleNoRoutes.cs" />

--- a/src/Nancy/Helpers/ExceptionExtensions.cs
+++ b/src/Nancy/Helpers/ExceptionExtensions.cs
@@ -18,12 +18,7 @@
                     return flattenedAggregateException;
                 }
 
-                return flattenedAggregateException.InnerException.FlattenInnerExceptions();
-            }
-
-            if (exception != null && exception.InnerException != null)
-            {
-                return exception.InnerException.FlattenInnerExceptions();
+                return flattenedAggregateException.InnerException;
             }
 
             return exception;


### PR DESCRIPTION
ExceptionExtensions.FlattenInnerExceptions() was returning inner
exceptions of non-aggregate exceptions. This caused the wrong exception to
be passed to the error pipeline.

I found this bug after upgrading from Nancy 1.2 to 1.3. My application has an OnError pipeline handler to take the exception thrown by the app and return the exception text in the response body. Automated tests that were checking error messages returned by the service started failing but only for exceptions where the InnerException property was set to a non-null value. Oddly, the inner exception message text was returned by the service. The bug was in ExceptionExtensions.FlattenInnerExceptions(). It was returning the inner exception for non-aggregate exceptions and throwing away the original exception. This means the OnError pipeline was receiving the incorrect exception.