### PR TITLE
Migrated JsonSettings to the configuration API

### DIFF
--- a/src/Nancy.Testing.Tests/BrowserResponseBodyWrapperExtensionsFixture.cs
+++ b/src/Nancy.Testing.Tests/BrowserResponseBodyWrapperExtensionsFixture.cs
@@ -1,7 +1,7 @@
 namespace Nancy.Testing.Tests
 {
     using System.IO;
-
+    using FakeItEasy;
     using Nancy.Tests;
 
     using Xunit;
@@ -20,7 +20,7 @@ namespace Nancy.Testing.Tests
                     writer.Write("This is the content");
                     writer.Flush();
                 }
-            });
+            }, A.Dummy<BrowserContext>());
 
             // When
             var result = body.AsString();

--- a/src/Nancy.Testing.Tests/BrowserResponseBodyWrapperFixture.cs
+++ b/src/Nancy.Testing.Tests/BrowserResponseBodyWrapperFixture.cs
@@ -3,7 +3,7 @@
     using System.IO;
     using System.Linq;
     using System.Text;
-
+    using FakeItEasy;
     using Nancy.Tests;
 
     using Xunit;
@@ -22,7 +22,7 @@
                     writer.Write("This is the content");
                     writer.Flush();
                 }
-            });
+            }, A.Dummy<BrowserContext>());
 
             var content = Encoding.ASCII.GetBytes("This is the content");
 
@@ -45,7 +45,7 @@
                     writer.Write("<div>Outer and <div id='bar'>inner</div></div>");
                     writer.Flush();
                 }
-            });
+            }, A.Dummy<BrowserContext>());
 
             // When
             var result = body["#bar"];

--- a/src/Nancy.Testing.Tests/BrowserResponseExtensionsTests.cs
+++ b/src/Nancy.Testing.Tests/BrowserResponseExtensionsTests.cs
@@ -1,9 +1,7 @@
 ﻿namespace Nancy.Testing.Tests
 {
     using System.Xml;
-
     using FakeItEasy;
-
     using Xunit;
 
     public class BrowserResponseExtensionsTests
@@ -13,19 +11,27 @@
 		[Fact]
 		public void Should_create_xdocument_from_xml_body()
 		{
+            // Given
 			var context = new NancyContext() { Response = "<tag />" };
-            sut = new BrowserResponse(context, A.Fake<Browser>()); 
+            sut = new BrowserResponse(context, A.Fake<Browser>(), A.Dummy<BrowserContext>());
+
+            // When
             var bodyAsXml = sut.BodyAsXml();
 
+            // Then
 			Assert.NotNull(bodyAsXml.Element("tag"));
 		}
 
 		[Fact]
 		public void Should_fail_to_create_xdocument_from_non_xml_body()
 		{
+            // Given
 			var context = new NancyContext() { Response = "hello" };
-			sut = new BrowserResponse(context, A.Fake<Browser>());	
 
+            // When
+		    sut = new BrowserResponse(context, A.Fake<Browser>(), A.Dummy<BrowserContext>());
+
+            // Then
 			Assert.Throws<XmlException>(() => sut.BodyAsXml());
 		}
 	}

--- a/src/Nancy.Testing.Tests/ContextExtensionsTests.cs
+++ b/src/Nancy.Testing.Tests/ContextExtensionsTests.cs
@@ -4,6 +4,7 @@ namespace Nancy.Testing.Tests
     using System.IO;
     using System.Text;
     using Nancy.Configuration;
+    using Nancy.Json;
     using Nancy.Responses;
     using Nancy.Tests;
     using Nancy.Xml;
