### PR TITLE
Add the method name to the InvalidOperationException

### DIFF
--- a/src/Nancy.Tests/Unit/AfterPipelineFixture.cs
+++ b/src/Nancy.Tests/Unit/AfterPipelineFixture.cs
@@ -1,4 +1,4 @@
-﻿namespace Nancy.Tests.Unit
+namespace Nancy.Tests.Unit
 {
     using System;
     using System.Linq;
@@ -114,7 +114,7 @@
                 pipeline.Invoke(CreateContext(), new CancellationToken());
             });
 
-            Assert.Equal("An after-pipeline action must not return null, a Task was expected.", exception.Message);
+            Assert.Equal("The after-pipeline action ReturnNull returned null; a Task was expected.", exception.Message);
         }
 
         [Fact]
@@ -127,7 +127,7 @@
                 pipeline.Invoke(CreateContext(), new CancellationToken());
             });
 
-            Assert.Equal("An after-pipeline action must not return null, a Task was expected.", exception.Message);
+            Assert.Equal("An after-pipeline action must not return null; a Task was expected.", exception.Message);
         }
         
         private static Task ReturnNull(NancyContext context, CancellationToken ct)

--- a/src/Nancy/AfterPipeline.cs
+++ b/src/Nancy/AfterPipeline.cs
@@ -1,7 +1,8 @@
-﻿namespace Nancy
+namespace Nancy
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -85,7 +86,14 @@
 
                 if (current == null)
                 {
-                    throw new InvalidOperationException("An after-pipeline action must not return null, a Task was expected.");
+                    if (enumerator.Current.Method != null && !new[] { '<', '>' }.Any(enumerator.Current.Method.Name.Contains))
+                    {
+                        throw new InvalidOperationException(
+                            string.Format("The after-pipeline action {0} returned null; a Task was expected.",
+                                          enumerator.Current.Method.Name));
+                    }
+
+                    throw new InvalidOperationException("An after-pipeline action must not return null; a Task was expected.");
                 }
 
                 if (current.Status == TaskStatus.Created)


### PR DESCRIPTION
This PR adds the method name to the `InvalidOperationException` thrown when a pipeline action returns null, and use semicolon instead of comma to separate the clauses in the message.