### PR TITLE
Fixes issue #2131 with XmlProcessor

### DIFF
--- a/src/Nancy/Responses/Negotiation/XmlProcessor.cs
+++ b/src/Nancy/Responses/Negotiation/XmlProcessor.cs
@@ -83,7 +83,13 @@
         {
             return new Response
             {
-                Contents = stream => serializer.Serialize("application/xml", model, stream),
+                Contents = stream =>
+                {
+                    if (model != null)
+                    {
+                        serializer.Serialize("application/xml", model, stream);
+                    }
+                },
                 ContentType = "application/xml",
                 StatusCode = HttpStatusCode.OK
             };


### PR DESCRIPTION
When the model passed to CreateResponse is null don't try to serialize
it as XML, effectively pass an empty body.