### PR TITLE
Added GetEnvironment() method on INancyBootstrapper

### DIFF
--- a/src/Nancy.Hosting.Aspnet/DefaultNancyAspNetBootstrapper.cs
+++ b/src/Nancy.Hosting.Aspnet/DefaultNancyAspNetBootstrapper.cs
@@ -73,7 +73,7 @@
         /// </summary>
         /// <param name="context">Current request context</param>
         /// <returns>IEnumerable of INancyModule</returns>
-        public override sealed IEnumerable<INancyModule> GetAllModules(NancyContext context)
+        public sealed override IEnumerable<INancyModule> GetAllModules(NancyContext context)
         {
             return this.ApplicationContainer.ResolveAll<INancyModule>(false);
         }
@@ -94,7 +94,7 @@
         /// </summary>
         /// <param name="context">The <see cref="NancyContext"/> used by the request.</param>
         /// <returns>An <see cref="IPipelines"/> instance.</returns>
-        protected override sealed IPipelines InitializeRequestPipelines(NancyContext context)
+        protected sealed override IPipelines InitializeRequestPipelines(NancyContext context)
         {
             return base.InitializeRequestPipelines(context);
         }
@@ -114,7 +114,7 @@
         /// Resolve INancyEngine
         /// </summary>
         /// <returns>INancyEngine implementation</returns>
-        protected override sealed INancyEngine GetEngineInternal()
+        protected sealed override INancyEngine GetEngineInternal()
         {
             return this.ApplicationContainer.Resolve<INancyEngine>();
         }
@@ -134,7 +134,7 @@
         /// to take the responsibility of registering things like INancyModuleCatalog manually.
         /// </summary>
         /// <param name="applicationContainer">Application container to register into</param>
-        protected override sealed void RegisterBootstrapperTypes(TinyIoCContainer applicationContainer)
+        protected sealed override void RegisterBootstrapperTypes(TinyIoCContainer applicationContainer)
         {
             applicationContainer.Register<INancyModuleCatalog>(this);
         }
@@ -159,11 +159,21 @@
         }
 
         /// <summary>
+        /// Get the <see cref="INancyEnvironment"/> instance.
+        /// </summary>
+        /// <returns>An configured <see cref="INancyEnvironment"/> instance.</returns>
+        /// <remarks>The boostrapper must be initialised (<see cref="INancyBootstrapper.Initialise"/>) prior to calling this.</remarks>
+        public override INancyEnvironment GetEnvironment()
+        {
+            return this.ApplicationContainer.Resolve<INancyEnvironment>();
+        }
+
+        /// <summary>
         /// Register the default implementations of internally used types into the container as singletons
         /// </summary>
         /// <param name="container">Container to register into</param>
         /// <param name="typeRegistrations">Type registrations to register</param>
