### PR TITLE
Virtual Dispose in NancyBootstrapperBase

### DIFF
--- a/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
+++ b/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
@@ -396,7 +396,7 @@
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
         /// <filterpriority>2</filterpriority>
-        public virtual void Dispose()
+        public void Dispose()
         {
             // Prevent StackOverflowException if ApplicationContainer.Dispose re-triggers this Dispose
             if (this.disposing)
@@ -426,6 +426,8 @@
             catch (ObjectDisposedException)
             {
             }
+
+            Dispose(true);
         }
 
         /// <summary>
@@ -516,6 +518,14 @@
         /// </summary>
         /// <param name="nancyConventions">Convention object instance</param>
         protected virtual void ConfigureConventions(NancyConventions nancyConventions)
+        {
+        }
+        
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
         {
         }
 

--- a/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
+++ b/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
@@ -414,18 +414,17 @@
 
             var container = this.ApplicationContainer as IDisposable;
 
-            if (container == null)
+            if (container != null)
             {
-                return;
+                try
+                {
+                    container.Dispose();
+                }
+                catch (ObjectDisposedException)
+                {
+                }
             }
 
-            try
-            {
-                container.Dispose();
-            }
-            catch (ObjectDisposedException)
-            {
-            }
 
             Dispose(true);
         }

--- a/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
+++ b/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
@@ -396,7 +396,7 @@
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
         /// <filterpriority>2</filterpriority>
-        public void Dispose()
+        public virtual void Dispose()
         {
             // Prevent StackOverflowException if ApplicationContainer.Dispose re-triggers this Dispose
             if (this.disposing)


### PR DESCRIPTION
This PR makes made `NancyBootstrapperBase.Dispose()` `virtual` so it can be overridden in deriving classes. This makes it easier for `StructureMapNancyBootstrapper` and others to dispose resources other than the `ApplicationContainer`.