### PR TITLE
[WIP]Migrated StaticConfiguration to config API

### DIFF
--- a/src/Nancy/StaticConfiguration.cs
+++ b/src/Nancy/StaticConfiguration.cs
@@ -7,14 +7,14 @@ namespace Nancy
     using Nancy.Bootstrapper;
     using Nancy.Diagnostics;
 
-    public static class StaticConfiguration
+    public class StaticConfiguration
     {
-        private static bool? isRunningDebug;
-        private static bool? disableCaches;
+        private bool? isRunningDebug;
+        private bool? disableCaches;
 
-        private static bool? disableErrorTraces;
+        private bool? disableErrorTraces;
 
-        static StaticConfiguration()
+        public StaticConfiguration()
         {
             disableErrorTraces = !(disableCaches = IsRunningDebug);
             CaseSensitive = false;
@@ -26,7 +26,7 @@ namespace Nancy
         /// Gets or sets a value indicating whether or not to disable traces in error messages
         /// </summary>
         [Description("Disables trace output in the default 500 error pages.")]
-        public static bool DisableErrorTraces
+        public bool DisableErrorTraces
         {
             get
             {
@@ -42,26 +42,26 @@ namespace Nancy
         /// Gets or sets a value indicating whether or not to respond with 405 responses
         /// </summary>
         [Description("Disables 405 responses from being sent to the client.")]
-        public static bool DisableMethodNotAllowedResponses { get; set; }
+        public bool DisableMethodNotAllowedResponses { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether or not to enable case sensitivity in query, parameters (DynamicDictionary) and model binding. Enable this to conform with RFC3986.
         /// </summary>
         [Description("Enable case sensitivity in query, parameters (DynamicDictionary) and model binding. Enable this to conform with RFC3986.")]
-        public static bool CaseSensitive { get; set; }
+        public bool CaseSensitive { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether or not to route HEAD requests explicitly.
         /// </summary>
         [Description("Enables explicit HEAD routing and disables the usage of GET routes for HEAD requests.")]
-        public static bool EnableHeadRouting { get; set; }
+        public bool EnableHeadRouting { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether we are running in debug mode or not.
         /// Checks the entry assembly to see whether it has been built in debug mode.
         /// If anything goes wrong it returns false.
         /// </summary>
-        public static bool IsRunningDebug
+        public bool IsRunningDebug
         {
             get
             {
@@ -73,9 +73,9 @@ namespace Nancy
         /// Gets or sets the limit on the number of query string variables, form fields,
         /// or multipart sections in a request.
         /// </summary>
-        public static int RequestQueryFormMultipartLimit { get; set; }
+        public int RequestQueryFormMultipartLimit { get; set; }
 
-        private static bool GetDebugMode()
+        private bool GetDebugMode()
         {
             try
             {
@@ -100,32 +100,32 @@ namespace Nancy
         /// Gets or sets a value indicating whether or not to enable request tracing
         /// </summary>
         [Description("Enable request tracing.")]
-        public static bool EnableRequestTracing { get; set; }
+        public bool EnableRequestTracing { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether or not to disable request stream switching
         /// </summary>
-        public static bool? DisableRequestStreamSwitching { get; set; }
+        public bool? DisableRequestStreamSwitching { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether this <see cref="Nancy.StaticConfiguration"/> allow file stream
         /// upload async due to mono issues before v4.  Uploads of over 80mb would result in extra padded chars to the filestream corrupting the file.
         /// </summary>
         /// <value><c>true</c> if allow file stream upload async; otherwise, <c>false</c>.</value>
-        public static bool AllowFileStreamUploadAsync { get; set; }
+        public bool AllowFileStreamUploadAsync { get; set; }
 
-        public static class Caching
+        public class Caching
         {
-            private static bool? enableRuntimeViewDiscovery;
+            private bool? enableRuntimeViewDiscovery;
 
-            private static bool? enableRuntimeViewUpdates;
+            private bool? enableRuntimeViewUpdates;
 
             /// <summary>
             /// Gets or sets a value indicating whether or not to enable runtime view discovery
             /// Defaults to True in debug mode and False in release mode
             /// </summary>
             [Description("Enable runtime discovery of new views.")]
-            public static bool EnableRuntimeViewDiscovery
+            public bool EnableRuntimeViewDiscovery
             {
                 get
                 {
@@ -142,7 +142,7 @@ namespace Nancy
             /// Defaults to True in debug mode and False in release mode
             /// </summary>
             [Description("Enable runtime updating of view templates.")]
-            public static bool EnableRuntimeViewUpdates
+            public bool EnableRuntimeViewUpdates
             {
                 get
                 {


### PR DESCRIPTION
_Opening this pull-request early for the sake of discussions_

## Background

The `StaticConfiguration` design has served us well over the years, but the time has come for us to remove this static class. We need to move away from static instances for various reasons (multi-tenancy, DNX, improved testing and so on). The class will be migrated over the new config API that was implemented in #1999 

## Overview

This one is probably going to be broken up into several different configurations (one pull-request each), because right now `StaticConfiguration` is a mix of things.
The following members are on the class today

- `DisableErrorTraces` (Tracing)
- `DisableMethodNotAllowedResponses` (Routing)
- `CaseSensitive` (???)
- `EnableHeadRouting` (Routing)
- `IsRunningDebug` (Discussion in the comments [here](https://github.com/NancyFx/Nancy/pull/2125#issuecomment-158758527))
- `RequestQueryFormMultipartLimit` (Request file uploads)
- `EnableRequestTracing` (Tracing)
- `DisableRequestStreamSwitching` (Request file uploads)
- `AllowFileStreamUploadAsync` (Request file uploads)
- `EnableRuntimeViewDiscovery` (Views)
- `EnableRuntimeViewUpdates` (Views)

These need to be

1. Decided if any of them should be deleted, i.e does it still make sense to have all of them around?
1. Grouped into different configs
1. Renamed to make more sense in their new context

I have a feeling that `IsRunningDebug` probably should not be a config thing, but rather be placed in a class that you can take a dependency on if you need to know

```#
public interface IEnvironmentInformation
{
    bool IsDebug();
}
```

I know the name sucks (suggestions?), but it illustrates the point ;)
Update: See the [comment below](https://github.com/NancyFx/Nancy/pull/2125#issuecomment-158758527) for a discussion / spike on this

## Naming

Right now the static configurations uses a mix of `EnableXXXX` and `DisableXXXX`. I think all of these should follow the same naming convention and use appropriate default values instead.

## Progress

Removed all use of the `static` ketword in the `StaticConfiguration` class and ended up with 32 errors

![image](https://cloud.githubusercontent.com/assets/50543/11323300/91b40988-910f-11e5-8cd6-db8ae934d6fc.png)