-        protected override sealed void RegisterTypes(TinyIoCContainer container, IEnumerable<TypeRegistration> typeRegistrations)
+        protected sealed override void RegisterTypes(TinyIoCContainer container, IEnumerable<TypeRegistration> typeRegistrations)
         {
             foreach (var typeRegistration in typeRegistrations)
             {
@@ -190,7 +200,7 @@
         /// </summary>
         /// <param name="container">Container to register into</param>
         /// <param name="collectionTypeRegistrations">Collection type registrations to register</param>
-        protected override sealed void RegisterCollectionTypes(TinyIoCContainer container, IEnumerable<CollectionTypeRegistration> collectionTypeRegistrations)
+        protected sealed override void RegisterCollectionTypes(TinyIoCContainer container, IEnumerable<CollectionTypeRegistration> collectionTypeRegistrations)
         {
             foreach (var collectionTypeRegistration in collectionTypeRegistrations)
             {
@@ -216,7 +226,7 @@
         /// </summary>
         /// <param name="container">Container to register into</param>
         /// <param name="moduleRegistrationTypes">NancyModule types</param>
-        protected override sealed void RegisterModules(TinyIoCContainer container, IEnumerable<ModuleRegistration> moduleRegistrationTypes)
+        protected sealed override void RegisterModules(TinyIoCContainer container, IEnumerable<ModuleRegistration> moduleRegistrationTypes)
         {
             foreach (var registrationType in moduleRegistrationTypes)
             {

--- a/src/Nancy.Testing/ConfigurableBootstrapper.cs
+++ b/src/Nancy.Testing/ConfigurableBootstrapper.cs
@@ -148,6 +148,16 @@ namespace Nancy.Testing
         }
 
         /// <summary>
+        /// Get the <see cref="INancyEnvironment"/> instance.
+        /// </summary>
+        /// <returns>An configured <see cref="INancyEnvironment"/> instance.</returns>
+        /// <remarks>The boostrapper must be initialised (<see cref="INancyBootstrapper.Initialise"/>) prior to calling this.</remarks>
+        public override INancyEnvironment GetEnvironment()
+        {
+            return base.ApplicationContainer.Resolve<INancyEnvironment>();
+        }
+
+        /// <summary>
         /// Retrieve a specific module instance from the container
         /// </summary>
         /// <param name="container">Container to use</param>

--- a/src/Nancy.Tests/Unit/Bootstrapper/NancyBootstrapperBaseFixture.cs
+++ b/src/Nancy.Tests/Unit/Bootstrapper/NancyBootstrapperBaseFixture.cs
@@ -396,6 +396,11 @@
                     .FirstOrDefault();
         }
 
+        public override INancyEnvironment GetEnvironment()
+        {
+            throw new NotImplementedException();
+        }
+
         protected override void ConfigureApplicationContainer(FakeContainer existingContainer)
         {
             this.AppContainer = existingContainer;
@@ -555,6 +560,11 @@
         /// <param name="context">The current context</param>
         /// <returns>The <see cref="INancyModule"/> instance</returns>
         public override INancyModule GetModule(Type moduleType, NancyContext context)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override INancyEnvironment GetEnvironment()
         {
             throw new NotImplementedException();
         }

--- a/src/Nancy.Tests/Unit/Bootstrapper/NancyBootstrapperWithRequestContainerBaseFixture.cs
+++ b/src/Nancy.Tests/Unit/Bootstrapper/NancyBootstrapperWithRequestContainerBaseFixture.cs
@@ -292,6 +292,11 @@
                 return this.OverriddenRegistrationTasks ?? new IRegistrations[] { };
             }
 
+            public override INancyEnvironment GetEnvironment()
+            {
+                throw new NotImplementedException();
+            }
+
             protected override void ConfigureApplicationContainer(FakeContainer existingContainer)
             {
                 this.AppContainer = existingContainer;

--- a/src/Nancy/Bootstrapper/INancyBootstrapper.cs
+++ b/src/Nancy/Bootstrapper/INancyBootstrapper.cs
@@ -1,6 +1,7 @@
 ﻿namespace Nancy.Bootstrapper
 {
     using System;
+    using Nancy.Configuration;
 
     /// <summary>
     /// Bootstrapper for the Nancy Engine
@@ -8,14 +9,23 @@
     public interface INancyBootstrapper : IDisposable
     {
         /// <summary>
-        /// Initialise the bootstrapper. Must be called prior to GetEngine.
+        /// Initialise the bootstrapper.
         /// </summary>
+        /// <remarks>Must be called prior to <see cref="GetEngine"/> and <see cref="GetEnvironment"/>.</remarks>
         void Initialise();
 
         /// <summary>
-        /// Gets the configured INancyEngine
+        /// Gets the configured <see cref="INancyEngine"/>.
         /// </summary>
-        /// <returns>Configured INancyEngine</returns>
+        /// <returns>An configured <see cref="INancyEngine"/> instance.</returns>
+        /// <remarks>The boostrapper must be initialised (<see cref="Initialise"/>) prior to calling this.</remarks>
         INancyEngine GetEngine();
+
+        /// <summary>
+        /// Get the <see cref="INancyEnvironment"/> instance.
+        /// </summary>
+        /// <returns>An configured <see cref="INancyEnvironment"/> instance.</returns>
+        /// <remarks>The boostrapper must be initialised (<see cref="Initialise"/>) prior to calling this.</remarks>
+        INancyEnvironment GetEnvironment();
     }
 }

--- a/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
+++ b/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
@@ -100,7 +100,7 @@
                 return this.conventions;
             }
         }
-        
+
         /// <summary>
         /// Gets all available module types
         /// </summary>
@@ -273,7 +273,7 @@
         {
             applicationStartupTask.Initialize(this.ApplicationPipelines);
         }
-        
+
         this.RegisterModules(this.ApplicationContainer, this.Modules);
 
             this.ApplicationStartup(this.ApplicationContainer, this.ApplicationPipelines);
@@ -384,6 +384,13 @@
 
             return engine;
         }
+
+        /// <summary>
+        /// Get the <see cref="INancyEnvironment"/> instance.
+        /// </summary>
+        /// <returns>An configured <see cref="INancyEnvironment"/> instance.</returns>
+        /// <remarks>The boostrapper must be initialised (<see cref="INancyBootstrapper.Initialise"/>) prior to calling this.</remarks>
+        public abstract INancyEnvironment GetEnvironment();
 
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.

--- a/src/Nancy/DefaultNancyBootstrapper.cs
+++ b/src/Nancy/DefaultNancyBootstrapper.cs
@@ -238,6 +238,16 @@ namespace Nancy
         }
 
         /// <summary>
+        /// Get the <see cref="INancyEnvironment"/> instance.
+        /// </summary>
+        /// <returns>An configured <see cref="INancyEnvironment"/> instance.</returns>
+        /// <remarks>The boostrapper must be initialised (<see cref="INancyBootstrapper.Initialise"/>) prior to calling this.</remarks>
+        public override INancyEnvironment GetEnvironment()
+        {
+            return this.ApplicationContainer.Resolve<INancyEnvironment>();
+        }
+
+        /// <summary>
         /// Retrieve all module instances from the container
         /// </summary>
         /// <param name="container">Container to use</param>


### PR DESCRIPTION
This will let external environment (that hosts Nancy, such as out hosts and the `Nancy.Testing` stuff) get a hold of the ´INancyEnvironment` and read configuration values.

:warning: We're going to have to update the `Nancy.Bootstrapper.*` projects so they implement the new `INancyBootstrapper.GetEnvironment()`-method