### PR TITLE
Made is possible to disable asp.net output buffering

### DIFF
--- a/src/Nancy.Demo.Hosting.Aspnet/Web.config
+++ b/src/Nancy.Demo.Hosting.Aspnet/Web.config
@@ -8,6 +8,7 @@
 
   <nancyFx>
     <!-- We can override the bootstrapper inside the config if we don't want to rely on the bootstrapper locator. -->
+    <disableoutputbuffer value="false" />
     <bootstrapper assembly="Nancy.Demo.Hosting.Aspnet" type="Nancy.Demo.Hosting.Aspnet.DemoBootstrapper" />
   </nancyFx>
 

--- a/src/Nancy.Hosting.Aspnet/NancyFxSection.cs
+++ b/src/Nancy.Hosting.Aspnet/NancyFxSection.cs
@@ -5,45 +5,44 @@ namespace Nancy.Hosting.Aspnet
 
     public class NancyFxSection : ConfigurationSection
     {
+        [ConfigurationProperty("disableoutputbuffer")]
+        public DisableOutputBufferElement DisableOutputBuffer
+        {
+            get { return (DisableOutputBufferElement)this["disableoutputbuffer"]; }
+            set { this["disableoutputbuffer"] = value; }
+        }
+
         [ConfigurationProperty("bootstrapper")]
         public BootstrapperElement Bootstrapper
         {
-            get
+            get { return (BootstrapperElement)this["bootstrapper"]; }
+            set { this["bootstrapper"] = value; }
+        }
+
+        public class DisableOutputBufferElement : ConfigurationElement
+        {
+            [ConfigurationProperty("value", DefaultValue = false, IsRequired = true)]
+            public bool Value
             {
-                return (BootstrapperElement)this["bootstrapper"];
-            }
-            set
-            {
-                this["bootstrapper"] = value;
+                get { return (bool)this["value"]; }
+                set { this["value"] = value; }
             }
         }
 
         public class BootstrapperElement : ConfigurationElement
         {
             [ConfigurationProperty("type", DefaultValue = "", IsRequired = true)]
-            public String Type
+            public string Type
             {
-                get
-                {
-                    return (String)this["type"];
-                }
-                set
-                {
-                    this["type"] = value;
-                }
+                get { return (string)this["type"]; }
+                set { this["type"] = value; }
             }
 
             [ConfigurationProperty("assembly", DefaultValue = "", IsRequired = true)]
-            public String Assembly
+            public string Assembly
             {
-                get
-                {
-                    return (String)this["assembly"];
-                }
-                set
-                {
-                    this["assembly"] = value;
-                }
+                get { return (String)this["assembly"]; }
+                set { this["assembly"] = value; }
             }
         }
     }

--- a/src/Nancy.Hosting.Aspnet/NancyHandler.cs
+++ b/src/Nancy.Hosting.Aspnet/NancyHandler.cs
@@ -2,6 +2,7 @@ namespace Nancy.Hosting.Aspnet
 {
     using System;
     using System.Collections.Generic;
+    using System.Configuration;
     using System.Globalization;
     using System.Linq;
     using System.Threading.Tasks;
@@ -151,6 +152,11 @@ namespace Nancy.Hosting.Aspnet
                 context.Response.ContentType = response.ContentType;
             }
 
+            if (IsOutputBufferDisabled())
+            {
+                context.Response.BufferOutput = false;
+            }
+
             context.Response.StatusCode = (int) response.StatusCode;
 
             if (response.ReasonPhrase != null)
@@ -159,6 +165,19 @@ namespace Nancy.Hosting.Aspnet
             }
 
             response.Contents.Invoke(new NancyResponseStream(context.Response));
+        }
+
+        private static bool IsOutputBufferDisabled()
+        {
+            var configurationSection =
+                ConfigurationManager.GetSection("nancyFx") as NancyFxSection;
+
+            if (configurationSection == null || configurationSection.DisableOutputBuffer == null)
+            {
+                return false;
+            }
+
+            return configurationSection.DisableOutputBuffer.Value;
         }
 
         private static void SetHttpResponseHeaders(HttpContextBase context, Response response)


### PR DESCRIPTION
The ASP.NET config section, for Nancy, now supports a new element
`<disableoutputbuffer value="true/false" />` which controls if output
buffer, on the underlying response stream, should be disabled or not.

Replaces #1549