@@ -70,7 +71,8 @@ namespace Nancy.Testing.Tests
         public void Should_create_new_wrapper_from_json_response_if_not_already_present()
         {
             // Given
-            var response = new JsonResponse<Model>(new Model() { Dummy = "Data" }, new DefaultJsonSerializer());
+            var environment = GetTestingEnvironment();
+            var response = new JsonResponse<Model>(new Model() { Dummy = "Data" }, new DefaultJsonSerializer(environment), environment);
             var context = new NancyContext() { Response = response };
 
             // When
@@ -114,7 +116,8 @@ namespace Nancy.Testing.Tests
         public void Should_fail_to_return_xml_body_on_non_xml_response()
         {
             // Given
-            var response = new JsonResponse<Model>(new Model() { Dummy = "Data" }, new DefaultJsonSerializer());
+            var environment = GetTestingEnvironment();
+            var response = new JsonResponse<Model>(new Model() { Dummy = "Data" }, new DefaultJsonSerializer(environment), environment);
             var context = new NancyContext() { Response = response };
 
             // When
@@ -122,6 +125,16 @@ namespace Nancy.Testing.Tests
 
             // Then
             result.ShouldNotBeNull();
+        }
+
+        private static INancyEnvironment GetTestingEnvironment()
+        {
+            var envionment =
+                new DefaultNancyEnvironment();
+
+            envionment.AddValue(JsonConfiguration.Default);
+
+            return envionment;
         }
 
         public class Model

--- a/src/Nancy.Testing/BrowserContextExtensions.cs
+++ b/src/Nancy.Testing/BrowserContextExtensions.cs
@@ -55,7 +55,7 @@
         {
             if (serializer == null)
             {
-                serializer = new DefaultJsonSerializer();
+                serializer = new DefaultJsonSerializer(browserContext.Environment);
             }
 
             var contextValues =

--- a/src/Nancy.Testing/BrowserResponse.cs
+++ b/src/Nancy.Testing/BrowserResponse.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-
     using Nancy.Cookies;
 
     /// <summary>
@@ -11,7 +10,7 @@
     public class BrowserResponse
     {
         private readonly Browser hostBrowser;
-
+        private readonly BrowserContext browserContext;
         private BrowserResponseBodyWrapper body;
 
         /// <summary>
@@ -19,8 +18,9 @@
         /// </summary>
         /// <param name="context">The <see cref="NancyContext"/> that <see cref="Browser"/> was invoked with.</param>
         /// <param name="hostBrowser">Host browser object</param>
+        /// <param name="browserContext">An <see cref="BrowserContext"/> instance.</param>
         /// <exception cref="ArgumentNullException">The value of the <paramref name="context"/> parameter was <see langword="null"/>.</exception>
-        public BrowserResponse(NancyContext context, Browser hostBrowser)
+        public BrowserResponse(NancyContext context, Browser hostBrowser, BrowserContext browserContext)
         {
             if (context == null)
             {
@@ -33,6 +33,7 @@
             }
 
             this.hostBrowser = hostBrowser;
+            this.browserContext = browserContext;
 
             this.Context = context;
         }
@@ -45,7 +46,7 @@
         {
             get
             {
-                return this.body ?? (this.body = new BrowserResponseBodyWrapper(this.Context.Response));
+                return this.body ?? (this.body = new BrowserResponseBodyWrapper(this.Context.Response, this.browserContext));
             }
         }
 

--- a/src/Nancy.Testing/BrowserResponseBodyWrapper.cs
+++ b/src/Nancy.Testing/BrowserResponseBodyWrapper.cs
@@ -18,8 +18,10 @@ namespace Nancy.Testing
         /// Initializes a new instance of the <see cref="BrowserResponseBodyWrapper"/> class.
         /// </summary>
         /// <param name="response">The <see cref="Response"/> to wrap.</param>
-        public BrowserResponseBodyWrapper(Response response)
+        /// <param name="browserContext">The <see cref="BrowserContext"/> of the request that generated the response.</param>
+        public BrowserResponseBodyWrapper(Response response, BrowserContext browserContext)
         {
+            this.BrowserContext = browserContext;
             var contentStream = GetContentStream(response);
 
             this.responseBytes = contentStream.ToArray();
@@ -34,6 +36,12 @@ namespace Nancy.Testing
         {
             get { return this.contentType; }
         }
+
+        /// <summary>
+        /// Gets the <see cref="BrowserContext"/> of the request that generated the response.
+        /// </summary>
+        /// <value>A <see cref="BrowserContext"/> intance.</value>
+        public BrowserContext BrowserContext { get; private set; }
 
         private static MemoryStream GetContentStream(Response response)
         {

--- a/src/Nancy.Testing/BrowserResponseBodyWrapperExtensions.cs
+++ b/src/Nancy.Testing/BrowserResponseBodyWrapperExtensions.cs
@@ -55,7 +55,7 @@ namespace Nancy.Testing
         /// <value>A <typeparamref name="TModel"/> instance representation of the HTTP response body.</value>
         public static TModel DeserializeJson<TModel>(this BrowserResponseBodyWrapper bodyWrapper)
         {
-            var bodyDeserializer = new JsonBodyDeserializer();
+            var bodyDeserializer = new JsonBodyDeserializer(bodyWrapper.BrowserContext.Environment);
 
             return bodyWrapper.Deserialize<TModel>(bodyDeserializer);
         }

--- a/src/Nancy.Tests/Unit/DefaultSerializerFactoryFixture.cs
+++ b/src/Nancy.Tests/Unit/DefaultSerializerFactoryFixture.cs
@@ -4,6 +4,8 @@
     using System.Collections.Generic;
     using System.IO;
     using System.Threading;
+    using Nancy.Configuration;
+    using Nancy.Json;
     using Nancy.Responses;
     using Nancy.Responses.Negotiation;
     using Xunit;
@@ -100,7 +102,7 @@
             var serializers = new ISerializer[]
             {
                 new TestableSerializer("application/json"),
-                new DefaultJsonSerializer()
+                new DefaultJsonSerializer(GetTestingEnvironment())
             };
 
             this.serializerFactory = new DefaultSerializerFactory(serializers);
@@ -119,7 +121,7 @@
 
             var serializers = new ISerializer[]
             {
-                new DefaultJsonSerializer(),
+                new DefaultJsonSerializer(GetTestingEnvironment()),
                 expectedSerializer
             };
 
@@ -137,7 +139,7 @@
         {
             // Given
             var expectedSerializer =
-                new DefaultJsonSerializer();
+                new DefaultJsonSerializer(GetTestingEnvironment());
 
             var serializers = new ISerializer[]
             {
@@ -153,6 +155,16 @@
 
             // Then
             result.ShouldBeSameAs(expectedSerializer);
+        }
+
+        private static INancyEnvironment GetTestingEnvironment()
+        {
+            var envionment =
+                new DefaultNancyEnvironment();
+
+            envionment.AddValue(JsonConfiguration.Default);
+
+            return envionment;
         }
 
         internal class ExceptionThrowingSerializer : ISerializer

--- a/src/Nancy.Tests/Unit/Json/JavaScriptSerializerFixture.cs
+++ b/src/Nancy.Tests/Unit/Json/JavaScriptSerializerFixture.cs
@@ -18,8 +18,8 @@
         public void Should_register_converters_when_asked()
         {
             // Given
-            JsonSettings.Converters.Add(new TestConverter());
-            JsonSettings.PrimitiveConverters.Add(new TestPrimitiveConverter());
+            JsonConfiguration.Converters.Add(new TestConverter());
+            JsonConfiguration.PrimitiveConverters.Add(new TestPrimitiveConverter());
 
             var defaultSerializer = new JavaScriptSerializer();
 
@@ -60,8 +60,8 @@
         public void Should_not_register_converters_when_not_asked()
         {
             // Given
-            JsonSettings.Converters.Add(new TestConverter());
-            JsonSettings.PrimitiveConverters.Add(new TestPrimitiveConverter());
+            JsonConfiguration.Converters.Add(new TestConverter());
+            JsonConfiguration.PrimitiveConverters.Add(new TestPrimitiveConverter());
 
             var defaultSerializer = new JavaScriptSerializer();
 

--- a/src/Nancy.Tests/Unit/Json/JavaScriptSerializerFixture.cs
+++ b/src/Nancy.Tests/Unit/Json/JavaScriptSerializerFixture.cs
@@ -1,15 +1,10 @@
 ﻿namespace Nancy.Tests.Unit.Json
 {
     using System;
-    using System.Collections.Generic;
-    using System.IO;
-    using FakeItEasy;
-    using Nancy.IO;
+    using Nancy.Configuration;
     using Nancy.Json;
     using Nancy.Json.Converters;
-
     using Xunit;
-    using Xunit.Extensions;
     using Xunit.Sdk;
 
     public class JavaScriptSerializerFixture
@@ -18,9 +13,6 @@
         public void Should_register_converters_when_asked()
         {
             // Given
-            JsonConfiguration.Converters.Add(new TestConverter());
-            JsonConfiguration.PrimitiveConverters.Add(new TestPrimitiveConverter());
-
             var defaultSerializer = new JavaScriptSerializer();
 
             // When
@@ -30,7 +22,9 @@
                 maxJsonLength: defaultSerializer.MaxJsonLength,
                 recursionLimit: defaultSerializer.RecursionLimit,
                 retainCasing: defaultSerializer.RetainCasing,
-                iso8601DateFormat: defaultSerializer.ISO8601DateFormat);
+                iso8601DateFormat: defaultSerializer.ISO8601DateFormat,
+                converters: new[] { new TestConverter() },
+                primitiveConverters: new[] { new TestPrimitiveConverter() });
 
             var data =
                 new TestData()
@@ -60,9 +54,6 @@
         public void Should_not_register_converters_when_not_asked()
         {
             // Given
-            JsonConfiguration.Converters.Add(new TestConverter());
-            JsonConfiguration.PrimitiveConverters.Add(new TestPrimitiveConverter());
-
             var defaultSerializer = new JavaScriptSerializer();
 
             // When
@@ -72,7 +63,9 @@
                 maxJsonLength: defaultSerializer.MaxJsonLength,
                 recursionLimit: defaultSerializer.RecursionLimit,
                 retainCasing: defaultSerializer.RetainCasing,
-                iso8601DateFormat: defaultSerializer.ISO8601DateFormat);
+                iso8601DateFormat: defaultSerializer.ISO8601DateFormat,
+                converters: new[] { new TestConverter() },
+                primitiveConverters: new[] { new TestPrimitiveConverter() });
 
             var data =
                 new TestData()
@@ -176,6 +169,16 @@
             var typeWithTuple = serializer.Deserialize<TypeWithTuple>(@"{""value"":{""item1"":10,""item2"":11}}");
             typeWithTuple.Value.Item1.ShouldEqual(10);
             typeWithTuple.Value.Item2.ShouldEqual(11);
+        }
+
+        private INancyEnvironment GetTestingEnvironment(JsonConfiguration configuration)
+        {
+            var environment =
+                new DefaultNancyEnvironment();
+
+            environment.AddValue(configuration);
+
+            return environment;
         }
     }
 }

--- a/src/Nancy.Tests/Unit/JsonFormatterExtensionsFixtures.cs
+++ b/src/Nancy.Tests/Unit/JsonFormatterExtensionsFixtures.cs
@@ -4,7 +4,8 @@ namespace Nancy.Tests.Unit
     using System.Text;
 
     using FakeItEasy;
-
+    using Nancy.Configuration;
+    using Nancy.Json;
     using Nancy.Responses;
     using Nancy.Tests.Fakes;
 
@@ -18,10 +19,12 @@ namespace Nancy.Tests.Unit
 
         public JsonFormatterExtensionsFixtures()
         {
+            var environment = GetTestingEnvironment();
             var serializerFactory =
-               new DefaultSerializerFactory(new ISerializer[] { new DefaultJsonSerializer() });
+               new DefaultSerializerFactory(new ISerializer[] { new DefaultJsonSerializer(environment) });
 
             this.formatter = A.Fake<IResponseFormatter>();
+            A.CallTo(() => this.formatter.Environment).Returns(environment);
             A.CallTo(() => this.formatter.SerializerFactory).Returns(serializerFactory);
             this.model = new Person { FirstName = "Andy", LastName = "Pike" };
             this.response = this.formatter.AsJson(model);
@@ -77,6 +80,16 @@ namespace Nancy.Tests.Unit
         {
             var response = formatter.AsJson(new { foo = "bar" }, HttpStatusCode.InternalServerError);
             Assert.Equal(response.StatusCode, HttpStatusCode.InternalServerError);
+        }
+
+        private static INancyEnvironment GetTestingEnvironment()
+        {
+            var envionment =
+                new DefaultNancyEnvironment();
+
+            envionment.AddValue(JsonConfiguration.Default);
+
+            return envionment;
         }
     }
 }

--- a/src/Nancy.Tests/Unit/ModelBinding/DefaultBinderFixture.cs
+++ b/src/Nancy.Tests/Unit/ModelBinding/DefaultBinderFixture.cs
@@ -42,7 +42,7 @@ namespace Nancy.Tests.Unit.ModelBinding
             A.CallTo(() => this.emptyDefaults.DefaultTypeConverters).Returns(new ITypeConverter[] { });
 
             this.serializer = new JavaScriptSerializer();
-            this.serializer.RegisterConverters(JsonSettings.Converters);
+            this.serializer.RegisterConverters(JsonConfiguration.Converters);
         }
 
         [Fact]

--- a/src/Nancy.Tests/Unit/ModelBinding/DefaultBinderFixture.cs
+++ b/src/Nancy.Tests/Unit/ModelBinding/DefaultBinderFixture.cs
@@ -7,9 +7,8 @@ namespace Nancy.Tests.Unit.ModelBinding
     using System.Linq;
     using System.Text;
     using System.Xml.Serialization;
-
     using FakeItEasy;
-
+    using Nancy.Configuration;
     using Nancy.IO;
     using Nancy.Json;
     using Nancy.ModelBinding;
@@ -27,29 +26,31 @@ namespace Nancy.Tests.Unit.ModelBinding
         private readonly IFieldNameConverter passthroughNameConverter;
         private readonly BindingDefaults emptyDefaults;
         private readonly JavaScriptSerializer serializer;
-        private readonly BindingContext defaultBindingContext;
+        private readonly BindingDefaults bindingDefaults;
 
         public DefaultBinderFixture()
         {
-            this.defaultBindingContext = new BindingContext();
+            var environment = new DefaultNancyEnvironment();
+            environment.AddValue(JsonConfiguration.Default);
 
             this.passthroughNameConverter = A.Fake<IFieldNameConverter>();
             A.CallTo(() => this.passthroughNameConverter.Convert(null)).WithAnyArguments()
                 .ReturnsLazily(f => (string)f.Arguments[0]);
 
-            this.emptyDefaults = A.Fake<BindingDefaults>();
+            this.serializer = new JavaScriptSerializer();
+            this.serializer.RegisterConverters(JsonConfiguration.Default.Converters);
+            this.bindingDefaults = new BindingDefaults(environment);
+
+            this.emptyDefaults = A.Fake<BindingDefaults>(options => options.WithArgumentsForConstructor(new[] { environment }));
             A.CallTo(() => this.emptyDefaults.DefaultBodyDeserializers).Returns(new IBodyDeserializer[] { });
             A.CallTo(() => this.emptyDefaults.DefaultTypeConverters).Returns(new ITypeConverter[] { });
-
-            this.serializer = new JavaScriptSerializer();
-            this.serializer.RegisterConverters(JsonConfiguration.Converters);
         }
 
         [Fact]
         public void Should_throw_if_type_converters_is_null()
         {
             // Given, When
-            var result = Record.Exception(() => new DefaultBinder(null, new IBodyDeserializer[] { }, A.Fake<IFieldNameConverter>(), new BindingDefaults()));
+            var result = Record.Exception(() => new DefaultBinder(null, new IBodyDeserializer[] { }, A.Fake<IFieldNameConverter>(), this.bindingDefaults));
 
             // Then
             result.ShouldBeOfType(typeof(ArgumentNullException));
@@ -59,7 +60,7 @@ namespace Nancy.Tests.Unit.ModelBinding
         public void Should_throw_if_body_deserializers_is_null()
         {
             // Given, When
-            var result = Record.Exception(() => new DefaultBinder(new ITypeConverter[] { }, null, A.Fake<IFieldNameConverter>(), new BindingDefaults()));
+            var result = Record.Exception(() => new DefaultBinder(new ITypeConverter[] { }, null, A.Fake<IFieldNameConverter>(), this.bindingDefaults));
 
             // Then
             result.ShouldBeOfType(typeof(ArgumentNullException));
@@ -103,7 +104,7 @@ namespace Nancy.Tests.Unit.ModelBinding
         public void Should_throw_if_field_name_converter_is_null()
         {
             // Given, When
-            var result = Record.Exception(() => new DefaultBinder(new ITypeConverter[] { }, new IBodyDeserializer[] { }, null, new BindingDefaults()));
+            var result = Record.Exception(() => new DefaultBinder(new ITypeConverter[] { }, new IBodyDeserializer[] { }, null, this.bindingDefaults));
 
             // Then
             result.ShouldBeOfType(typeof(ArgumentNullException));
@@ -1220,7 +1221,7 @@ namespace Nancy.Tests.Unit.ModelBinding
         public void Should_bind_string_array_model_from_body()
         {
             //Given
-            var binder = this.GetBinder(null, new List<IBodyDeserializer> { new JsonBodyDeserializer() });
+            var binder = this.GetBinder(null, new List<IBodyDeserializer> { new JsonBodyDeserializer(GetTestingEnvironment()) });
             var body = serializer.Serialize(new[] { "Test","AnotherTest"});
 
             var context = CreateContextWithHeaderAndBody("Content-Type", new[] { "application/json" }, body);
@@ -1237,7 +1238,7 @@ namespace Nancy.Tests.Unit.ModelBinding
         public void Should_bind_ienumerable_model_from_body()
         {
             //Given
-            var binder = this.GetBinder(null, new List<IBodyDeserializer> { new JsonBodyDeserializer() });
+            var binder = this.GetBinder(null, new List<IBodyDeserializer> { new JsonBodyDeserializer(GetTestingEnvironment()) });
             var body = serializer.Serialize(new List<TestModel>(new[] { new TestModel { StringProperty = "Test" }, new TestModel { StringProperty = "AnotherTest" } }));
 
             var context = CreateContextWithHeaderAndBody("Content-Type", new[] { "application/json" }, body);
@@ -1255,7 +1256,7 @@ namespace Nancy.Tests.Unit.ModelBinding
         public void Should_bind_ienumerable_model_with_instance_from_body()
         {
             //Given
-            var binder = this.GetBinder(null, new List<IBodyDeserializer> { new JsonBodyDeserializer() });
+            var binder = this.GetBinder(null, new List<IBodyDeserializer> { new JsonBodyDeserializer(GetTestingEnvironment()) });
             var body = serializer.Serialize(new List<TestModel>(new[] { new TestModel { StringProperty = "Test" }, new TestModel { StringProperty = "AnotherTest" } }));
 
             var context = CreateContextWithHeaderAndBody("Content-Type", new[] { "application/json" }, body);
@@ -1301,7 +1302,7 @@ namespace Nancy.Tests.Unit.ModelBinding
         {
             //Given
             var typeConverters = new ITypeConverter[] { new CollectionConverter(), new FallbackConverter() };
-            var binder = this.GetBinder(typeConverters, new List<IBodyDeserializer> { new JsonBodyDeserializer() });
+            var binder = this.GetBinder(typeConverters, new List<IBodyDeserializer> { new JsonBodyDeserializer(GetTestingEnvironment()) });
             var body = serializer.Serialize(
                 new TestModel
                 {
@@ -1327,7 +1328,7 @@ namespace Nancy.Tests.Unit.ModelBinding
         public void Should_bind_array_model_from_body_that_contains_an_array()
         {
             //Given
-            var binder = this.GetBinder(null, new List<IBodyDeserializer> { new JsonBodyDeserializer() });
+            var binder = this.GetBinder(null, new List<IBodyDeserializer> { new JsonBodyDeserializer(GetTestingEnvironment()) });
             var body =
                 serializer.Serialize(new[]
                 {
@@ -1471,7 +1472,7 @@ namespace Nancy.Tests.Unit.ModelBinding
         public void Should_bind_to_valuetype_from_body()
         {
             //Given
-            var binder = this.GetBinder(null, new List<IBodyDeserializer> { new JsonBodyDeserializer() });
+            var binder = this.GetBinder(null, new List<IBodyDeserializer> { new JsonBodyDeserializer(GetTestingEnvironment()) });
             var body = serializer.Serialize(1);
 
             var context = CreateContextWithHeaderAndBody("Content-Type", new[] { "application/json" }, body);
@@ -1487,7 +1488,7 @@ namespace Nancy.Tests.Unit.ModelBinding
         public void Should_bind_ienumerable_model__of_valuetype_from_body()
         {
             //Given
-            var binder = this.GetBinder(null, new List<IBodyDeserializer> { new JsonBodyDeserializer() });
+            var binder = this.GetBinder(null, new List<IBodyDeserializer> { new JsonBodyDeserializer(GetTestingEnvironment()) });
             var body = serializer.Serialize(new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 });
 
             var context = CreateContextWithHeaderAndBody("Content-Type", new[] { "application/json" }, body);
@@ -1552,6 +1553,16 @@ namespace Nancy.Tests.Unit.ModelBinding
                 Request = new FakeRequest("GET", "/", header, bodyStream, "http", string.Empty),
                 Parameters = DynamicDictionary.Empty
             };
+        }
+
+        private static INancyEnvironment GetTestingEnvironment()
+        {
+            var envionment =
+                new DefaultNancyEnvironment();
+
+            envionment.AddValue(JsonConfiguration.Default);
+
+            return envionment;
         }
 
         public class TestModel

--- a/src/Nancy.Tests/Unit/ModelBinding/DefaultBodyDeserializers/JsonBodyDeserializerFixture.cs
+++ b/src/Nancy.Tests/Unit/ModelBinding/DefaultBodyDeserializers/JsonBodyDeserializerFixture.cs
@@ -7,13 +7,11 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
     using System.Linq;
     using System.Text;
     using System.Threading;
-
     using FakeItEasy;
-
+    using Nancy.Configuration;
     using Nancy.Json;
     using Nancy.ModelBinding;
     using Nancy.ModelBinding.DefaultBodyDeserializers;
-
     using Xunit;
     using Xunit.Extensions;
 
@@ -22,11 +20,13 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
         private readonly JavaScriptSerializer serializer;
         private readonly JsonBodyDeserializer deserialize;
         private readonly TestModel testModel;
-        private readonly string testModelJson;
 
         public JsonBodyDeserializerFixture()
         {
-            this.deserialize = new JsonBodyDeserializer();
+            var environment = new DefaultNancyEnvironment();
+            environment.AddValue(JsonConfiguration.Default);
+
+            this.deserialize = new JsonBodyDeserializer(environment);
 
             this.testModel = new TestModel()
                 {
@@ -37,8 +37,7 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
                 };
 
             this.serializer = new JavaScriptSerializer();
-            this.serializer.RegisterConverters(JsonConfiguration.Converters);
-            this.testModelJson = this.serializer.Serialize(this.testModel);
+            this.serializer.RegisterConverters(JsonConfiguration.Default.Converters);
         }
 
         [Fact]
@@ -444,7 +443,7 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
         public double Longitude;
     }
 
-    public class ModelWithNullables 
+    public class ModelWithNullables
     {
         public int? P1 { get; set; }
         public uint P2 { get; set; }
@@ -454,5 +453,4 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
         public uint F2;
         public uint? F3;
     }
-
 }

--- a/src/Nancy.Tests/Unit/ModelBinding/DefaultBodyDeserializers/JsonBodyDeserializerFixture.cs
+++ b/src/Nancy.Tests/Unit/ModelBinding/DefaultBodyDeserializers/JsonBodyDeserializerFixture.cs
@@ -37,7 +37,7 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
                 };
 
             this.serializer = new JavaScriptSerializer();
-            this.serializer.RegisterConverters(JsonSettings.Converters);
+            this.serializer.RegisterConverters(JsonConfiguration.Converters);
             this.testModelJson = this.serializer.Serialize(this.testModel);
         }
 

--- a/src/Nancy.Tests/Unit/ModelBinding/DefaultModelBinderLocatorFixture.cs
+++ b/src/Nancy.Tests/Unit/ModelBinding/DefaultModelBinderLocatorFixture.cs
@@ -3,7 +3,8 @@ namespace Nancy.Tests.Unit.ModelBinding
     using System;
 
     using FakeItEasy;
-
+    using Nancy.Configuration;
+    using Nancy.Json;
     using Nancy.ModelBinding;
     using Nancy.Tests.Fakes;
 
@@ -18,7 +19,13 @@ namespace Nancy.Tests.Unit.ModelBinding
         /// </summary>
         public DefaultModelBinderLocatorFixture()
         {
-            this.defaultBinder = new DefaultBinder(new ITypeConverter[] { }, new IBodyDeserializer[] { }, A.Fake<IFieldNameConverter>(), new BindingDefaults());
+            var environment = new DefaultNancyEnvironment();
+            environment.AddValue(JsonConfiguration.Default);
+
+            var bindingDefaults =
+                new BindingDefaults(environment);
+
+            this.defaultBinder = new DefaultBinder(new ITypeConverter[] { }, new IBodyDeserializer[] { }, A.Fake<IFieldNameConverter>(), bindingDefaults);
         }
 
         [Fact]
@@ -80,12 +87,12 @@ namespace Nancy.Tests.Unit.ModelBinding
         [Fact]
         public void Should_be_able_to_bind_interfaces_using_module_extensions()
         {
-            var binder = 
+            var binder =
                 new InterfaceModelBinder();
-            
-            var locator = 
+
+            var locator =
                 new DefaultModelBinderLocator(new IModelBinder[] { binder }, this.defaultBinder);
-            
+
             var module = new TestBindingModule
             {
                 Context = new NancyContext() { Request = new FakeRequest("GET", "/") },

--- a/src/Nancy.Tests/Unit/Responses/DefaultJsonSerializerFixture.cs
+++ b/src/Nancy.Tests/Unit/Responses/DefaultJsonSerializerFixture.cs
@@ -131,7 +131,7 @@
         public void Should_use_wcf_datetimeformat_when_iso8601dateformat_is_false()
         {
             // Given
-            var environment = GetTestableEnvironment(x => x.Json(iso8601DateFormat: false));
+            var environment = GetTestableEnvironment(x => x.Json(useIso8601DateFormat: false));
             var serializer = new DefaultJsonSerializer(environment);
             var input = new
             {

--- a/src/Nancy.Tests/Unit/Responses/DefaultJsonSerializerFixture.cs
+++ b/src/Nancy.Tests/Unit/Responses/DefaultJsonSerializerFixture.cs
@@ -71,7 +71,7 @@
         [Fact]
         public void Should_not_change_casing_when_retain_casing_is_true()
         {
-            JsonSettings.RetainCasing = true;
+            JsonConfiguration.RetainCasing = true;
             try
             {
                 // Given
@@ -87,14 +87,14 @@
             }
             finally
             {
-                JsonSettings.RetainCasing = false;
+                JsonConfiguration.RetainCasing = false;
             }
         }
 
         [Fact]
         public void Should_camel_case_property_names_if_local_override_is_set()
         {
-            JsonSettings.RetainCasing = true;
+            JsonConfiguration.RetainCasing = true;
             try
             {
                 // Given
@@ -111,7 +111,7 @@
             }
             finally
             {
-                JsonSettings.RetainCasing = false;
+                JsonConfiguration.RetainCasing = false;
             }
         }
 
@@ -146,7 +146,7 @@
         [Fact]
         public void Should_use_wcf_datetimeformat_when_iso8601dateformat_is_false()
         {
-            JsonSettings.ISO8601DateFormat = false;
+            JsonConfiguration.ISO8601DateFormat = false;
             try
             {
                 // Given
@@ -170,7 +170,7 @@
             }
             finally
             {
-                JsonSettings.ISO8601DateFormat = true;
+                JsonConfiguration.ISO8601DateFormat = true;
             }
         }
 

--- a/src/Nancy.Tests/Unit/Responses/DefaultJsonSerializerFixture.cs
+++ b/src/Nancy.Tests/Unit/Responses/DefaultJsonSerializerFixture.cs
@@ -4,30 +4,23 @@
     using System.Collections.Generic;
     using System.IO;
     using System.Text;
-
+    using Nancy.Configuration;
     using Nancy.Json;
     using Nancy.Responses;
-
     using Xunit;
 
     public class DefaultJsonSerializerFixture
     {
-        private readonly DefaultJsonSerializer serializer;
-
-        public DefaultJsonSerializerFixture()
-        {
-            this.serializer = new DefaultJsonSerializer();
-        }
-
         [Fact]
         public void Should_camel_case_property_names_by_default()
         {
             // Given
             var input = new { FirstName = "Joe", lastName = "Doe" };
-  
+            var serializer = new DefaultJsonSerializer(GetTestableEnvironment());
+
             // When
-            var output = new MemoryStream(); 
-            this.serializer.Serialize("application/json", input, output);
+            var output = new MemoryStream();
+            serializer.Serialize("application/json", input, output);
             var actual = Encoding.UTF8.GetString(output.ToArray());
 
             // Then
@@ -39,10 +32,11 @@
         {
             // Given
             var input = new PersonWithFields { FirstName = "Joe", LastName = "Doe" };
+            var serializer = new DefaultJsonSerializer(GetTestableEnvironment());
 
             // When
             var output = new MemoryStream();
-            this.serializer.Serialize("application/json", input, output);
+            serializer.Serialize("application/json", input, output);
             var actual = Encoding.UTF8.GetString(output.ToArray());
 
             // Then
@@ -59,9 +53,11 @@
                 { "John", new PersonWithFields { FirstName = "John" } }
             };
 
+            var serializer = new DefaultJsonSerializer(GetTestableEnvironment());
+
             // When
             var output = new MemoryStream();
-            this.serializer.Serialize("application/json", input, output);
+            serializer.Serialize("application/json", input, output);
             var actual = Encoding.UTF8.GetString(output.ToArray());
 
             // Then
@@ -71,48 +67,36 @@
         [Fact]
         public void Should_not_change_casing_when_retain_casing_is_true()
         {
-            JsonConfiguration.RetainCasing = true;
-            try
-            {
-                // Given
-                var input = new {FirstName = "Joe", lastName = "Doe"};
+            // Given
+            var input = new {FirstName = "Joe", lastName = "Doe"};
+            var environment = GetTestableEnvironment(x => x.Json(retainCasing: true));
+            var serializer = new DefaultJsonSerializer(environment);
 
-                // When
-                var output = new MemoryStream();
-                this.serializer.Serialize("application/json", input, output);
-                var actual = Encoding.UTF8.GetString(output.ToArray());
+            // When
+            var output = new MemoryStream();
+            serializer.Serialize("application/json", input, output);
+            var actual = Encoding.UTF8.GetString(output.ToArray());
 
-                // Then
-                actual.ShouldEqual("{\"FirstName\":\"Joe\",\"lastName\":\"Doe\"}");
-            }
-            finally
-            {
-                JsonConfiguration.RetainCasing = false;
-            }
+            // Then
+            actual.ShouldEqual("{\"FirstName\":\"Joe\",\"lastName\":\"Doe\"}");
         }
 
         [Fact]
         public void Should_camel_case_property_names_if_local_override_is_set()
         {
-            JsonConfiguration.RetainCasing = true;
-            try
-            {
-                // Given
-                var sut = new DefaultJsonSerializer { RetainCasing = false };
-                var input = new { FirstName = "Joe", lastName = "Doe" };
+            // Given
+            var environment = GetTestableEnvironment(x => x.Json(retainCasing: true));
+            var serializer = new DefaultJsonSerializer(environment) { RetainCasing = false };
 
-                // When
-                var output = new MemoryStream();
-                sut.Serialize("application/json", input, output);
-                var actual = Encoding.UTF8.GetString(output.ToArray());
+            var input = new { FirstName = "Joe", lastName = "Doe" };
 
-                // Then
-                actual.ShouldEqual("{\"firstName\":\"Joe\",\"lastName\":\"Doe\"}");
-            }
-            finally
-            {
-                JsonConfiguration.RetainCasing = false;
-            }
+            // When
+            var output = new MemoryStream();
+            serializer.Serialize("application/json", input, output);
+            var actual = Encoding.UTF8.GetString(output.ToArray());
+
+            // Then
+            actual.ShouldEqual("{\"firstName\":\"Joe\",\"lastName\":\"Doe\"}");
         }
 
         public class PersonWithFields
@@ -125,7 +109,7 @@
         public void Should_use_iso8601_datetimes_by_default()
         {
             // Given
-            var sut = new DefaultJsonSerializer();
+            var serializer = new DefaultJsonSerializer(GetTestableEnvironment());
             var input = new
             {
                 UnspecifiedDateTime = new DateTime(2014, 3, 9, 17, 03, 25).AddMilliseconds(234),
@@ -135,53 +119,44 @@
 
             // When
             var output = new MemoryStream();
-            sut.Serialize("application/json", input, output);
+            serializer.Serialize("application/json", input, output);
             var actual = Encoding.UTF8.GetString(output.ToArray());
 
             // Then
-            actual.ShouldEqual(String.Format(@"{{""unspecifiedDateTime"":""2014-03-09T17:03:25.2340000{0}"",""localDateTime"":""2014-03-09T17:03:25.2340000{0}"",""utcDateTime"":""2014-03-09T16:03:25.2340000Z""}}",
+            actual.ShouldEqual(string.Format(@"{{""unspecifiedDateTime"":""2014-03-09T17:03:25.2340000{0}"",""localDateTime"":""2014-03-09T17:03:25.2340000{0}"",""utcDateTime"":""2014-03-09T16:03:25.2340000Z""}}",
                 GetTimezoneSuffix(input.LocalDateTime, ":")));
         }
 
         [Fact]
         public void Should_use_wcf_datetimeformat_when_iso8601dateformat_is_false()
         {
-            JsonConfiguration.ISO8601DateFormat = false;
-            try
+            // Given
+            var environment = GetTestableEnvironment(x => x.Json(iso8601DateFormat: false));
+            var serializer = new DefaultJsonSerializer(environment);
+            var input = new
             {
-                // Given
-                var sut = new DefaultJsonSerializer();
-                var input = new
-                {
-                    UnspecifiedDateTime = new DateTime(2014, 3, 9, 17, 03, 25).AddMilliseconds(234),
-                    LocalDateTime = new DateTime(2014, 3, 9, 17, 03, 25, DateTimeKind.Local).AddMilliseconds(234),
-                    UtcDateTime = new DateTime(2014, 3, 9, 16, 03, 25, DateTimeKind.Utc).AddMilliseconds(234)
-                };
+                UnspecifiedDateTime = new DateTime(2014, 3, 9, 17, 03, 25).AddMilliseconds(234),
+                LocalDateTime = new DateTime(2014, 3, 9, 17, 03, 25, DateTimeKind.Local).AddMilliseconds(234),
+                UtcDateTime = new DateTime(2014, 3, 9, 16, 03, 25, DateTimeKind.Utc).AddMilliseconds(234)
+            };
 
-                // When
-                var output = new MemoryStream();
-                sut.Serialize("application/json", input, output);
-                var actual = Encoding.UTF8.GetString(output.ToArray());
+            // When
+            var output = new MemoryStream();
+            serializer.Serialize("application/json", input, output);
+            var actual = Encoding.UTF8.GetString(output.ToArray());
 
-                // Then
-		        long ticks = (input.LocalDateTime.ToUniversalTime().Ticks - InitialJavaScriptDateTicks)/(long)10000;
-                actual.ShouldEqual(String.Format(@"{{""unspecifiedDateTime"":""\/Date({0}{1})\/"",""localDateTime"":""\/Date({0}{1})\/"",""utcDateTime"":""\/Date(1394381005234)\/""}}",
-                    ticks, GetTimezoneSuffix(input.LocalDateTime)));
-            }
-            finally
-            {
-                JsonConfiguration.ISO8601DateFormat = true;
-            }
+            // Then
+		    var ticks = (input.LocalDateTime.ToUniversalTime().Ticks - InitialJavaScriptDateTicks)/(long)10000;
+            actual.ShouldEqual(string.Format(@"{{""unspecifiedDateTime"":""\/Date({0}{1})\/"",""localDateTime"":""\/Date({0}{1})\/"",""utcDateTime"":""\/Date(1394381005234)\/""}}",
+                ticks, GetTimezoneSuffix(input.LocalDateTime)));
         }
 
         [Fact]
         public void Should_use_wcf_datetimeformat_when_iso8601dateformat_local_override_is_false()
         {
             // Given
-            var sut = new DefaultJsonSerializer()
-            {
-                ISO8601DateFormat = false
-            };
+            var environment = GetTestableEnvironment(x => x.Json());
+            var sut = new DefaultJsonSerializer(environment) { ISO8601DateFormat = false };
             var input = new
             {
                 UnspecifiedDateTime = new DateTime(2014, 3, 9, 17, 03, 25).AddMilliseconds(234),
@@ -195,9 +170,24 @@
             var actual = Encoding.UTF8.GetString(output.ToArray());
 
             // Then
-            long ticks = (input.LocalDateTime.ToUniversalTime().Ticks - InitialJavaScriptDateTicks) / (long)10000;
-            actual.ShouldEqual(String.Format(@"{{""unspecifiedDateTime"":""\/Date({0}{1})\/"",""localDateTime"":""\/Date({0}{1})\/"",""utcDateTime"":""\/Date(1394381005234)\/""}}",
+            var ticks = (input.LocalDateTime.ToUniversalTime().Ticks - InitialJavaScriptDateTicks) / (long)10000;
+            actual.ShouldEqual(string.Format(@"{{""unspecifiedDateTime"":""\/Date({0}{1})\/"",""localDateTime"":""\/Date({0}{1})\/"",""utcDateTime"":""\/Date(1394381005234)\/""}}",
                 ticks, GetTimezoneSuffix(input.LocalDateTime)));
+        }
+
+        private static INancyEnvironment GetTestableEnvironment()
+        {
+            return GetTestableEnvironment(x => x.Json());
+        }
+
+        private static INancyEnvironment GetTestableEnvironment(Action<INancyEnvironment> closure)
+        {
+            var environment =
+                new DefaultNancyEnvironment();
+
+            closure.Invoke(environment);
+
+            return environment;
         }
 
         private static readonly long InitialJavaScriptDateTicks = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
@@ -205,7 +195,7 @@
         private static string GetTimezoneSuffix(DateTime value, string separator = "")
         {
             string suffix;
-		    DateTime time = value.ToUniversalTime();
+		    var time = value.ToUniversalTime();
 		    TimeSpan localTZOffset;
 		    if (value >= time)
 		    {

--- a/src/Nancy/Diagnostics/DiagnosticsModuleBuilder.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsModuleBuilder.cs
@@ -11,10 +11,10 @@ namespace Nancy.Diagnostics
         private readonly IModelBinderLocator modelBinderLocator;
         private readonly INancyEnvironment environment;
 
-        public DiagnosticsModuleBuilder(IRootPathProvider rootPathProvider, IModelBinderLocator modelBinderLocator, INancyEnvironment environment)
+        public DiagnosticsModuleBuilder(IRootPathProvider rootPathProvider, IModelBinderLocator modelBinderLocator, INancyEnvironment diagnosticsEnvironment, INancyEnvironment environment)
         {
             this.rootPathProvider = rootPathProvider;
-            this.serializerFactory = new DiagnosticsSerializerFactory();
+            this.serializerFactory = new DiagnosticsSerializerFactory(diagnosticsEnvironment);
             this.modelBinderLocator = modelBinderLocator;
             this.environment = environment;
         }

--- a/src/Nancy/Diagnostics/DiagnosticsSerializerFactory.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsSerializerFactory.cs
@@ -1,5 +1,6 @@
 namespace Nancy.Diagnostics
 {
+    using Nancy.Configuration;
     using Nancy.Responses;
     using Nancy.Responses.Negotiation;
 
@@ -7,9 +8,9 @@ namespace Nancy.Diagnostics
     {
         private readonly ISerializer serializer;
 
-        public DiagnosticsSerializerFactory()
+        public DiagnosticsSerializerFactory(INancyEnvironment diagnosticsEnvironment)
         {
-            this.serializer = new DefaultJsonSerializer { RetainCasing = false };
+            this.serializer = new DefaultJsonSerializer(diagnosticsEnvironment);
         }
 
         /// <summary>

--- a/src/Nancy/FormatterExtensions.cs
+++ b/src/Nancy/FormatterExtensions.cs
@@ -100,7 +100,7 @@ namespace Nancy
         {
             var serializer = jsonSerializer ?? (jsonSerializer = formatter.SerializerFactory.GetSerializer("application/json"));
 
-            return new JsonResponse<TModel>(model, serializer)
+            return new JsonResponse<TModel>(model, serializer, formatter.Environment)
             {
                 StatusCode = statusCode
             };

--- a/src/Nancy/Json/DefaultJsonConfigurationProvider.cs
+++ b/src/Nancy/Json/DefaultJsonConfigurationProvider.cs
@@ -1,0 +1,20 @@
+namespace Nancy.Json
+{
+    using Nancy.Configuration;
+
+    /// <summary>
+    /// Provides the default configuration for <see cref="JsonConfiguration"/>.
+    /// </summary>
+    public class DefaultJsonConfigurationProvider : NancyDefaultConfigurationProvider<JsonConfiguration>
+    {
+        /// <summary>
+        /// Gets the default configuration instance to register in the <see cref="INancyEnvironment"/>.
+        /// </summary>
+        /// <returns>The configuration instance</returns>
+        /// <remarks>Will return <see cref="JsonConfiguration.Default"/></remarks>
+        public override JsonConfiguration GetDefaultConfiguration()
+        {
+            return JsonConfiguration.Default;
+        }
+    }
+}

--- a/src/Nancy/Json/JavaScriptSerializer.cs
+++ b/src/Nancy/Json/JavaScriptSerializer.cs
@@ -14,10 +14,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -45,6 +45,7 @@ namespace Nancy.Json
 
         List<IEnumerable<JavaScriptConverter>> _converterList;
         List<IEnumerable<JavaScriptPrimitiveConverter>> _primitiveConverterList;
+
         int _maxJsonLength;
         int _recursionLimit;
         bool _retainCasing;
@@ -64,19 +65,19 @@ namespace Nancy.Json
         {
         }
 #else
-        internal static readonly JavaScriptSerializer DefaultSerializer = new JavaScriptSerializer(null, false, 102400, 100, false, true);
+        internal static readonly JavaScriptSerializer DefaultSerializer = new JavaScriptSerializer(null, false, 102400, 100, false, true, null, null);
 
         public JavaScriptSerializer()
-            : this(null, false, 102400, 100, false, true)
+            : this(null, false, 102400, 100, false, true, null, null)
         {
         }
 
         public JavaScriptSerializer(JavaScriptTypeResolver resolver)
-            : this(resolver, false, 102400, 100, false, true)
+            : this(resolver, false, 102400, 100, false, true, null, null)
         {
         }
 #endif
-        public JavaScriptSerializer(JavaScriptTypeResolver resolver, bool registerConverters, int maxJsonLength, int recursionLimit, bool retainCasing, bool iso8601DateFormat)
+        public JavaScriptSerializer(JavaScriptTypeResolver resolver, bool registerConverters, int maxJsonLength, int recursionLimit, bool retainCasing, bool iso8601DateFormat, IEnumerable<JavaScriptConverter> converters, IEnumerable<JavaScriptPrimitiveConverter> primitiveConverters)
         {
             _typeResolver = resolver;
             _maxJsonLength = maxJsonLength;
@@ -87,7 +88,7 @@ namespace Nancy.Json
             _iso8601DateFormat = iso8601DateFormat;
 
             if (registerConverters)
-                RegisterConverters(JsonConfiguration.Converters, JsonConfiguration.PrimitiveConverters);
+                RegisterConverters(converters, primitiveConverters);
         }
 
 
@@ -196,8 +197,8 @@ namespace Nancy.Json
             if ((type.IsGenericType) && (type.GetGenericTypeDefinition() == typeof(Nullable<>)))
             {
                 /*
-                 * Take care of the special case whereas in JSON an empty string ("") really means 
-                 * an empty value 
+                 * Take care of the special case whereas in JSON an empty string ("") really means
+                 * an empty value
                  * (see: https://bugzilla.novell.com/show_bug.cgi?id=328836)
                  */
                 string s = obj as String;

--- a/src/Nancy/Json/JavaScriptSerializer.cs
+++ b/src/Nancy/Json/JavaScriptSerializer.cs
@@ -87,7 +87,7 @@ namespace Nancy.Json
             _iso8601DateFormat = iso8601DateFormat;
 
             if (registerConverters)
-                RegisterConverters(JsonSettings.Converters, JsonSettings.PrimitiveConverters);
+                RegisterConverters(JsonConfiguration.Converters, JsonConfiguration.PrimitiveConverters);
         }
 
 

--- a/src/Nancy/Json/JsonConfiguration.cs
+++ b/src/Nancy/Json/JsonConfiguration.cs
@@ -17,7 +17,7 @@ namespace Nancy.Json
         {
             Converters = new List<JavaScriptConverter> { new TimeSpanConverter(), new TupleConverter() },
             DefaultEncoding = Encoding.UTF8,
-            ISO8601DateFormat = true,
+            UseISO8601DateFormat = true,
             MaxJsonLength = 102400,
             MaxRecursions = 100,
             PrimitiveConverters = new List<JavaScriptPrimitiveConverter>(),
@@ -31,9 +31,16 @@ namespace Nancy.Json
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonConfiguration"/> class.
         /// </summary>
-        public JsonConfiguration(bool? iso8601DateFormat, int? maxJsonLength, int? maxRecursions, Encoding defaultEncoding, IList<JavaScriptConverter> converters, IList<JavaScriptPrimitiveConverter> primitiveConverters, bool? retainCasing)
+        /// <param name="useIso8601DateFormat"><see langword="true"/> if ISO-8601 date formats should be used, otherwise <see langword="false"/>.</param>
+        /// <param name="maxJsonLength">The maximum allowed lenght for the JSON output.</param>
+        /// <param name="maxRecursions">The maximum number of recrusions allowed by the serializer.</param>
+        /// <param name="defaultEncoding">The default <see cref="Encoding"/> that should be used by the serializer.</param>
+        /// <param name="converters">List of <see cref="JavaScriptConverter"/> instances.</param>
+        /// <param name="primitiveConverters">List of <see cref="JavaScriptPrimitiveConverter"/> instances.</param>
+        /// <param name="retainCasing"><see langword="true"/> if the name casing should be retained during serialization, otherwise <see langword="false"/>.</param>
+        public JsonConfiguration(bool? useIso8601DateFormat, int? maxJsonLength, int? maxRecursions, Encoding defaultEncoding, IList<JavaScriptConverter> converters, IList<JavaScriptPrimitiveConverter> primitiveConverters, bool? retainCasing)
         {
-            this.ISO8601DateFormat = iso8601DateFormat ?? Default.ISO8601DateFormat;
+            this.UseISO8601DateFormat = useIso8601DateFormat ?? Default.UseISO8601DateFormat;
             this.MaxJsonLength = maxJsonLength ?? Default.MaxJsonLength;
             this.MaxRecursions = maxRecursions ?? Default.MaxRecursions;
             this.DefaultEncoding = defaultEncoding ?? Default.DefaultEncoding;
@@ -82,6 +89,6 @@ namespace Nancy.Json
         /// Gets or sets if ISO-860 date formats should be used or not.
         /// </summary>
         /// <remarks>The default is <see langword="false"/>.</remarks>
-        public bool ISO8601DateFormat { get; private set; }
+        public bool UseISO8601DateFormat { get; private set; }
     }
 }

--- a/src/Nancy/Json/JsonConfiguration.cs
+++ b/src/Nancy/Json/JsonConfiguration.cs
@@ -1,66 +1,87 @@
 namespace Nancy.Json
 {
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Text;
     using Nancy.Json.Converters;
 
     /// <summary>
-    /// JSON serializer settings
+    /// Configuration for JSON serialization.
     /// </summary>
     public class JsonConfiguration
     {
-        private string defaultCharset;
-
         /// <summary>
-        ///Initializes a new instance of the <see cref="JsonConfiguration"/> class.
+        /// A default instance of the <see cref="JsonConfiguration"/> class.
         /// </summary>
-        public JsonConfiguration()
+        public static readonly JsonConfiguration Default = new JsonConfiguration
         {
-            ISO8601DateFormat = true;
-            MaxJsonLength = 102400;
-            MaxRecursions = 100;
-            DefaultEncoding = Encoding.UTF8;
-            Converters = new List<JavaScriptConverter>
-            {
-                new TimeSpanConverter(),
-                new TupleConverter()
-            };
-            PrimitiveConverters = new List<JavaScriptPrimitiveConverter>();
-            RetainCasing = false;
+            Converters = new List<JavaScriptConverter> { new TimeSpanConverter(), new TupleConverter() },
+            DefaultEncoding = Encoding.UTF8,
+            ISO8601DateFormat = true,
+            MaxJsonLength = 102400,
+            MaxRecursions = 100,
+            PrimitiveConverters = new List<JavaScriptPrimitiveConverter>(),
+            RetainCasing = false
+        };
+
+        private JsonConfiguration()
+        {
         }
 
         /// <summary>
-        /// Max length of JSON output
+        /// Initializes a new instance of the <see cref="JsonConfiguration"/> class.
         /// </summary>
+        public JsonConfiguration(bool? iso8601DateFormat, int? maxJsonLength, int? maxRecursions, Encoding defaultEncoding, IList<JavaScriptConverter> converters, IList<JavaScriptPrimitiveConverter> primitiveConverters, bool? retainCasing)
+        {
+            this.ISO8601DateFormat = iso8601DateFormat ?? Default.ISO8601DateFormat;
+            this.MaxJsonLength = maxJsonLength ?? Default.MaxJsonLength;
+            this.MaxRecursions = maxRecursions ?? Default.MaxRecursions;
+            this.DefaultEncoding = defaultEncoding ?? Default.DefaultEncoding;
+            this.Converters = converters ?? Default.Converters;
+            this.PrimitiveConverters = primitiveConverters ?? Default.PrimitiveConverters;
+            this.RetainCasing = retainCasing ?? Default.RetainCasing;
+        }
+
+        /// <summary>
+        /// Max length of JSON output.
+        /// </summary>
+        /// <remarks>The default is 102400.</remarks>
         public int MaxJsonLength { get; private set; }
 
         /// <summary>
-        /// Maximum number of recursions
+        /// Maximum number of recursions.
         /// </summary>
+        /// <remarks>The default is 100.</remarks>
         public int MaxRecursions { get; private set; }
 
         /// <summary>
-        /// Gets the default encoding for JSON responses.
+        /// Gets the default <see cref="Encoding"/> for JSON responses.
         /// </summary>
-        /// <remarks>
-        /// The default value is <see langword="Encoding.UTF8" />
-        /// </remarks>
+        /// <remarks>The default is <see langword="Encoding.UTF8" />.</remarks>
         public Encoding DefaultEncoding { get; private set; }
 
+        /// <summary>
+        /// Gets or sets the type converters that should be used.
+        /// </summary>
+        /// <remarks>The default is <see cref="TimeSpanConverter"/> and <see cref="TupleConverter"/>.</remarks>
         public IList<JavaScriptConverter> Converters { get; private set; }
 
+        /// <summary>
+        /// Gets or sets the converters used for primitive types.
+        /// </summary>
+        /// <remarks>The default are no converters.</remarks>
         public IList<JavaScriptPrimitiveConverter> PrimitiveConverters { get; private set; }
 
         /// <summary>
-        /// Set to true to retain the casing used in the C# code in produced JSON.
-        /// Set to false to use camelCasing in the produced JSON.
-        /// False by default.
+        /// Gets or sets if C# casing should be retained or if camel-casing should be enforeced.
         /// </summary>
-        public bool RetainCasing { get; set; }
+        /// <remarks>The default is <see langword="false"/>.</remarks>
+        public bool RetainCasing { get; private set; }
 
         /// <summary>
-        /// Serialized date format
+        /// Gets or sets if ISO-860 date formats should be used or not.
         /// </summary>
+        /// <remarks>The default is <see langword="false"/>.</remarks>
         public bool ISO8601DateFormat { get; private set; }
     }
 }

--- a/src/Nancy/Json/JsonConfiguration.cs
+++ b/src/Nancy/Json/JsonConfiguration.cs
@@ -1,19 +1,20 @@
 namespace Nancy.Json
 {
-    using System;
     using System.Collections.Generic;
     using System.Text;
-
     using Nancy.Json.Converters;
 
     /// <summary>
     /// JSON serializer settings
     /// </summary>
-    public static class JsonSettings
+    public class JsonConfiguration
     {
-        private static string _defaultCharset;
+        private string defaultCharset;
 
-        static JsonSettings()
+        /// <summary>
+        ///Initializes a new instance of the <see cref="JsonConfiguration"/> class.
+        /// </summary>
+        public JsonConfiguration()
         {
             ISO8601DateFormat = true;
             MaxJsonLength = 102400;
@@ -31,12 +32,12 @@ namespace Nancy.Json
         /// <summary>
         /// Max length of JSON output
         /// </summary>
-        public static int MaxJsonLength { get; set; }
+        public int MaxJsonLength { get; private set; }
 
         /// <summary>
         /// Maximum number of recursions
         /// </summary>
-        public static int MaxRecursions { get; set; }
+        public int MaxRecursions { get; private set; }
 
         /// <summary>
         /// Gets the default encoding for JSON responses.
@@ -44,22 +45,22 @@ namespace Nancy.Json
         /// <remarks>
         /// The default value is <see langword="Encoding.UTF8" />
         /// </remarks>
-        public static Encoding DefaultEncoding { get; set; }
+        public Encoding DefaultEncoding { get; private set; }
 
-        public static IList<JavaScriptConverter> Converters { get; set; }
+        public IList<JavaScriptConverter> Converters { get; private set; }
 
-        public static IList<JavaScriptPrimitiveConverter> PrimitiveConverters { get; set; }
+        public IList<JavaScriptPrimitiveConverter> PrimitiveConverters { get; private set; }
 
         /// <summary>
         /// Set to true to retain the casing used in the C# code in produced JSON.
         /// Set to false to use camelCasing in the produced JSON.
         /// False by default.
         /// </summary>
-        public static bool RetainCasing { get; set; }
+        public bool RetainCasing { get; set; }
 
         /// <summary>
         /// Serialized date format
         /// </summary>
-        public static bool ISO8601DateFormat { get; set; }
+        public bool ISO8601DateFormat { get; private set; }
     }
 }

--- a/src/Nancy/Json/JsonConfigurationExtensions.cs
+++ b/src/Nancy/Json/JsonConfigurationExtensions.cs
@@ -1,0 +1,37 @@
+namespace Nancy.Json
+{
+    using System.Collections.Generic;
+    using System.Text;
+    using Nancy.Configuration;
+    using Nancy.Diagnostics;
+
+    /// <summary>
+    /// Contains <see cref="DiagnosticsConfiguration"/> configuration extensions for <see cref="INancyEnvironment"/>.
+    /// </summary>
+    public static class JsonConfigurationExtensions
+    {
+
+        /// <summary>
+        /// Configures JSON serialization.
+        /// </summary>
+        /// <param name="environment"><see cref="INancyEnvironment"/> that should be configured.</param>
+        /// <param name="iso8601DateFormat"><see langword="true" /> if ISO-860 date formats should be used, otherwise <see langword="false" />.</param>
+        /// <param name="maxJsonLength">Max length of JSON output.</param>
+        /// <param name="maxRecursions">Maximum number of recursions.</param>
+        /// <param name="defaultEncoding">The <see cref="Encoding"/> that should be as a default.</param>
+        /// <param name="converters">List of <see cref="JavaScriptConverter"/> that should be used.</param>
+        /// <param name="primitiveConverters">List of <see cref="JavaScriptPrimitiveConverter"/> that should be used.</param>
+        /// <param name="retainCasing"><see langword="true" /> if C# casing should be retained, otherwise <see langword="false" /> to use camel-casing.</param>
+        public static void Json(this INancyEnvironment environment, bool? iso8601DateFormat = null, int? maxJsonLength = null, int? maxRecursions = null, Encoding defaultEncoding = null, IList<JavaScriptConverter> converters = null, IList<JavaScriptPrimitiveConverter> primitiveConverters = null, bool? retainCasing = null)
+        {
+            environment.AddValue(new JsonConfiguration(
+                iso8601DateFormat ?? JsonConfiguration.Default.ISO8601DateFormat,
+                maxJsonLength ?? JsonConfiguration.Default.MaxJsonLength,
+                maxRecursions ?? JsonConfiguration.Default.MaxRecursions,
+                defaultEncoding,
+                converters,
+                primitiveConverters,
+                retainCasing ?? JsonConfiguration.Default.RetainCasing));
+        }
+    }
+}

--- a/src/Nancy/Json/JsonConfigurationExtensions.cs
+++ b/src/Nancy/Json/JsonConfigurationExtensions.cs
@@ -15,22 +15,22 @@ namespace Nancy.Json
         /// Configures JSON serialization.
         /// </summary>
         /// <param name="environment"><see cref="INancyEnvironment"/> that should be configured.</param>
-        /// <param name="iso8601DateFormat"><see langword="true" /> if ISO-860 date formats should be used, otherwise <see langword="false" />.</param>
+        /// <param name="useIso8601DateFormat"><see langword="true" /> if ISO-860 date formats should be used, otherwise <see langword="false" />.</param>
         /// <param name="maxJsonLength">Max length of JSON output.</param>
         /// <param name="maxRecursions">Maximum number of recursions.</param>
         /// <param name="defaultEncoding">The <see cref="Encoding"/> that should be as a default.</param>
         /// <param name="converters">List of <see cref="JavaScriptConverter"/> that should be used.</param>
         /// <param name="primitiveConverters">List of <see cref="JavaScriptPrimitiveConverter"/> that should be used.</param>
         /// <param name="retainCasing"><see langword="true" /> if C# casing should be retained, otherwise <see langword="false" /> to use camel-casing.</param>
-        public static void Json(this INancyEnvironment environment, bool? iso8601DateFormat = null, int? maxJsonLength = null, int? maxRecursions = null, Encoding defaultEncoding = null, IList<JavaScriptConverter> converters = null, IList<JavaScriptPrimitiveConverter> primitiveConverters = null, bool? retainCasing = null)
+        public static void Json(this INancyEnvironment environment, bool? useIso8601DateFormat = null, int? maxJsonLength = null, int? maxRecursions = null, Encoding defaultEncoding = null, IList<JavaScriptConverter> converters = null, IList<JavaScriptPrimitiveConverter> primitiveConverters = null, bool? retainCasing = null)
         {
             environment.AddValue(new JsonConfiguration(
-                iso8601DateFormat ?? JsonConfiguration.Default.ISO8601DateFormat,
+                useIso8601DateFormat ?? JsonConfiguration.Default.UseISO8601DateFormat,
                 maxJsonLength ?? JsonConfiguration.Default.MaxJsonLength,
                 maxRecursions ?? JsonConfiguration.Default.MaxRecursions,
-                defaultEncoding,
-                converters,
-                primitiveConverters,
+                defaultEncoding ?? JsonConfiguration.Default.DefaultEncoding,
+                converters ?? JsonConfiguration.Default.Converters,
+                primitiveConverters ?? JsonConfiguration.Default.PrimitiveConverters,
                 retainCasing ?? JsonConfiguration.Default.RetainCasing));
         }
     }

--- a/src/Nancy/Json/StringBuilderExtensions.cs
+++ b/src/Nancy/Json/StringBuilderExtensions.cs
@@ -36,7 +36,7 @@ namespace Nancy.Json
         static void CheckCount(StringBuilder sb, int maxCount)
         {
             if (sb.Length > maxCount)
-                throw new InvalidOperationException("Nancy.Json.JsonSettings.MaxJsonLength exceeded");
+                throw new InvalidOperationException("Nancy.Json.JsonConfiguration.MaxJsonLength exceeded");
         }
 
         public static StringBuilder AppendCount(StringBuilder sb, int maxCount, char[] value)

--- a/src/Nancy/Jsonp.cs
+++ b/src/Nancy/Jsonp.cs
@@ -18,7 +18,7 @@
 
         private static string Encoding
         {
-            get { return string.Concat("; charset=", JsonSettings.DefaultEncoding.WebName); }
+            get { return string.Concat("; charset=", JsonConfiguration.DefaultEncoding.WebName); }
         }
 
         /// <summary>

--- a/src/Nancy/Jsonp.cs
+++ b/src/Nancy/Jsonp.cs
@@ -3,13 +3,18 @@
     using System;
     using System.IO;
     using System.Linq;
-
+    using System.Text;
     using Nancy.Bootstrapper;
+    using Nancy.Configuration;
     using Nancy.Json;
 
+    /// <summary>
+    /// Handles JSONP requests.
+    /// </summary>
     public static class Jsonp
     {
         private static readonly PipelineItem<Action<NancyContext>> JsonpItem;
+        private static Encoding encoding;
 
         static Jsonp()
         {
@@ -18,19 +23,21 @@
 
         private static string Encoding
         {
-            get { return string.Concat("; charset=", JsonConfiguration.DefaultEncoding.WebName); }
+            get { return string.Concat("; charset=", encoding.WebName); }
         }
 
         /// <summary>
         /// Enable JSONP support in the application
         /// </summary>
         /// <param name="pipelines">Application Pipeline to Hook into</param>
-        public static void Enable(IPipelines pipelines)
+        /// <param name="environment">An <see cref="INancyEnvironment"/> instance.</param>
+        public static void Enable(IPipelines pipelines, INancyEnvironment environment)
         {
             var jsonpEnabled = pipelines.AfterRequest.PipelineItems.Any(ctx => ctx.Name == "JSONP");
 
             if (!jsonpEnabled)
             {
+                encoding = environment.GetValue<JsonConfiguration>().DefaultEncoding;
                 pipelines.AfterRequest.AddItemToEndOfPipeline(JsonpItem);
             }
         }

--- a/src/Nancy/JsonpApplicationStartup.cs
+++ b/src/Nancy/JsonpApplicationStartup.cs
@@ -1,19 +1,32 @@
 ﻿namespace Nancy
 {
     using Nancy.Bootstrapper;
+    using Nancy.Configuration;
 
     /// <summary>
     /// Enables JSONP support at application startup.
     /// </summary>
     public class JsonpApplicationStartup : IApplicationStartup
     {
+        private readonly INancyEnvironment environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonpApplicationStartup"/> class,
+        /// with the provided <see cref="INancyEnvironment"/> instance.
+        /// </summary>
+        /// <param name="environment">An <see cref="INancyEnvironment"/> instance.</param>
+        public JsonpApplicationStartup(INancyEnvironment environment)
+        {
+            this.environment = environment;
+        }
+
         /// <summary>
         /// Perform any initialisation tasks
         /// </summary>
         /// <param name="pipelines">Application pipelines</param>
         public void Initialize(IPipelines pipelines)
         {
-            Jsonp.Enable(pipelines);
+            Jsonp.Enable(pipelines, this.environment);
         }
     }
 }

--- a/src/Nancy/ModelBinding/BindingDefaults.cs
+++ b/src/Nancy/ModelBinding/BindingDefaults.cs
@@ -1,61 +1,58 @@
 namespace Nancy.ModelBinding
 {
     using System.Collections.Generic;
-
+    using Nancy.Configuration;
     using Nancy.ModelBinding.DefaultBodyDeserializers;
     using Nancy.ModelBinding.DefaultConverters;
 
     /// <summary>
     /// Provides default binding converters/deserializers
-    /// The defaults have less precedence than any user supplied ones 
+    /// The defaults have less precedence than any user supplied ones
     /// </summary>
     public class BindingDefaults
     {
         private readonly IEnumerable<ITypeConverter> defaultTypeConverters;
-
         private readonly IEnumerable<IBodyDeserializer> defaultBodyDeserializers;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="BindingDefaults"/> class.
+        /// Initializes a new instance of the <see cref="BindingDefaults"/> class,
+        /// with the provided <see cref="INancyEnvironment"/>.
         /// </summary>
-        public BindingDefaults()
+        /// <param name="environment">An <see cref="INancyEnvironment"/> instance.</param>
+        public BindingDefaults(INancyEnvironment environment)
         {
             // Ordering is important - for now we will new just these up
             // as the binding defaults class itself is replaceable if necessary,
             // and none of defaults have any dependencies.
             this.defaultTypeConverters = new ITypeConverter[]
-                {
-                    new CollectionConverter(),
-                    new FallbackConverter(),
-                };
+            {
+                new CollectionConverter(),
+                new FallbackConverter(),
+            };
 
             this.defaultBodyDeserializers = new IBodyDeserializer[]
-                {
-                    new JsonBodyDeserializer(),
-                    new XmlBodyDeserializer()
-                };
+            {
+                new JsonBodyDeserializer(environment),
+                new XmlBodyDeserializer()
+            };
         }
 
         /// <summary>
         /// Gets the default type converters
         /// </summary>
+        /// <value>An <see cref="IEnumerable{T}"/> of <see cref="ITypeConverter"/> instances.</value>
         public virtual IEnumerable<ITypeConverter> DefaultTypeConverters
         {
-            get
-            {
-                return this.defaultTypeConverters;
-            }
+            get { return this.defaultTypeConverters; }
         }
 
         /// <summary>
         /// Gets the default type converters
         /// </summary>
+        /// <value>An <see cref="IEnumerable{T}"/> of <see cref="IBodyDeserializer"/> instances.</value>
         public virtual IEnumerable<IBodyDeserializer> DefaultBodyDeserializers
         {
-            get
-            {
-                return this.defaultBodyDeserializers;
-            }
+            get { return this.defaultBodyDeserializers; }
         }
     }
 }

--- a/src/Nancy/ModelBinding/DefaultBodyDeserializers/JsonBodyDeserializer.cs
+++ b/src/Nancy/ModelBinding/DefaultBodyDeserializers/JsonBodyDeserializer.cs
@@ -32,8 +32,8 @@ namespace Nancy.ModelBinding.DefaultBodyDeserializers
         /// <returns>Model instance</returns>
         public object Deserialize(MediaRange mediaRange, Stream bodyStream, BindingContext context)
         {
-            var serializer = new JavaScriptSerializer(null, false, JsonSettings.MaxJsonLength, JsonSettings.MaxRecursions, JsonSettings.RetainCasing, JsonSettings.ISO8601DateFormat);
-            serializer.RegisterConverters(JsonSettings.Converters, JsonSettings.PrimitiveConverters);
+            var serializer = new JavaScriptSerializer(null, false, JsonConfiguration.MaxJsonLength, JsonConfiguration.MaxRecursions, JsonConfiguration.RetainCasing, JsonConfiguration.ISO8601DateFormat);
+            serializer.RegisterConverters(JsonConfiguration.Converters, JsonConfiguration.PrimitiveConverters);
 
             bodyStream.Position = 0;
             string bodyText;

--- a/src/Nancy/ModelBinding/DefaultBodyDeserializers/JsonBodyDeserializer.cs
+++ b/src/Nancy/ModelBinding/DefaultBodyDeserializers/JsonBodyDeserializer.cs
@@ -50,7 +50,7 @@ namespace Nancy.ModelBinding.DefaultBodyDeserializers
                 this.configuration.MaxJsonLength,
                 this.configuration.MaxRecursions,
                 this.configuration.RetainCasing,
-                this.configuration.ISO8601DateFormat,
+                this.configuration.UseISO8601DateFormat,
                 this.configuration.Converters,
                 this.configuration.PrimitiveConverters);
 

--- a/src/Nancy/ModelBinding/DefaultBodyDeserializers/JsonBodyDeserializer.cs
+++ b/src/Nancy/ModelBinding/DefaultBodyDeserializers/JsonBodyDeserializer.cs
@@ -2,6 +2,7 @@ namespace Nancy.ModelBinding.DefaultBodyDeserializers
 {
     using System.IO;
     using System.Reflection;
+    using Nancy.Configuration;
     using Nancy.Json;
     using Nancy.Responses.Negotiation;
 
@@ -11,6 +12,17 @@ namespace Nancy.ModelBinding.DefaultBodyDeserializers
     public class JsonBodyDeserializer : IBodyDeserializer
     {
         private readonly MethodInfo deserializeMethod = typeof(JavaScriptSerializer).GetMethod("Deserialize", BindingFlags.Instance | BindingFlags.Public);
+        private readonly JsonConfiguration configuration;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonBodyDeserializer"/>,
+        /// with the provided <paramref name="environment"/>.
+        /// </summary>
+        /// <param name="environment">An <see cref="INancyEnvironment"/> instance.</param>
+        public JsonBodyDeserializer(INancyEnvironment environment)
+        {
+            this.configuration = environment.GetValue<JsonConfiguration>();
+        }
 
         /// <summary>
         /// Whether the deserializer can deserialize the content type
@@ -32,8 +44,17 @@ namespace Nancy.ModelBinding.DefaultBodyDeserializers
         /// <returns>Model instance</returns>
         public object Deserialize(MediaRange mediaRange, Stream bodyStream, BindingContext context)
         {
-            var serializer = new JavaScriptSerializer(null, false, JsonConfiguration.MaxJsonLength, JsonConfiguration.MaxRecursions, JsonConfiguration.RetainCasing, JsonConfiguration.ISO8601DateFormat);
-            serializer.RegisterConverters(JsonConfiguration.Converters, JsonConfiguration.PrimitiveConverters);
+            var serializer = new JavaScriptSerializer(
+                null,
+                false,
+                this.configuration.MaxJsonLength,
+                this.configuration.MaxRecursions,
+                this.configuration.RetainCasing,
+                this.configuration.ISO8601DateFormat,
+                this.configuration.Converters,
+                this.configuration.PrimitiveConverters);
+
+            serializer.RegisterConverters(this.configuration.Converters, this.configuration.PrimitiveConverters);
 
             bodyStream.Position = 0;
             string bodyText;
@@ -42,9 +63,9 @@ namespace Nancy.ModelBinding.DefaultBodyDeserializers
                 bodyText = bodyReader.ReadToEnd();
             }
 
-            var genericDeserializeMethod = this.deserializeMethod.MakeGenericMethod(new[] { context.DestinationType });
+            var genericDeserializeMethod = this.deserializeMethod.MakeGenericMethod(context.DestinationType);
 
-            var deserializedObject = genericDeserializeMethod.Invoke(serializer, new[] { bodyText });
+            var deserializedObject = genericDeserializeMethod.Invoke(serializer, new object[] { bodyText });
 
             return deserializedObject;
         }

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -250,7 +250,7 @@
     <Compile Include="IO\UnclosableStreamWrapper.cs" />
     <Compile Include="ISerializer.cs" />
     <Compile Include="Json\Converters\TimeSpanConverter.cs" />
-    <Compile Include="Json\JsonSettings.cs" />
+    <Compile Include="Json\JsonConfiguration.cs" />
     <Compile Include="Responses\DefaultJsonSerializer.cs" />
     <Compile Include="Responses\DefaultXmlSerializer.cs" />
     <Compile Include="Responses\TextResponse.cs" />

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -195,7 +195,9 @@
     <Compile Include="ISerializerFactory.cs" />
     <Compile Include="IStaticContentProvider.cs" />
     <Compile Include="Json\Converters\TupleConverter.cs" />
+    <Compile Include="Json\DefaultJsonConfigurationProvider.cs" />
     <Compile Include="Json\JavaScriptPrimitiveConverter.cs" />
+    <Compile Include="Json\JsonConfigurationExtensions.cs" />
     <Compile Include="Localization\TextResourceFinder.cs" />
     <Compile Include="Helpers\TaskHelpers.cs" />
     <Compile Include="ModelBinding\BindingConfig.cs" />

--- a/src/Nancy/Responses/DefaultJsonSerializer.cs
+++ b/src/Nancy/Responses/DefaultJsonSerializer.cs
@@ -64,7 +64,7 @@
         /// </summary>
         public bool ISO8601DateFormat
         {
-            get { return iso8601DateFormat.HasValue ? iso8601DateFormat.Value : this.configuration.ISO8601DateFormat; }
+            get { return iso8601DateFormat.HasValue ? iso8601DateFormat.Value : this.configuration.UseISO8601DateFormat; }
             set { iso8601DateFormat = value; }
         }
 

--- a/src/Nancy/Responses/DefaultJsonSerializer.cs
+++ b/src/Nancy/Responses/DefaultJsonSerializer.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.IO;
-
+    using Nancy.Configuration;
     using Nancy.IO;
     using Nancy.Json;
     using Nancy.Responses.Negotiation;
@@ -15,6 +15,17 @@
     {
         private bool? retainCasing;
         private bool? iso8601DateFormat;
+        private readonly JsonConfiguration configuration;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultJsonSerializer"/> class,
+        /// with the provided <see cref="INancyEnvironment"/>.
+        /// </summary>
+        /// <param name="environment">An <see cref="INancyEnvironment"/> instance.</param>
+        public DefaultJsonSerializer(INancyEnvironment environment)
+        {
+            this.configuration = environment.GetValue<JsonConfiguration>();
+        }
 
         /// <summary>
         /// Whether the serializer can serialize the content type
@@ -42,7 +53,7 @@
         /// </summary>
         public bool RetainCasing
         {
-            get { return retainCasing.HasValue ? retainCasing.Value : JsonConfiguration.RetainCasing; }
+            get { return retainCasing.HasValue ? retainCasing.Value : this.configuration.RetainCasing; }
             set { retainCasing = value; }
         }
 
@@ -53,7 +64,7 @@
         /// </summary>
         public bool ISO8601DateFormat
         {
-            get { return iso8601DateFormat.HasValue ? iso8601DateFormat.Value : JsonConfiguration.ISO8601DateFormat; }
+            get { return iso8601DateFormat.HasValue ? iso8601DateFormat.Value : this.configuration.ISO8601DateFormat; }
             set { iso8601DateFormat = value; }
         }
 
@@ -68,9 +79,17 @@
         {
             using (var writer = new StreamWriter(new UnclosableStreamWrapper(outputStream)))
             {
-                var serializer = new JavaScriptSerializer(null, false, JsonConfiguration.MaxJsonLength, JsonConfiguration.MaxRecursions, RetainCasing, ISO8601DateFormat);
+                var serializer = new JavaScriptSerializer(
+                    null,
+                    false,
+                    this.configuration.MaxJsonLength,
+                    this.configuration.MaxRecursions,
+                    RetainCasing,
+                    ISO8601DateFormat,
+                    this.configuration.Converters,
+                    this.configuration.PrimitiveConverters);
 
-                serializer.RegisterConverters(JsonConfiguration.Converters, JsonConfiguration.PrimitiveConverters);
+                serializer.RegisterConverters(this.configuration.Converters, this.configuration.PrimitiveConverters);
 
                 try
                 {

--- a/src/Nancy/Responses/DefaultJsonSerializer.cs
+++ b/src/Nancy/Responses/DefaultJsonSerializer.cs
@@ -42,7 +42,7 @@
         /// </summary>
         public bool RetainCasing
         {
-            get { return retainCasing.HasValue ? retainCasing.Value : JsonSettings.RetainCasing; }
+            get { return retainCasing.HasValue ? retainCasing.Value : JsonConfiguration.RetainCasing; }
             set { retainCasing = value; }
         }
 
@@ -53,7 +53,7 @@
         /// </summary>
         public bool ISO8601DateFormat
         {
-            get { return iso8601DateFormat.HasValue ? iso8601DateFormat.Value : JsonSettings.ISO8601DateFormat; }
+            get { return iso8601DateFormat.HasValue ? iso8601DateFormat.Value : JsonConfiguration.ISO8601DateFormat; }
             set { iso8601DateFormat = value; }
         }
 
@@ -68,9 +68,9 @@
         {
             using (var writer = new StreamWriter(new UnclosableStreamWrapper(outputStream)))
             {
-                var serializer = new JavaScriptSerializer(null, false, JsonSettings.MaxJsonLength, JsonSettings.MaxRecursions, RetainCasing, ISO8601DateFormat);
+                var serializer = new JavaScriptSerializer(null, false, JsonConfiguration.MaxJsonLength, JsonConfiguration.MaxRecursions, RetainCasing, ISO8601DateFormat);
 
-                serializer.RegisterConverters(JsonSettings.Converters, JsonSettings.PrimitiveConverters);
+                serializer.RegisterConverters(JsonConfiguration.Converters, JsonConfiguration.PrimitiveConverters);
 
                 try
                 {

--- a/src/Nancy/Responses/JsonResponse.cs
+++ b/src/Nancy/Responses/JsonResponse.cs
@@ -2,42 +2,68 @@
 {
     using System;
     using System.IO;
-
+    using Nancy.Configuration;
     using Nancy.Json;
 
+    /// <summary>
+    /// Represents a JSON response of the type <typeparamref name="TModel"/>.
+    /// </summary>
+    /// <typeparam name="TModel">The type of the model.</typeparam>
     public class JsonResponse<TModel> : Response
     {
-        public JsonResponse(TModel model, ISerializer serializer)
+        private readonly JsonConfiguration configuration;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonResponse{TModel}"/> class,
+        /// with the provided <paramref name="model"/>, <paramref name="serializer"/>
+        /// and <paramref name="environment"/>.
+        /// </summary>
+        /// <param name="model">The model that should be returned as JSON.</param>
+        /// <param name="serializer">The <see cref="ISerializer"/> to use for the serialization.</param>
+        /// <param name="environment">An <see cref="INancyEnvironment"/> instance.</param>
+        public JsonResponse(TModel model, ISerializer serializer, INancyEnvironment environment)
         {
             if (serializer == null)
             {
                 throw new InvalidOperationException("JSON Serializer not set");
             }
 
-            this.Contents = model == null ? NoBody : GetJsonContents(model, serializer);
-            this.ContentType = DefaultContentType;
+            this.configuration = environment.GetValue<JsonConfiguration>();
+            this.Contents = model == null ? NoBody : this.GetJsonContents(model, serializer);
+            this.ContentType = this.DefaultContentType;
             this.StatusCode = HttpStatusCode.OK;
         }
 
-        private static string DefaultContentType
+        private string DefaultContentType
         {
-            get { return string.Concat("application/json", Encoding); }
+            get { return string.Concat("application/json", this.Encoding); }
         }
 
-        private static string Encoding
+        private string Encoding
         {
-            get { return string.Concat("; charset=", JsonConfiguration.DefaultEncoding.WebName); }
+            get { return string.Concat("; charset=", this.configuration.DefaultEncoding.WebName); }
         }
 
-        private static Action<Stream> GetJsonContents(TModel model, ISerializer serializer)
+        private Action<Stream> GetJsonContents(TModel model, ISerializer serializer)
         {
-            return stream => serializer.Serialize(DefaultContentType, model, stream);
+            return stream => serializer.Serialize(this.DefaultContentType, model, stream);
         }
     }
 
+    /// <summary>
+    /// Represents a JSON response
+    /// </summary>
     public class JsonResponse : JsonResponse<object>
     {
-        public JsonResponse(object model, ISerializer serializer) : base(model, serializer)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonResponse{TModel}"/> class,
+        /// with the provided <paramref name="model"/>, <paramref name="serializer"/>
+        /// and <paramref name="environment"/>.
+        /// </summary>
+        /// <param name="model">The model that should be returned as JSON.</param>
+        /// <param name="serializer">The <see cref="ISerializer"/> to use for the serialization.</param>
+        /// <param name="environment">An <see cref="INancyEnvironment"/> instance.</param>
+        public JsonResponse(object model, ISerializer serializer, INancyEnvironment environment) : base(model, serializer, environment)
         {
         }
     }

--- a/src/Nancy/Responses/JsonResponse.cs
+++ b/src/Nancy/Responses/JsonResponse.cs
@@ -26,7 +26,7 @@
 
         private static string Encoding
         {
-            get { return string.Concat("; charset=", JsonSettings.DefaultEncoding.WebName); }
+            get { return string.Concat("; charset=", JsonConfiguration.DefaultEncoding.WebName); }
         }
 
         private static Action<Stream> GetJsonContents(TModel model, ISerializer serializer)

--- a/src/Nancy/Responses/Negotiation/JsonProcessor.cs
+++ b/src/Nancy/Responses/Negotiation/JsonProcessor.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Nancy.Configuration;
 
     /// <summary>
     /// Processes the model for json media types and extension.
@@ -10,6 +11,7 @@
     public class JsonProcessor : IResponseProcessor
     {
         private readonly ISerializer serializer;
+        private readonly INancyEnvironment environment;
 
         private static readonly IEnumerable<Tuple<string, MediaRange>> extensionMappings =
             new[] { new Tuple<string, MediaRange>("json", new MediaRange("application/json")) };
@@ -19,9 +21,11 @@
         /// with the provided <paramref name="serializers"/>.
         /// </summary>
         /// <param name="serializers">The serializes that the processor will use to process the request.</param>
-        public JsonProcessor(IEnumerable<ISerializer> serializers)
+        /// <param name="environment">An <see cref="INancyEnvironment"/> instance.</param>
+        public JsonProcessor(IEnumerable<ISerializer> serializers, INancyEnvironment environment)
         {
             this.serializer = serializers.FirstOrDefault(x => x.CanSerialize("application/json"));
+            this.environment = environment;
         }
 
         /// <summary>
@@ -76,7 +80,7 @@
         /// <returns>A response</returns>
         public Response Process(MediaRange requestedMediaRange, dynamic model, NancyContext context)
         {
-            return new JsonResponse(model, this.serializer);
+            return new JsonResponse(model, this.serializer, this.environment);
         }
 
         private static bool IsExactJsonContentType(MediaRange requestedContentType)


### PR DESCRIPTION
In theory, this pull-request is ready to be pulled in but I have decided to **WIP** it because it is going to require a proper review.

The usual suspects have been added

- `JsonConfiguration` - Renamed `JsonSettings` to align with the naming conventions we're following for these. Also made it immutable. Also contains `JsonConfiguration.Default`
- `JsonConfigurationExtensions` - Contains the `INancyEnvironment.Json(...)` extension method
- `DefaultJsonConfigurationProvider` - To make sure we always have json settings available even if the user hasn't explicitly configured them

The reason that this pull-request has so many changed files are mainly because of two things

- The model binder has a bit of a smell to it where it explicitly news up default body deserializers, so I had to trickle the environment into that API (we probably should have a `IBodyDeserializerFactory` like we recently introduced `ISerializerFactory` .. perhaps even unify the interfaces and just have the one that supports symmetrical operations - but that's a different dragon to slay) 
- The `Nancy.Testing` stuff has some helper extensions that allows you to easily deserialize response bodies so I had make sure it was available to the response wrapper that we return from the `Browser` operations