### PR TITLE
fix Test LoginFixture.Should_return_unauthorized_without_user_agent()

### DIFF
--- a/src/Nancy.Demo.Authentication.Token.TestingDemo/LoginFixture.cs
+++ b/src/Nancy.Demo.Authentication.Token.TestingDemo/LoginFixture.cs
@@ -98,6 +98,7 @@ namespace Nancy.Demo.Authentication.Token.TestingDemo
                 with.Accept("application/json");
                 with.FormValue("UserName", "demo");
                 with.FormValue("Password", "demo");
+                with.Header("User-Agent", null);
             });
 
             // Then


### PR DESCRIPTION
This test did not define not to send a user agent. 
As the user-agent header entry was missing, Nancy.Testing.Browser.CreateRequest() added a default test user agent "Nancy.Testing.Browser" - thus the defining part of the fact to test was missing.

I simply defined user-agent to be null, thus the test sends the request intended and passes again.