### PR TITLE
NullReferenceException in pipeline

### DIFF
--- a/src/Nancy.Tests/Unit/AfterPipelineFixture.cs
+++ b/src/Nancy.Tests/Unit/AfterPipelineFixture.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Linq;
     using System.Threading;
+    using System.Threading.Tasks;
 
     using Xunit;
 
@@ -101,6 +102,37 @@
             Assert.True(item2Called);
             Assert.True(item3Called);
             Assert.True(item4Called);
+        }
+
+        [Fact]
+        public void Pipeline_containing_method_returning_null_throws_InvalidOperationException()
+        {
+            pipeline.AddItemToEndOfPipeline(ReturnNull);
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+            {
+                pipeline.Invoke(CreateContext(), new CancellationToken());
+            });
+
+            Assert.Equal("An after-pipeline action must not return null, a Task was expected.", exception.Message);
+        }
+
+        [Fact]
+        public void Pipeline_containing_lambda_returning_null_throws_InvalidOperationException()
+        {
+            pipeline.AddItemToEndOfPipeline((context, ct) => null);
+
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+            {
+                pipeline.Invoke(CreateContext(), new CancellationToken());
+            });
+
+            Assert.Equal("An after-pipeline action must not return null, a Task was expected.", exception.Message);
+        }
+        
+        private static Task ReturnNull(NancyContext context, CancellationToken ct)
+        {
+            return null;
         }
     }
 }

--- a/src/Nancy/AfterPipeline.cs
+++ b/src/Nancy/AfterPipeline.cs
@@ -83,6 +83,11 @@
             {
                 var current = enumerator.Current.Invoke(context, cancellationToken);
 
+                if (current == null)
+                {
+                    throw new InvalidOperationException("An after-pipeline action must not return null, a Task was expected.");
+                }
+
                 if (current.Status == TaskStatus.Created)
                 {
                     current.Start();


### PR DESCRIPTION
If a pipeline method returning `Task` for some reason returns `null`, `Nancy.AfterPipeline.ExecuteTasksInternal()` blows up with a `NullReferenceException`. This PR fixes this by instead throwing an informative `InvalidOperationException` as well as a couple of tests ensuring the expected behavior.