### PR TITLE
Ensure http verbs are compared in a case insensitive way

### DIFF
--- a/src/Nancy.Tests.Functional/Tests/MethodRewriteFixture.cs
+++ b/src/Nancy.Tests.Functional/Tests/MethodRewriteFixture.cs
@@ -1,14 +1,13 @@
 namespace Nancy.Tests.Functional.Tests
 {
     using System;
-
-    using Nancy.Testing;
-
+    using Testing;
     using Xunit;
+    using Xunit.Extensions;
 
     public class MethodRewriteFixture
     {
-        private Browser browser;
+        private readonly Browser browser;
 
         public MethodRewriteFixture()
         {
@@ -18,23 +17,29 @@ namespace Nancy.Tests.Functional.Tests
             });
         }
 
-        [Fact]
-        public void Should_rewrite_method_when_method_form_input_is_provided()
+        [Theory]
+        [InlineData("delete")]
+        [InlineData("dElEtE")]
+        [InlineData("DELETE")]
+        public void Should_rewrite_method_when_method_form_input_is_provided(string method)
         {
             var response = this.browser.Post("/", with =>
             {
-                with.FormValue("_method", "DELETE");
+                with.FormValue("_method", method);
             });
 
             Assert.Equal("Delete route", response.Body.AsString());
         }
 
-        [Fact]
-        public void Should_rewrite_method_when_x_http_method_override_form_input_is_provided()
+        [Theory]
+        [InlineData("delete")]
+        [InlineData("dElEtE")]
+        [InlineData("DELETE")]
+        public void Should_rewrite_method_when_x_http_method_override_form_input_is_provided(string method)
         {
             var response = this.browser.Post("/", with =>
             {
-                with.FormValue("X-HTTP-Method-Override", "DELETE");
+                with.FormValue("X-HTTP-Method-Override", method);
             });
 
             Assert.Equal("Delete route", response.Body.AsString());

--- a/src/Nancy/Diagnostics/DiagnosticsHook.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsHook.cs
@@ -5,18 +5,18 @@ namespace Nancy.Diagnostics
     using System.IO;
     using System.Linq;
     using System.Threading;
-    using Nancy.Bootstrapper;
-    using Nancy.Configuration;
-    using Nancy.Cookies;
-    using Nancy.Cryptography;
-    using Nancy.Culture;
-    using Nancy.Localization;
-    using Nancy.ModelBinding;
-    using Nancy.Responses;
-    using Nancy.Responses.Negotiation;
-    using Nancy.Routing;
-    using Nancy.Routing.Constraints;
-    using Nancy.Routing.Trie;
+    using Bootstrapper;
+    using Configuration;
+    using Cookies;
+    using Cryptography;
+    using Culture;
+    using Localization;
+    using ModelBinding;
+    using Responses;
+    using Responses.Negotiation;
+    using Routing;
+    using Routing.Constraints;
+    using Routing.Trie;
 
     public static class DiagnosticsHook
     {

--- a/src/Nancy/Diagnostics/DiagnosticsHook.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsHook.cs
@@ -147,7 +147,7 @@ namespace Nancy.Diagnostics
                 ctx.Response = task.Result;
             }
 
-            if (ctx.Request.Method.ToUpperInvariant() == "HEAD")
+            if (ctx.Request.Method.Equals("HEAD", StringComparison.OrdinalIgnoreCase))
             {
                 ctx.Response = new HeadResponse(ctx.Response);
             }
@@ -253,7 +253,7 @@ namespace Nancy.Diagnostics
 
         private static bool IsLoginRequest(NancyContext context, DiagnosticsConfiguration diagnosticsConfiguration)
         {
-            return context.Request.Method == "POST" &&
+            return context.Request.Method.Equals("POST", StringComparison.OrdinalIgnoreCase) &&
                 context.Request.Url.BasePath.TrimEnd(new[] { '/' }).EndsWith(diagnosticsConfiguration.Path) &&
                 context.Request.Url.Path == "/";
         }

--- a/src/Nancy/Request.cs
+++ b/src/Nancy/Request.cs
@@ -8,10 +8,9 @@ namespace Nancy
     using System.Linq;
     using System.Security.Cryptography.X509Certificates;
     using System.Text.RegularExpressions;
-
-    using Nancy.Extensions;
-    using Nancy.Helpers;
-    using Nancy.IO;
+    using Extensions;
+    using Helpers;
+    using IO;
     using Session;
 
     /// <summary>

--- a/src/Nancy/Request.cs
+++ b/src/Nancy/Request.cs
@@ -299,14 +299,15 @@ namespace Nancy
                 };
 
             var providedOverride =
