### PR TITLE
Fixed dll paths in Nancy.ViewEngines.Razor.targets

### DIFF
--- a/src/Nancy.ViewEngines.Razor/targets/Nancy.ViewEngines.Razor.targets
+++ b/src/Nancy.ViewEngines.Razor/targets/Nancy.ViewEngines.Razor.targets
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <Target Name="CopyRazorFiles" Condition="'$(Configuration)'=='DEBUG'">
-     <Copy SourceFiles="$(MSBuildThisFileDirectory)..\BuildProviders\Nancy.Viewengines.Razor.BuildProviders.dll" DestinationFolder="$(DestinationFolder)" ContinueOnError="true" />
-     <Copy SourceFiles="$(MSBuildThisFileDirectory)..\lib\net40\Nancy.Viewengines.Razor.dll" DestinationFolder="$(DestinationFolder)" ContinueOnError="true" />
+     <Copy SourceFiles="$(MSBuildThisFileDirectory)..\BuildProviders\Nancy.ViewEngines.Razor.BuildProviders.dll" DestinationFolder="$(DestinationFolder)" ContinueOnError="true" />
+     <Copy SourceFiles="$(MSBuildThisFileDirectory)..\lib\net40\Nancy.ViewEngines.Razor.dll" DestinationFolder="$(DestinationFolder)" ContinueOnError="true" />
    </Target>
 </Project>


### PR DESCRIPTION
This should fix following build problem on mono
"Cannot copy packages/Nancy.Viewengines.Razor.1.4.1/BuildProviders/Nancy.Viewengines.Razor.BuildProviders.dll [...] as the source file doesn't exist."