### PR TITLE
Added ISerializerFactory + implementation

### DIFF
--- a/src/Nancy.Demo.Hosting.Aspnet/MainModule.cs
+++ b/src/Nancy.Demo.Hosting.Aspnet/MainModule.cs
@@ -10,7 +10,7 @@ namespace Nancy.Demo.Hosting.Aspnet
 
     public class MainModule : NancyModule
     {
-        public MainModule(IRouteCacheProvider routeCacheProvider, INancyEnvironment environment, ISerializerFactory serializerFactory)
+        public MainModule(IRouteCacheProvider routeCacheProvider, INancyEnvironment environment)
         {
             Get["/"] = x => {
                 return View["routes", routeCacheProvider.GetCache()];

--- a/src/Nancy.Demo.Hosting.Aspnet/MainModule.cs
+++ b/src/Nancy.Demo.Hosting.Aspnet/MainModule.cs
@@ -10,7 +10,7 @@ namespace Nancy.Demo.Hosting.Aspnet
 
     public class MainModule : NancyModule
     {
-        public MainModule(IRouteCacheProvider routeCacheProvider, INancyEnvironment environment)
+        public MainModule(IRouteCacheProvider routeCacheProvider, INancyEnvironment environment, ISerializerFactory serializerFactory)
         {
             Get["/"] = x => {
                 return View["routes", routeCacheProvider.GetCache()];
@@ -18,7 +18,6 @@ namespace Nancy.Demo.Hosting.Aspnet
 
             Get["/texts"] = parameters => {
                 return (string)this.Context.Text.Menu.Home;
-                
             };
 
             Get["/env"] = _ =>

--- a/src/Nancy.Demo.Hosting.Aspnet/PngSerializer.cs
+++ b/src/Nancy.Demo.Hosting.Aspnet/PngSerializer.cs
@@ -26,7 +26,7 @@
         /// <returns>True if supported, false otherwise</returns>
         public bool CanSerialize(MediaRange mediaRange)
         {
-            return ((string)mediaRange).Equals("image/png", StringComparison.OrdinalIgnoreCase);
+            return mediaRange.Matches("image/png");
         }
 
         /// <summary>

--- a/src/Nancy.Demo.Hosting.Aspnet/PngSerializer.cs
+++ b/src/Nancy.Demo.Hosting.Aspnet/PngSerializer.cs
@@ -5,6 +5,7 @@
     using System.Drawing;
     using System.Drawing.Imaging;
     using System.IO;
+    using Nancy.Responses.Negotiation;
 
     /// <summary>
     /// If you request /negotiated with an accept header with the value image/png you will get an image back
@@ -21,11 +22,11 @@
         /// <summary>
         /// Whether the serializer can serialize the content type
         /// </summary>
-        /// <param name="contentType">Content type to serialise</param>
+        /// <param name="mediaRange">Content type to serialise</param>
         /// <returns>True if supported, false otherwise</returns>
-        public bool CanSerialize(string contentType)
+        public bool CanSerialize(MediaRange mediaRange)
         {
-            return contentType.Equals("image/png", StringComparison.OrdinalIgnoreCase);
+            return ((string)mediaRange).Equals("image/png", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -40,11 +41,11 @@
         /// <summary>
         /// Serialize the given model with the given contentType
         /// </summary>
-        /// <param name="contentType">Content type to serialize into</param>
+        /// <param name="mediaRange">Content type to serialize into</param>
         /// <param name="model">Model to serialize</param>
         /// <param name="outputStream">Output stream to serialize to</param>
         /// <returns>Serialised object</returns>
-        public void Serialize<TModel>(string contentType, TModel model, Stream outputStream)
+        public void Serialize<TModel>(MediaRange mediaRange, TModel model, Stream outputStream)
         {
             var path =
                 Path.Combine(this.rootPathProvider.GetRootPath(), "content/face.png");

--- a/src/Nancy.Testing/BrowserContextExtensions.cs
+++ b/src/Nancy.Testing/BrowserContextExtensions.cs
@@ -1,5 +1,4 @@
-﻿
-namespace Nancy.Testing
+﻿namespace Nancy.Testing
 {
     using System;
     using System.Collections.Generic;
@@ -187,7 +186,7 @@ namespace Nancy.Testing
                     if (contextValues.Headers["accept"].Any(x => x.Equals("*/*")))
                     {
                         contextValues.Headers.Remove("accept");
-                    }    
+                    }
                 }
             }
 

--- a/src/Nancy.Testing/ConfigurableBootstrapper.cs
+++ b/src/Nancy.Testing/ConfigurableBootstrapper.cs
@@ -1965,6 +1965,30 @@ namespace Nancy.Testing
             }
 
             /// <summary>
+            /// Configures the bootstrapper to create an <see cref="ISerializerFactory"/> instance of the specified type.
+            /// </summary>
+            /// <typeparam name="T">The type of the <see cref="ISerializerFactory"/> that the bootstrapper should use.</typeparam>
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator SerializerFactory<T>() where T : ISerializerFactory
+            {
+                this.bootstrapper.configuration.SerializerFactory = typeof(T);
+                return this;
+            }
+
+            /// <summary>
+            /// Configures the bootstrapper to use the provided instance of <see cref="IResponseNegotiator"/>.
+            /// </summary>
+            /// <param name="serializer">The <see cref="IResponseNegotiator"/> instance that should be used by the bootstrapper.</param>
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator SerializerFactory(ISerializerFactory serializer)
+            {
+                this.bootstrapper.registeredInstances.Add(
+                    new InstanceRegistration(typeof(ISerializerFactory), serializer));
+
+                return this;
+            }
+
+            /// <summary>
             /// Configures the bootstrapper to use the provided instance of <see cref="IApplicationStartup"/>.
             /// </summary>
             /// <typeparam name="T">The type of the <see cref="IApplicationStartup"/> that the bootstrapper should use.</typeparam>

--- a/src/Nancy.Tests/Nancy.Tests.csproj
+++ b/src/Nancy.Tests/Nancy.Tests.csproj
@@ -166,6 +166,7 @@
     <Compile Include="Unit\Culture\BuiltInCultureConventionFixture.cs" />
     <Compile Include="Unit\DefaultNancyBootstrapperFixture.cs" />
     <Compile Include="Unit\DefaultResponseFormatterFactoryFixture.cs" />
+    <Compile Include="Unit\DefaultSerializerFactoryFixture.cs" />
     <Compile Include="Unit\Diagnostics\ConcurrentLimitedCollectionFixture.cs" />
     <Compile Include="Unit\Diagnostics\CustomInteractiveDiagnosticsFixture.cs" />
     <Compile Include="Unit\Diagnostics\DefaultRequestTraceFactoryFixture.cs" />

--- a/src/Nancy.Tests/Unit/DefaultResponseFormatterFactoryFixture.cs
+++ b/src/Nancy.Tests/Unit/DefaultResponseFormatterFactoryFixture.cs
@@ -1,22 +1,23 @@
 ﻿namespace Nancy.Tests.Unit
 {
     using FakeItEasy;
-
+    using Nancy.Responses.Negotiation;
     using Xunit;
 
     public class DefaultResponseFormatterFactoryFixture
     {
         private readonly IRootPathProvider rootPathProvider;
         private readonly DefaultResponseFormatterFactory factory;
-        private readonly ISerializer[] serializers;
+        private readonly ISerializerFactory serializerFactory;
 
         public DefaultResponseFormatterFactoryFixture()
         {
             this.rootPathProvider = A.Fake<IRootPathProvider>();
             A.CallTo(() => this.rootPathProvider.GetRootPath()).Returns("RootPath");
 
-            this.serializers = new[] { A.Fake<ISerializer>() };
-            this.factory = new DefaultResponseFormatterFactory(this.rootPathProvider, this.serializers);
+            this.serializerFactory = A.Fake<ISerializerFactory>();
+            A.CallTo(() => this.serializerFactory.GetSerializer(A<MediaRange>._));
+            this.factory = new DefaultResponseFormatterFactory(this.rootPathProvider, this.serializerFactory);
         }
 
         [Fact]
@@ -43,7 +44,7 @@
         }
 
         [Fact]
-        public void Should_create_response_formmater_with_serializers_set()
+        public void Should_create_response_formater_with_serializer_factory()
         {
             // Given
             var context = new NancyContext();
@@ -52,7 +53,7 @@
             var formatter = this.factory.Create(context);
 
             // Then
-            formatter.Serializers.ShouldEqualSequence(this.serializers);
+            formatter.SerializerFactory.ShouldBeSameAs(this.serializerFactory);
         }
     }
 }

--- a/src/Nancy.Tests/Unit/DefaultResponseFormatterFixture.cs
+++ b/src/Nancy.Tests/Unit/DefaultResponseFormatterFixture.cs
@@ -1,7 +1,6 @@
 namespace Nancy.Tests.Unit
 {
     using FakeItEasy;
-
     using Xunit;
 
     public class DefaultResponseFormatterFixture
@@ -12,7 +11,7 @@ namespace Nancy.Tests.Unit
             // Given
             var rootPathProvider = A.Fake<IRootPathProvider>();
             A.CallTo(() => rootPathProvider.GetRootPath()).Returns("foo");
-            var formatter = new DefaultResponseFormatter(rootPathProvider, null, new ISerializer[] { });
+            var formatter = new DefaultResponseFormatter(rootPathProvider, null, new DefaultSerializerFactory(null));
 
             // When
             var result = formatter.RootPath;
@@ -28,7 +27,7 @@ namespace Nancy.Tests.Unit
             var context = new NancyContext();
 
             // When
-            var formatter = new DefaultResponseFormatter(null, context, new ISerializer[] { });
+            var formatter = new DefaultResponseFormatter(null, context, new DefaultSerializerFactory(null));
 
             // Then
             formatter.Context.ShouldBeSameAs(context);

--- a/src/Nancy.Tests/Unit/DefaultSerializerFactoryFixture.cs
+++ b/src/Nancy.Tests/Unit/DefaultSerializerFactoryFixture.cs
@@ -1,0 +1,195 @@
+﻿namespace Nancy.Tests.Unit
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Threading;
+    using Nancy.Responses;
+    using Nancy.Responses.Negotiation;
+    using Xunit;
+    using Xunit.Extensions;
+
+    public class DefaultSerializerFactoryFixture
+    {
+        private DefaultSerializerFactory serializerFactory;
+
+        public DefaultSerializerFactoryFixture()
+        {
+        }
+
+        [Theory]
+        [InlineData("application/json")]
+        [InlineData("application/xml")]
+        [InlineData("image/png")]
+        public void Should_return_serializer_for_media_range(string expectedMediaRange)
+        {
+            // Given
+            var expectedSerializer =
+                new TestableSerializer(expectedMediaRange);
+
+            var serializers = new ISerializer[]
+            {
+                expectedSerializer,
+                new TestableSerializer("custom/foo"),
+                new TestableSerializer("custom/bar"),
+                new TestableSerializer("custom/baz"),
+            };
+
+            this.serializerFactory = new DefaultSerializerFactory(serializers);
+
+            // When
+            var result = this.serializerFactory.GetSerializer(expectedMediaRange);
+
+            // Then
+            result.ShouldBeSameAs(expectedSerializer);
+        }
+
+        [Fact]
+        public void Should_return_null_if_no_serializer_matched_media_range()
+        {
+            // Given
+            var serializers = new ISerializer[]
+            {
+                new TestableSerializer("custom/foo"),
+                new TestableSerializer("custom/bar"),
+                new TestableSerializer("custom/baz"),
+            };
+
+            this.serializerFactory = new DefaultSerializerFactory(serializers);
+
+            // When
+            var result = this.serializerFactory.GetSerializer("application/json");
+
+            // Then
+            result.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Should_not_throw_exception_if_a_serializer_throws()
+        {
+            // Given
+            var serializers = new ISerializer[]
+            {
+                new ExceptionThrowingSerializer()
+            };
+
+            this.serializerFactory = new DefaultSerializerFactory(serializers);
+
+            // When, Then
+            Assert.DoesNotThrow(() => this.serializerFactory.GetSerializer("application/json"));
+        }
+
+        [Fact]
+        public void Should_throw_if_multiple_serializers_matched_media_range()
+        {
+            var serializers = new ISerializer[]
+            {
+                new TestableSerializer("application/json"),
+                new TestableSerializer("application/json")
+            };
+
+            this.serializerFactory = new DefaultSerializerFactory(serializers);
+
+            // When, Then
+            Assert.Throws<InvalidOperationException>(() => this.serializerFactory.GetSerializer("application/json"));
+        }
+
+        [Fact]
+        public void Should_not_include_default_serializers_when_counting_matches()
+        {
+            var serializers = new ISerializer[]
+            {
+                new TestableSerializer("application/json"),
+                new DefaultJsonSerializer()
+            };
+
+            this.serializerFactory = new DefaultSerializerFactory(serializers);
+
+            // When, Then
+            Assert.DoesNotThrow(() => this.serializerFactory.GetSerializer("application/json"));
+        }
+
+        [Fact]
+        public void Should_prioritize_non_default_serializer_match()
+        {
+            const string expectedMediaRange = "application/json";
+
+            var expectedSerializer =
+                new TestableSerializer(expectedMediaRange);
+
+            var serializers = new ISerializer[]
+            {
+                new DefaultJsonSerializer(),
+                expectedSerializer
+            };
+
+            this.serializerFactory = new DefaultSerializerFactory(serializers);
+
+            // When
+            var result = this.serializerFactory.GetSerializer(expectedMediaRange);
+
+            // Then
+            result.ShouldBeSameAs(expectedSerializer);
+        }
+
+        [Fact]
+        public void Should_return_default_serializer_if_no_other_match_could_be_made()
+        {
+            // Given
+            var expectedSerializer =
+                new DefaultJsonSerializer();
+
+            var serializers = new ISerializer[]
+            {
+                expectedSerializer,
+                new TestableSerializer("application/xml"),
+                new TestableSerializer("application/xml"),
+            };
+
+            this.serializerFactory = new DefaultSerializerFactory(serializers);
+
+            // When
+            var result = this.serializerFactory.GetSerializer("application/json");
+
+            // Then
+            result.ShouldBeSameAs(expectedSerializer);
+        }
+
+        internal class ExceptionThrowingSerializer : ISerializer
+        {
+            public bool CanSerialize(MediaRange mediaRange)
+            {
+                throw new Exception();
+            }
+
+            public IEnumerable<string> Extensions { get; }
+
+            public void Serialize<TModel>(MediaRange mediaRange, TModel model, Stream outputStream)
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+
+        internal class TestableSerializer : ISerializer
+        {
+            private readonly MediaRange mediaRange;
+
+            public TestableSerializer(MediaRange mediaRange)
+            {
+                this.mediaRange = mediaRange;
+            }
+
+            public bool CanSerialize(MediaRange mediaRange)
+            {
+                return this.mediaRange.Matches(mediaRange);
+            }
+
+            public IEnumerable<string> Extensions { get; }
+
+            public void Serialize<TModel>(MediaRange mediaRange, TModel model, Stream outputStream)
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Nancy.Tests/Unit/DefaultSerializerFactoryFixture.cs
+++ b/src/Nancy.Tests/Unit/DefaultSerializerFactoryFixture.cs
@@ -162,7 +162,7 @@
                 throw new Exception();
             }
 
-            public IEnumerable<string> Extensions { get; }
+            public IEnumerable<string> Extensions { get; set; }
 
             public void Serialize<TModel>(MediaRange mediaRange, TModel model, Stream outputStream)
             {
@@ -184,7 +184,7 @@
                 return this.mediaRange.Matches(mediaRange);
             }
 
-            public IEnumerable<string> Extensions { get; }
+            public IEnumerable<string> Extensions { get; set; }
 
             public void Serialize<TModel>(MediaRange mediaRange, TModel model, Stream outputStream)
             {

--- a/src/Nancy.Tests/Unit/FormatterExtensionsFixture.cs
+++ b/src/Nancy.Tests/Unit/FormatterExtensionsFixture.cs
@@ -1,7 +1,6 @@
 ﻿namespace Nancy.Tests.Unit
 {
     using FakeItEasy;
-
     using Xunit;
 
     public class FormatterExtensionsFixture
@@ -12,14 +11,15 @@
         public FormatterExtensionsFixture()
         {
             this.context = new NancyContext();
-            this.formatter = new DefaultResponseFormatter(A.Fake<IRootPathProvider>(), context, new ISerializer[] { });
+            this.formatter = new DefaultResponseFormatter(A.Fake<IRootPathProvider>(), context, new DefaultSerializerFactory(null));
         }
 
         [Fact]
         public void Should_expand_base_path_for_redirect_if_tilde_present()
         {
+            // Given
             this.context.Request = new Request(
-                "GET", 
+                "GET",
                 new Url
                     {
                         BasePath = "/basePath",
@@ -27,14 +27,17 @@
                         Scheme = "http",
                     });
 
+            // When
             var result = this.formatter.AsRedirect("~/test");
 
+            // Then
             result.Headers["Location"].ShouldEqual("/basePath/test");
         }
 
         [Fact]
         public void Should_leave_path_untouched_for_redirect_if_no_tilde()
         {
+            // Given
             this.context.Request = new Request(
                 "GET",
                 new Url
@@ -44,8 +47,10 @@
                     Scheme = "http",
                 });
 
+            // When
             var result = this.formatter.AsRedirect("/test");
 
+            // Then
             result.Headers["Location"].ShouldEqual("/test");
         }
     }

--- a/src/Nancy.Tests/Unit/JsonFormatterExtensionsFixtures.cs
+++ b/src/Nancy.Tests/Unit/JsonFormatterExtensionsFixtures.cs
@@ -18,8 +18,11 @@ namespace Nancy.Tests.Unit
 
         public JsonFormatterExtensionsFixtures()
         {
+            var serializerFactory =
+               new DefaultSerializerFactory(new ISerializer[] { new DefaultJsonSerializer() });
+
             this.formatter = A.Fake<IResponseFormatter>();
-            A.CallTo(() => this.formatter.Serializers).Returns(new[] { new DefaultJsonSerializer() });
+            A.CallTo(() => this.formatter.SerializerFactory).Returns(serializerFactory);
             this.model = new Person { FirstName = "Andy", LastName = "Pike" };
             this.response = this.formatter.AsJson(model);
         }

--- a/src/Nancy.Tests/Unit/Routing/DefaultRouteResolverFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/DefaultRouteResolverFixture.cs
@@ -387,7 +387,7 @@
             // Given
             StaticConfiguration.DisableMethodNotAllowedResponses = false;
             var localBrowser = new Browser(with => with.Module<MethodNotAllowedModule>());
-            
+
             // When
             var result = localBrowser.Get("/");
 
@@ -412,7 +412,7 @@
             public MethodNotAllowedModule()
             {
                 Delete["/"] = x => 200;
-                
+
                 Post["/"] = x => 200;
             }
         }
@@ -422,7 +422,7 @@
             public NoRootModule()
             {
                 Get["/notroot"] = _ => "foo";
-            }        
+            }
         }
 
         private class TestModule : NancyModule
@@ -456,7 +456,7 @@
                 Get["/multipleparameters/{file}.{extension}"] = _ => "Multiple parameters " + _.file + "." + _.extension;
 
                 Get["/capturenodewithliteral/{file}.html"] = _ => "CaptureNodeWithLiteral " + _.file + ".html";
-                
+
                 Get[@"/regex/(?<foo>\d{2,4})/{bar}"] = x => string.Format("RegEx {0} {1}", x.foo, x.bar);
             }
         }

--- a/src/Nancy.Tests/Unit/XmlFormatterExtensionsFixtures.cs
+++ b/src/Nancy.Tests/Unit/XmlFormatterExtensionsFixtures.cs
@@ -2,12 +2,9 @@ namespace Nancy.Tests.Unit
 {
     using System.IO;
     using System.Xml;
-
     using FakeItEasy;
-
     using Nancy.Responses;
     using Nancy.Tests.Fakes;
-
     using Xunit;
 
     public class XmlFormatterExtensionsFixtures
@@ -17,13 +14,15 @@ namespace Nancy.Tests.Unit
         private readonly Response response;
         private readonly IRootPathProvider rootPathProvider;
 
-
         public XmlFormatterExtensionsFixtures()
         {
             this.rootPathProvider = A.Fake<IRootPathProvider>();
-            
+
+            var serializerFactory =
+                new DefaultSerializerFactory(new ISerializer[] { new DefaultXmlSerializer() });
+
             this.responseFormatter =
-                new DefaultResponseFormatter(this.rootPathProvider, new NancyContext(), new ISerializer[] { new DefaultXmlSerializer() });
+                new DefaultResponseFormatter(this.rootPathProvider, new NancyContext(), serializerFactory);
 
             this.model = new Person { FirstName = "Andy", LastName = "Pike" };
             this.response = this.responseFormatter.AsXml(model);

--- a/src/Nancy/Bootstrapper/NancyInternalConfiguration.cs
+++ b/src/Nancy/Bootstrapper/NancyInternalConfiguration.cs
@@ -80,9 +80,12 @@ namespace Nancy.Bootstrapper
                     EnvironmentFactory = typeof(DefaultNancyEnvironmentFactory),
                     EnvironmentConfigurator = typeof(DefaultNancyEnvironmentConfigurator),
                     DefaultConfigurationProviders = AppDomainAssemblyTypeScanner.TypesOf<INancyDefaultConfigurationProvider>().ToList(),
+                    SerializerFactory = typeof(DefaultSerializerFactory),
                 };
             }
         }
+
+        public Type SerializerFactory { get; set; }
 
         public IList<Type> DefaultConfigurationProviders { get; set; }
 
@@ -251,7 +254,8 @@ namespace Nancy.Bootstrapper
                 new TypeRegistration(typeof(IRequestTraceFactory), this.RequestTraceFactory),
                 new TypeRegistration(typeof(IResponseNegotiator), this.ResponseNegotiator),
                 new TypeRegistration(typeof(INancyEnvironmentConfigurator), this.EnvironmentConfigurator),
-                new TypeRegistration(typeof(INancyEnvironmentFactory), this.EnvironmentFactory)
+                new TypeRegistration(typeof(INancyEnvironmentFactory), this.EnvironmentFactory),
+                new TypeRegistration(typeof(ISerializerFactory), this.SerializerFactory)
             };
         }
 

--- a/src/Nancy/DefaultResponseFormatter.cs
+++ b/src/Nancy/DefaultResponseFormatter.cs
@@ -9,30 +9,28 @@
     public class DefaultResponseFormatter : IResponseFormatter
     {
         private readonly IRootPathProvider rootPathProvider;
-        private readonly IEnumerable<ISerializer> serializers;
         private readonly NancyContext context;
+        private readonly ISerializerFactory serializerFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultResponseFormatter"/> class.
         /// </summary>
         /// <param name="rootPathProvider">The <see cref="IRootPathProvider"/> that should be used by the instance.</param>
         /// <param name="context">The <see cref="NancyContext"/> that should be used by the instance.</param>
-        public DefaultResponseFormatter(IRootPathProvider rootPathProvider, NancyContext context, IEnumerable<ISerializer> serializers)
+        /// <param name="serializerFactory"></param>
+        public DefaultResponseFormatter(IRootPathProvider rootPathProvider, NancyContext context, ISerializerFactory serializerFactory)
         {
-            this.serializers = serializers.ToArray();
             this.rootPathProvider = rootPathProvider;
             this.context = context;
+            this.serializerFactory = serializerFactory;
         }
 
         /// <summary>
-        /// Gets all serializers currently registered
+        /// Gets all <see cref="ISerializerFactory"/> factory.
         /// </summary>
-        public IEnumerable<ISerializer> Serializers
+        public ISerializerFactory SerializerFactory
         {
-            get
-            {
-                return this.serializers;
-            }
+            get { return this.serializerFactory; }
         }
 
         /// <summary>

--- a/src/Nancy/DefaultResponseFormatterFactory.cs
+++ b/src/Nancy/DefaultResponseFormatterFactory.cs
@@ -9,18 +9,17 @@
     public class DefaultResponseFormatterFactory : IResponseFormatterFactory
     {
         private readonly IRootPathProvider rootPathProvider;
-
-        private readonly IEnumerable<ISerializer> serializers;
+        private readonly ISerializerFactory serializerFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultResponseFormatter"/> class, with the
         /// provided <see cref="IRootPathProvider"/>.
         /// </summary>
         /// <param name="rootPathProvider"></param>
-        public DefaultResponseFormatterFactory(IRootPathProvider rootPathProvider, IEnumerable<ISerializer> serializers)
+        public DefaultResponseFormatterFactory(IRootPathProvider rootPathProvider, ISerializerFactory serializerFactory)
         {
             this.rootPathProvider = rootPathProvider;
-            this.serializers = serializers.ToArray();
+            this.serializerFactory = serializerFactory;
         }
 
         /// <summary>
@@ -30,7 +29,7 @@
         /// <returns>An <see cref="IResponseFormatter"/> instance.</returns>
         public IResponseFormatter Create(NancyContext context)
         {
-            return new DefaultResponseFormatter(this.rootPathProvider, context, this.serializers);
+            return new DefaultResponseFormatter(this.rootPathProvider, context, this.serializerFactory);
         }
     }
 }

--- a/src/Nancy/DefaultSerializerFactory.cs
+++ b/src/Nancy/DefaultSerializerFactory.cs
@@ -1,0 +1,85 @@
+namespace Nancy
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Nancy.Responses.Negotiation;
+
+    /// <summary>
+    /// Default implementation of the <see cref="ISerializerFactory"/> interface.
+    /// </summary>
+    /// <remarks>This implementation will ignore the default implementations (those found in the Nancy assembly) unless no other match could be made.</remarks>
+    public class DefaultSerializerFactory : ISerializerFactory
+    {
+        private readonly IEnumerable<ISerializer> serializers;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultSerializerFactory"/> class,
+        /// with the provided <paramref name="serializers"/>.
+        /// </summary>
+        /// <param name="serializers">The <see cref="ISerializer"/> implementations that should be available to the factory.</param>
+        public DefaultSerializerFactory(IEnumerable<ISerializer> serializers)
+        {
+            this.serializers = serializers;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ISerializer"/> implementation that can serialize the provided <paramref name="mediaRange"/>.
+        /// </summary>
+        /// <param name="mediaRange">The <see cref="MediaRange"/> to get a serializer for.</param>
+        /// <returns>An <see cref="ISerializer"/> instance, or <see langword="null" /> if not match was found.</returns>
+        /// <exception cref="InvalidOperationException">If more than one <see cref="ISerializer"/> (not counting the default serializers) matched the provided media range.</exception>
+        public ISerializer GetSerializer(MediaRange mediaRange)
+        {
+            var defaultSerializerForMediaRange =
+                this.GetDefaultSerializerForMediaRange(mediaRange);
+
+            var matches = this.serializers
+                              .Where(x => x != defaultSerializerForMediaRange)
+                              .Where(x => SafeCanSerialize(x, mediaRange)).ToArray();
+
+            if (matches.Length > 1)
+            {
+                throw new InvalidOperationException(GetErrorMessage(matches, mediaRange));
+            }
+
+            return matches
+                .Concat(new[] { defaultSerializerForMediaRange })
+                .FirstOrDefault();
+        }
+
+        private ISerializer GetDefaultSerializerForMediaRange(MediaRange mediaRange)
+        {
+            try
+            {
+                return this.serializers
+                           .Where(x => x.GetType().Assembly.Equals(typeof(INancyEngine).Assembly))
+                           .SingleOrDefault(x => x.CanSerialize(mediaRange));
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string GetErrorMessage(IEnumerable<ISerializer> matches, MediaRange mediaRange)
+        {
+            var details =
+                string.Join("\n", matches.Select(x => string.Concat(" - ", x.GetType().FullName)));
+
+            return string.Format("Multiple ISerializer implementations matched the '{0}' media range.\nThe following serializers matched \n\n{1}", mediaRange, details);
+        }
+
+        private static bool SafeCanSerialize(ISerializer serializer, MediaRange mediaRange)
+        {
+            try
+            {
+                return serializer.CanSerialize(mediaRange);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/Nancy/DefaultSerializerFactory.cs
+++ b/src/Nancy/DefaultSerializerFactory.cs
@@ -35,8 +35,8 @@ namespace Nancy
                 this.GetDefaultSerializerForMediaRange(mediaRange);
 
             var matches = this.serializers
-                              .Where(x => x != defaultSerializerForMediaRange)
-                              .Where(x => SafeCanSerialize(x, mediaRange)).ToArray();
+                .Where(x => x != defaultSerializerForMediaRange)
+                .Where(x => SafeCanSerialize(x, mediaRange)).ToArray();
 
             if (matches.Length > 1)
             {
@@ -53,8 +53,8 @@ namespace Nancy
             try
             {
                 return this.serializers
-                           .Where(x => x.GetType().Assembly.Equals(typeof(INancyEngine).Assembly))
-                           .SingleOrDefault(x => x.CanSerialize(mediaRange));
+                    .Where(x => x.GetType().Assembly.Equals(typeof(INancyEngine).Assembly))
+                    .SingleOrDefault(x => x.CanSerialize(mediaRange));
             }
             catch
             {

--- a/src/Nancy/Diagnostics/DiagnosticsModuleBuilder.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsModuleBuilder.cs
@@ -1,22 +1,18 @@
 namespace Nancy.Diagnostics
 {
-    using System.Collections.Generic;
-
     using Nancy.ModelBinding;
-    using Nancy.Responses;
     using Nancy.Routing;
 
     internal class DiagnosticsModuleBuilder : INancyModuleBuilder
     {
         private readonly IRootPathProvider rootPathProvider;
-
-        private readonly IEnumerable<ISerializer> serializers;
+        private readonly ISerializerFactory serializerFactory;
         private readonly IModelBinderLocator modelBinderLocator;
 
         public DiagnosticsModuleBuilder(IRootPathProvider rootPathProvider, IModelBinderLocator modelBinderLocator)
         {
             this.rootPathProvider = rootPathProvider;
-            this.serializers = new[] { new DefaultJsonSerializer { RetainCasing = false } };
+            this.serializerFactory = new DiagnosticsSerializerFactory();
             this.modelBinderLocator = modelBinderLocator;
         }
 
@@ -28,9 +24,8 @@ namespace Nancy.Diagnostics
         /// <returns>A fully configured <see cref="INancyModule"/> instance.</returns>
         public INancyModule BuildModule(INancyModule module, NancyContext context)
         {
-            // Currently we don't connect view location, binders etc.
             module.Context = context;
-            module.Response = new DefaultResponseFormatter(rootPathProvider, context, serializers);
+            module.Response = new DefaultResponseFormatter(rootPathProvider, context, this.serializerFactory);
             module.ModelBinderLocator = this.modelBinderLocator;
 
             module.After = new AfterPipeline();

--- a/src/Nancy/Diagnostics/DiagnosticsSerializerFactory.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsSerializerFactory.cs
@@ -1,0 +1,25 @@
+namespace Nancy.Diagnostics
+{
+    using Nancy.Responses;
+    using Nancy.Responses.Negotiation;
+
+    internal class DiagnosticsSerializerFactory : ISerializerFactory
+    {
+        private readonly ISerializer serializer;
+
+        public DiagnosticsSerializerFactory()
+        {
+            this.serializer = new DefaultJsonSerializer { RetainCasing = false };
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ISerializer"/> implementation that can serialize the provided <paramref name="mediaRange"/>.
+        /// </summary>
+        /// <param name="mediaRange">The <see cref="MediaRange"/> to get a serializer for.</param>
+        /// <returns>An <see cref="ISerializer"/> instance, or <see langword="null" /> if not match was found.</returns>
+        public ISerializer GetSerializer(MediaRange mediaRange)
+        {
+            return this.serializer;
+        }
+    }
+}

--- a/src/Nancy/FormatterExtensions.cs
+++ b/src/Nancy/FormatterExtensions.cs
@@ -2,7 +2,6 @@ namespace Nancy
 {
     using System;
     using System.IO;
-    using System.Linq;
 
     using Nancy.Extensions;
     using Nancy.Responses;
@@ -40,12 +39,12 @@ namespace Nancy
 
         public static Response AsJson<TModel>(this IResponseFormatter formatter, TModel model, HttpStatusCode statusCode = HttpStatusCode.OK)
         {
-            var serializer = jsonSerializer ?? (jsonSerializer = formatter.Serializers.FirstOrDefault(s => s.CanSerialize("application/json")));
+            var serializer = jsonSerializer ?? (jsonSerializer = formatter.SerializerFactory.GetSerializer("application/json"));
 
-            var r = new JsonResponse<TModel>(model, serializer);
-        	r.StatusCode = statusCode;
-
-        	return r;
+            return new JsonResponse<TModel>(model, serializer)
+            {
+                StatusCode = statusCode
+            };
         }
 
         public static Response AsRedirect(this IResponseFormatter formatter, string location, RedirectResponse.RedirectType type = RedirectResponse.RedirectType.SeeOther)
@@ -55,7 +54,7 @@ namespace Nancy
 
         public static Response AsXml<TModel>(this IResponseFormatter formatter, TModel model)
         {
-            var serializer = xmlSerializer ?? (xmlSerializer = formatter.Serializers.FirstOrDefault(s => s.CanSerialize("application/xml")));
+            var serializer = xmlSerializer ?? (xmlSerializer = formatter.SerializerFactory.GetSerializer("application/xml"));
 
             return new XmlResponse<TModel>(model, serializer);
         }

--- a/src/Nancy/IResponseFormatter.cs
+++ b/src/Nancy/IResponseFormatter.cs
@@ -9,9 +9,9 @@
     public interface IResponseFormatter : IHideObjectMembers
     {
         /// <summary>
-        /// Gets all serializers currently registered
+        /// Gets all <see cref="ISerializerFactory"/> factory.
         /// </summary>
-        IEnumerable<ISerializer> Serializers { get; }
+        ISerializerFactory SerializerFactory { get; }
 
         /// <summary>
         /// Gets the context for which the response is being formatted.

--- a/src/Nancy/ISerializer.cs
+++ b/src/Nancy/ISerializer.cs
@@ -3,9 +3,11 @@
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Linq;
     using Nancy.Responses.Negotiation;
 
+    /// <summary>
+    /// Defines the functionality for providing serialization support.
+    /// </summary>
     public interface ISerializer
     {
         /// <summary>

--- a/src/Nancy/ISerializer.cs
+++ b/src/Nancy/ISerializer.cs
@@ -1,16 +1,19 @@
 ﻿namespace Nancy
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
+    using Nancy.Responses.Negotiation;
 
     public interface ISerializer
     {
         /// <summary>
         /// Whether the serializer can serialize the content type
         /// </summary>
-        /// <param name="contentType">Content type to serialise</param>
+        /// <param name="mediaRange">Content type to serialise</param>
         /// <returns>True if supported, false otherwise</returns>
-        bool CanSerialize(string contentType);
+        bool CanSerialize(MediaRange mediaRange);
 
         /// <summary>
         /// Gets the list of extensions that the serializer can handle.
@@ -21,10 +24,10 @@
         /// <summary>
         /// Serialize the given model with the given contentType
         /// </summary>
-        /// <param name="contentType">Content type to serialize into</param>
+        /// <param name="mediaRange">Content type to serialize into</param>
         /// <param name="model">Model to serialize</param>
         /// <param name="outputStream">Output stream to serialize to</param>
         /// <returns>Serialised object</returns>
-        void Serialize<TModel>(string contentType, TModel model, Stream outputStream);
+        void Serialize<TModel>(MediaRange mediaRange, TModel model, Stream outputStream);
     }
 }

--- a/src/Nancy/ISerializer.cs
+++ b/src/Nancy/ISerializer.cs
@@ -1,6 +1,5 @@
 ﻿namespace Nancy
 {
-    using System;
     using System.Collections.Generic;
     using System.IO;
     using Nancy.Responses.Negotiation;

--- a/src/Nancy/ISerializerFactory.cs
+++ b/src/Nancy/ISerializerFactory.cs
@@ -1,0 +1,17 @@
+namespace Nancy
+{
+    using Nancy.Responses.Negotiation;
+
+    /// <summary>
+    /// Defines the functionality of an <see cref="ISerializer"/> factory.
+    /// </summary>
+    public interface ISerializerFactory
+    {
+        /// <summary>
+        /// Gets the <see cref="ISerializer"/> implementation that can serialize the provided <paramref name="mediaRange"/>.
+        /// </summary>
+        /// <param name="mediaRange">The <see cref="MediaRange"/> to get a serializer for.</param>
+        /// <returns>An <see cref="ISerializer"/> instance, or <see langword="null" /> if not match was found.</returns>
+        ISerializer GetSerializer(MediaRange mediaRange);
+    }
+}

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -164,6 +164,7 @@
     <Compile Include="Diagnostics\DiagnosticsConfiguration.cs" />
     <Compile Include="Diagnostics\DiagnosticsConfigurationExtensions.cs" />
     <Compile Include="Diagnostics\DiagnosticsDefaultConfigurationProvider.cs" />
+    <Compile Include="Diagnostics\DiagnosticsSerializerFactory.cs" />
     <Compile Include="Diagnostics\DiagnosticsSession.cs" />
     <Compile Include="Diagnostics\ConcurrentLimitedCollection.cs" />
     <Compile Include="Diagnostics\DisabledDiagnostics.cs" />

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -157,6 +157,7 @@
     <Compile Include="Culture\ICultureService.cs" />
     <Compile Include="DefaultResponseFormatterFactory.cs" />
     <Compile Include="DefaultRootPathProvider.cs" />
+    <Compile Include="DefaultSerializerFactory.cs" />
     <Compile Include="DefaultStaticContentProvider.cs" />
     <Compile Include="Diagnostics\DefaultRequestTraceFactory.cs" />
     <Compile Include="Diagnostics\DefaultTraceLog.cs" />
@@ -190,6 +191,7 @@
     <Compile Include="Helpers\CacheHelpers.cs" />
     <Compile Include="Helpers\ExceptionExtensions.cs" />
     <Compile Include="IncludeInNancyAssemblyScanningAttribute.cs" />
+    <Compile Include="ISerializerFactory.cs" />
     <Compile Include="IStaticContentProvider.cs" />
     <Compile Include="Json\Converters\TupleConverter.cs" />
     <Compile Include="Json\JavaScriptPrimitiveConverter.cs" />

--- a/src/Nancy/Responses/DefaultJsonSerializer.cs
+++ b/src/Nancy/Responses/DefaultJsonSerializer.cs
@@ -6,6 +6,7 @@
 
     using Nancy.IO;
     using Nancy.Json;
+    using Nancy.Responses.Negotiation;
 
     public class DefaultJsonSerializer : ISerializer
     {
@@ -15,11 +16,11 @@
         /// <summary>
         /// Whether the serializer can serialize the content type
         /// </summary>
-        /// <param name="contentType">Content type to serialise</param>
+        /// <param name="mediaRange">Content type to serialise</param>
         /// <returns>True if supported, false otherwise</returns>
-        public bool CanSerialize(string contentType)
+        public bool CanSerialize(MediaRange mediaRange)
         {
-            return IsJsonType(contentType);
+            return IsJsonType(mediaRange);
         }
 
         /// <summary>
@@ -59,11 +60,11 @@
         /// <summary>
         /// Serialize the given model with the given contentType
         /// </summary>
-        /// <param name="contentType">Content type to serialize into</param>
+        /// <param name="mediaRange">Content type to serialize into</param>
         /// <param name="model">Model to serialize</param>
         /// <param name="outputStream">Stream to serialize to</param>
         /// <returns>Serialised object</returns>
-        public void Serialize<TModel>(string contentType, TModel model, Stream outputStream)
+        public void Serialize<TModel>(MediaRange mediaRange, TModel model, Stream outputStream)
         {
             using (var writer = new StreamWriter(new UnclosableStreamWrapper(outputStream)))
             {

--- a/src/Nancy/Responses/DefaultJsonSerializer.cs
+++ b/src/Nancy/Responses/DefaultJsonSerializer.cs
@@ -32,10 +32,7 @@
         /// <value>An <see cref="IEnumerable{T}"/> of extensions if any are available, otherwise an empty enumerable.</value>
         public IEnumerable<string> Extensions
         {
-            get
-            {
-                yield return "json";
-            }
+            get { yield return "json"; }
         }
 
         /// <summary>

--- a/src/Nancy/Responses/DefaultJsonSerializer.cs
+++ b/src/Nancy/Responses/DefaultJsonSerializer.cs
@@ -8,6 +8,9 @@
     using Nancy.Json;
     using Nancy.Responses.Negotiation;
 
+    /// <summary>
+    /// Default <see cref="ISerializer"/> implementation for JSON serialization.
+    /// </summary>
     public class DefaultJsonSerializer : ISerializer
     {
         private bool? retainCasing;

--- a/src/Nancy/Responses/DefaultXmlSerializer.cs
+++ b/src/Nancy/Responses/DefaultXmlSerializer.cs
@@ -29,10 +29,7 @@
         /// <value>An <see cref="IEnumerable{T}"/> of extensions if any are available, otherwise an empty enumerable.</value>
         public IEnumerable<string> Extensions
         {
-            get
-            {
-                yield return "xml";
-            }
+            get { yield return "xml"; }
         }
 
         /// <summary>

--- a/src/Nancy/Responses/DefaultXmlSerializer.cs
+++ b/src/Nancy/Responses/DefaultXmlSerializer.cs
@@ -5,6 +5,7 @@
     using System.IO;
     using System.Xml.Serialization;
     using System.Text;
+    using Nancy.Responses.Negotiation;
     using Nancy.Xml;
 
     public class DefaultXmlSerializer : ISerializer
@@ -12,11 +13,11 @@
         /// <summary>
         /// Whether the serializer can serialize the content type
         /// </summary>
-        /// <param name="contentType">Content type to serialise</param>
+        /// <param name="mediaRange">Content type to serialise</param>
         /// <returns>True if supported, false otherwise</returns>
-        public bool CanSerialize(string contentType)
+        public bool CanSerialize(MediaRange mediaRange)
         {
-            return IsXmlType(contentType);
+            return IsXmlType(mediaRange);
         }
 
         /// <summary>
@@ -34,11 +35,11 @@
         /// <summary>
         /// Serialize the given model with the given contentType
         /// </summary>
-        /// <param name="contentType">Content type to serialize into</param>
+        /// <param name="mediaRange">Content type to serialize into</param>
         /// <param name="model">Model to serialize</param>
         /// <param name="outputStream">Output stream to serialize to</param>
         /// <returns>Serialised object</returns>
-        public void Serialize<TModel>(string contentType, TModel model, Stream outputStream)
+        public void Serialize<TModel>(MediaRange mediaRange, TModel model, Stream outputStream)
         {
             try
             {

--- a/src/Nancy/Responses/DefaultXmlSerializer.cs
+++ b/src/Nancy/Responses/DefaultXmlSerializer.cs
@@ -8,6 +8,9 @@
     using Nancy.Responses.Negotiation;
     using Nancy.Xml;
 
+    /// <summary>
+    /// Default <see cref="ISerializer"/> implementation for XML serialization.
+    /// </summary>
     public class DefaultXmlSerializer : ISerializer
     {
         /// <summary>

--- a/src/Nancy/Responses/Negotiation/JsonProcessor.cs
+++ b/src/Nancy/Responses/Negotiation/JsonProcessor.cs
@@ -30,7 +30,7 @@
         /// </summary>
         public IEnumerable<Tuple<string, MediaRange>> ExtensionMappings
         {
-            get {  return extensionMappings; }
+            get { return extensionMappings; }
         }
 
         /// <summary>
@@ -45,10 +45,10 @@
             if (IsExactJsonContentType(requestedMediaRange))
             {
                 return new ProcessorMatch
-                    {
-                        ModelResult = MatchResult.DontCare,
-                        RequestedContentTypeResult = MatchResult.ExactMatch
-                    };
+                {
+                    ModelResult = MatchResult.DontCare,
+                    RequestedContentTypeResult = MatchResult.ExactMatch
+                };
             }
 
             if (IsWildcardJsonContentType(requestedMediaRange))


### PR DESCRIPTION
The idea is that this what you will take a dependency on, instead of `IEnumerable<ISerializer>`, and it will give you the serializer that matches the provided `MediaRange`.

The default implementation will take the default serializers into account and only return them if no other match could be made. 

If there are multiple matched (not counting the defaults) then it will throw an `InvalidOperationException` with a detailed error message, telling you about the types of the implementations that it matched.

I have also updated the `ISerializer.CanSerialize` and `Serialize` methods to accept a `MediaRange` instance, instead of string, for the `contentType` parameter. This works fine since it can implicitly be case to/from a string.

--

Except for adding this in to `NancyInternalConfiguration` I've not made any use of this yet. I wanted to get some feedback before I started ripping stuff apart and plugging this in. The idea is that this both makes things more testable, but also reduces the need for all `ISerializer` users to do the matching themselves. We currently have a couple of places (like the `AsXml` and `AsJson` extension methods) where we explicitly new up instances of `DefaultXmlSerializer` and `DefaultJsonSerializer`, creating hidden dependencies in the code.

This is a bit of yakshaving before migrating the `JsonSettings` and `XmlSettings` into the new unified configuration API.