-                overrides.Where(x => !string.IsNullOrEmpty(x.Item2));
+                overrides.Where(x => !string.IsNullOrEmpty(x.Item2))
+                         .ToList();
 
             if (!providedOverride.Any())
             {
                 return;
             }
 
-            if (providedOverride.Count() > 1)
+            if (providedOverride.Count > 1)
             {
                 var overrideSources =
                     string.Join(", ", providedOverride);

--- a/src/Nancy/Routing/DefaultRequestDispatcher.cs
+++ b/src/Nancy/Routing/DefaultRequestDispatcher.cs
@@ -6,9 +6,8 @@ namespace Nancy.Routing
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-
-    using Nancy.Helpers;
-    using Nancy.Responses.Negotiation;
+    using Helpers;
+    using Responses.Negotiation;
 
     /// <summary>
     /// Default implementation of a request dispatcher.

--- a/src/Nancy/Routing/DefaultRequestDispatcher.cs
+++ b/src/Nancy/Routing/DefaultRequestDispatcher.cs
@@ -69,7 +69,7 @@ namespace Nancy.Routing
                                     {
                                         context.Response = completedRouteTask.Result;
 
-                                        if (context.Request.Method.ToUpperInvariant() == "HEAD")
+                                        if (context.Request.Method.Equals("HEAD", StringComparison.OrdinalIgnoreCase))
                                         {
                                             context.Response = new HeadResponse(context.Response);
                                         }

--- a/src/Nancy/Routing/DefaultRouteResolver.cs
+++ b/src/Nancy/Routing/DefaultRouteResolver.cs
@@ -93,7 +93,7 @@
 
         private static bool IsOptionsRequest(NancyContext context)
         {
-            return context.Request.Method.Equals("OPTIONS", StringComparison.Ordinal);
+            return context.Request.Method.Equals("OPTIONS", StringComparison.OrdinalIgnoreCase);
         }
 
         private void BuildTrie()
@@ -163,7 +163,7 @@
 
             if (!StaticConfiguration.EnableHeadRouting)
             {
-                return requestedMethod.Equals("HEAD", StringComparison.Ordinal) ?
+                return requestedMethod.Equals("HEAD", StringComparison.OrdinalIgnoreCase) ?
                     "GET" :
                     requestedMethod;
             }

--- a/src/Nancy/Routing/DefaultRouteResolver.cs
+++ b/src/Nancy/Routing/DefaultRouteResolver.cs
@@ -3,9 +3,8 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-
-    using Nancy.Helpers;
-    using Nancy.Routing.Trie;
+    using Helpers;
+    using Trie;
 
     /// <summary>
     /// Default implementation of the <see cref="IRouteResolver"/> interface.

--- a/src/Nancy/Routing/Trie/RouteResolverTrie.cs
+++ b/src/Nancy/Routing/Trie/RouteResolverTrie.cs
@@ -4,8 +4,7 @@ namespace Nancy.Routing.Trie
     using System.Collections.Generic;
     using System.Linq;
     using System.Text;
-
-    using Nancy.Routing.Trie.Nodes;
+    using Nodes;
 
     /// <summary>
     /// The default route resolution trie

--- a/src/Nancy/Routing/Trie/RouteResolverTrie.cs
+++ b/src/Nancy/Routing/Trie/RouteResolverTrie.cs
@@ -14,7 +14,7 @@ namespace Nancy.Routing.Trie
     {
         private readonly ITrieNodeFactory nodeFactory;
 
-        private readonly IDictionary<string, TrieNode> routeTries = new Dictionary<string, TrieNode>();
+        private readonly IDictionary<string, TrieNode> routeTries = new Dictionary<string, TrieNode>(StringComparer.OrdinalIgnoreCase);
 
         private static char[] splitSeparators = new[] {'/'};
 


### PR DESCRIPTION
This should resolve #2119. I used `.ToUpperInvariant()` because it's what was used in [DefaultRequestDispatcher.cs#L72](https://github.com/NancyFx/Nancy/blob/df8722d11e983029446d48d5b08740d9dad24218/src/Nancy/Routing/DefaultRequestDispatcher.cs#L72)

This also removes the multiple enumeration of `providedOverride` but if we don't want to make that change I can revert it.