### PR TITLE
Fix for #2076

### DIFF
--- a/src/Nancy.Tests/Unit/ModelBinding/DefaultBinderFixture.cs
+++ b/src/Nancy.Tests/Unit/ModelBinding/DefaultBinderFixture.cs
@@ -580,6 +580,25 @@ namespace Nancy.Tests.Unit.ModelBinding
         }
 
         [Fact]
+        public void Should_bind_inherited_model_from_request()
+        {
+            // Given
+            var binder = this.GetBinder();
+            var context = CreateContextWithHeader("Content-Type", new[] { "application/xml" });
+            context.Request.Query["StringProperty"] = "Test";
+            context.Request.Query["IntProperty"] = "3";
+            context.Request.Query["AnotherProperty"] = "Hello";
+
+            // When
+            var result = (InheritedTestModel)binder.Bind(context, typeof(InheritedTestModel), null, BindingConfig.Default);
+
+            // Then
+            result.StringProperty.ShouldEqual("Test");
+            result.IntProperty.ShouldEqual(3);
+            result.AnotherProperty.ShouldEqual("Hello");
+        }
+
+        [Fact]
         public void Should_bind_model_from_context_parameters()
         {
             // Given
@@ -1594,6 +1613,11 @@ namespace Nancy.Tests.Unit.ModelBinding
             public List<AnotherTestModel> ModelsProperty { get; set; }
 
             public List<AnotherTestModel> ModelsField;
+        }
+
+        public class InheritedTestModel : TestModel
+        {
+            public string AnotherProperty { get; set; }
         }
 
         public class AnotherTestModel

--- a/src/Nancy/ModelBinding/DynamicModelBinderAdapter.cs
+++ b/src/Nancy/ModelBinding/DynamicModelBinderAdapter.cs
@@ -55,14 +55,16 @@
         /// <param name="binder">Provides information about the conversion operation. The binder.Type property provides the type to which the object must be converted. For example, for the statement (String)sampleObject in C# (CType(sampleObject, Type) in Visual Basic), where sampleObject is an instance of the class derived from the <see cref="T:System.Dynamic.DynamicObject"/> class, binder.Type returns the <see cref="T:System.String"/> type. The binder.Explicit property provides information about the kind of conversion that occurs. It returns true for explicit conversion and false for implicit conversion.</param><param name="result">The result of the type conversion operation.</param>
         public override bool TryConvert(ConvertBinder binder, out object result)
         {
-            var modelBinder = this.locator.GetBinderForType(binder.Type, this.context);
+            var instanceType = instance == null ? binder.Type : this.instance.GetType();
+
+            var modelBinder = this.locator.GetBinderForType(instanceType, this.context);
 
             if (modelBinder == null)
             {
-                throw new ModelBindingException(binder.Type);
+                throw new ModelBindingException(instanceType);
             }
 
-            result = modelBinder.Bind(this.context, binder.Type, this.instance, this.configuration, this.blacklistedProperties);
+            result = modelBinder.Bind(this.context, instanceType, this.instance, this.configuration, this.blacklistedProperties);
 
             return result != null || base.TryConvert(binder, out result);
         }


### PR DESCRIPTION
The dynamic object receives a reference to the parent type in the binder
and not the inherited type. As the instance type is detectable and is
the eventual target, it should be used to call Bind on the model binder.

Closes #2102

This is a rebased version of #2102 with @jchannon's feedback addressed. This should be good to merge, IMO.