### PR TITLE
Properly dispose CancellationTokenSource

### DIFF
--- a/src/Nancy/NancyEngine.cs
+++ b/src/Nancy/NancyEngine.cs
@@ -101,60 +101,61 @@
         /// <returns>The task object representing the asynchronous operation.</returns>
         public Task<NancyContext> HandleRequest(Request request, Func<NancyContext, NancyContext> preRequest, CancellationToken cancellationToken)
         {
-            var cts = CancellationTokenSource.CreateLinkedTokenSource(this.engineDisposedCts.Token, cancellationToken);
-
-            cts.Token.ThrowIfCancellationRequested();
-
-            var tcs = new TaskCompletionSource<NancyContext>();
-
-            if (request == null)
+            using (var cts = CancellationTokenSource.CreateLinkedTokenSource(this.engineDisposedCts.Token, cancellationToken))
             {
-                throw new ArgumentNullException("request", "The request parameter cannot be null.");
-            }
+                cts.Token.ThrowIfCancellationRequested();
 
-            var context = this.contextFactory.Create(request);
+                var tcs = new TaskCompletionSource<NancyContext>();
 
-            if (preRequest != null)
-            {
-                context = preRequest(context);
-            }
+                if (request == null)
+                {
+                    throw new ArgumentNullException("request", "The request parameter cannot be null.");
+                }
 
-            var staticContentResponse = this.staticContentProvider.GetContent(context);
-            if (staticContentResponse != null)
-            {
-                context.Response = staticContentResponse;
-                tcs.SetResult(context);
+                var context = this.contextFactory.Create(request);
+
+                if (preRequest != null)
+                {
+                    context = preRequest(context);
+                }
+
+                var staticContentResponse = this.staticContentProvider.GetContent(context);
+                if (staticContentResponse != null)
+                {
+                    context.Response = staticContentResponse;
+                    tcs.SetResult(context);
+                    return tcs.Task;
+                }
+
+                var pipelines = this.RequestPipelinesFactory.Invoke(context);
+
+                var lifeCycleTask = this.InvokeRequestLifeCycle(context, cts.Token, pipelines);
+
+                lifeCycleTask.WhenCompleted(
+                    completeTask =>
+                    {
+                        try
+                        {
+                            this.CheckStatusCodeHandler(completeTask.Result);
+
+                            this.SaveTraceInformation(completeTask.Result);
+                        }
+                        catch (Exception ex)
+                        {
+                            tcs.SetException(ex);
+                            return;
+                        }
+
+                        tcs.SetResult(completeTask.Result);
+                    },
+                    errorTask =>
+                    {
+                        tcs.SetException(errorTask.Exception);
+                    },
+                    true);
+
                 return tcs.Task;
             }
-
-            var pipelines = this.RequestPipelinesFactory.Invoke(context);
-
-            var lifeCycleTask = this.InvokeRequestLifeCycle(context, cts.Token, pipelines);
-
-            lifeCycleTask.WhenCompleted(
-                completeTask =>
-                {
-                    try
-                    {
-                        this.CheckStatusCodeHandler(completeTask.Result);
-
-                        this.SaveTraceInformation(completeTask.Result);
-                    }
-                    catch (Exception ex)
-                    {
-                        tcs.SetException(ex);
-                        return;
-                    }
-
-                    tcs.SetResult(completeTask.Result);
-                },
-                errorTask =>
-                {
-                    tcs.SetException(errorTask.Exception);
-                },
-                true);
-
-            return tcs.Task;
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes a memory leak of 40 bytes per request, introduced in https://github.com/NancyFx/Nancy/commit/4aeaf318e9710f9a0c3ac00befb35ee109ec82a2.

Because of the nesting (in the `using` block), this is best reviewed with [`?w=1`](https://github.com/NancyFx/Nancy/pull/2114/files?w=1) :wink:

We need to push this as 1.4.2 ASAP.

Closes #2113.