### PR TITLE
Added IRuntimeEnvironmentInformation

### DIFF
--- a/src/Nancy.Testing/ConfigurableBootstrapper.cs
+++ b/src/Nancy.Testing/ConfigurableBootstrapper.cs
@@ -1555,6 +1555,30 @@ namespace Nancy.Testing
             }
 
             /// <summary>
+            /// Configures the bootstrapper to use the provided instance of <see cref="IRuntimeEnvironmentInformation"/>.
+            /// </summary>
+            /// <param name="runtimeEnvironmentInformation">The <see cref="IRuntimeEnvironmentInformation"/> instance that should be used by the bootstrapper.</param>
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RuntimeEnvironmentInformation(IRuntimeEnvironmentInformation runtimeEnvironmentInformation)
+            {
+                this.bootstrapper.registeredInstances.Add(
+                    new InstanceRegistration(typeof(IRuntimeEnvironmentInformation), runtimeEnvironmentInformation));
+
+                return this;
+            }
+
+            /// <summary>
+            /// Configures the bootstrapper to create an <see cref="IRuntimeEnvironmentInformation"/> instance of the specified type.
+            /// </summary>
+            /// <typeparam name="T">The type of the <see cref="IRuntimeEnvironmentInformation"/> that the bootstrapper should use.</typeparam>
+            /// <returns>A reference to the current <see cref="ConfigurableBootstrapperConfigurator"/>.</returns>
+            public ConfigurableBootstrapperConfigurator RuntimeEnvironmentInformation<T>() where T : IRuntimeEnvironmentInformation
+            {
+                this.bootstrapper.configuration.RuntimeEnvironmentInformation = typeof(T);
+                return this;
+            }
+
+            /// <summary>
             /// Configures the bootstrapper to use the provided instance of <see cref="ITextResource"/>.
             /// </summary>
             /// <param name="textResource">The <see cref="ITextResource"/> instance that should be used by the bootstrapper.</param>

--- a/src/Nancy/Bootstrapper/NancyInternalConfiguration.cs
+++ b/src/Nancy/Bootstrapper/NancyInternalConfiguration.cs
@@ -81,9 +81,12 @@ namespace Nancy.Bootstrapper
                     EnvironmentConfigurator = typeof(DefaultNancyEnvironmentConfigurator),
                     DefaultConfigurationProviders = AppDomainAssemblyTypeScanner.TypesOf<INancyDefaultConfigurationProvider>().ToList(),
                     SerializerFactory = typeof(DefaultSerializerFactory),
+                    RuntimeEnvironmentInformation = typeof(DefaultRuntimeEnvironmentInformation),
                 };
             }
         }
+
+        public Type RuntimeEnvironmentInformation { get; set; }
 
         public Type SerializerFactory { get; set; }
 
@@ -255,7 +258,8 @@ namespace Nancy.Bootstrapper
                 new TypeRegistration(typeof(IResponseNegotiator), this.ResponseNegotiator),
                 new TypeRegistration(typeof(INancyEnvironmentConfigurator), this.EnvironmentConfigurator),
                 new TypeRegistration(typeof(INancyEnvironmentFactory), this.EnvironmentFactory),
-                new TypeRegistration(typeof(ISerializerFactory), this.SerializerFactory)
+                new TypeRegistration(typeof(ISerializerFactory), this.SerializerFactory),
+                new TypeRegistration(typeof(IRuntimeEnvironmentInformation), this.RuntimeEnvironmentInformation)
             };
         }
 

--- a/src/Nancy/DefaultRuntimeEnvironmentInformation.cs
+++ b/src/Nancy/DefaultRuntimeEnvironmentInformation.cs
@@ -10,7 +10,7 @@ namespace Nancy
     /// </summary>
     public class DefaultRuntimeEnvironmentInformation : IRuntimeEnvironmentInformation
     {
-        private readonly Lazy<bool> isDebug = GetDebugMode();
+        private readonly Lazy<bool> isDebug = new Lazy<bool>(GetDebugMode);
 
         /// <summary>
         /// Gets a value indicating if the application is running in debug mode.
@@ -21,24 +21,21 @@ namespace Nancy
             get { return this.isDebug.Value; }
         }
 
-        private static Lazy<bool> GetDebugMode()
+        private static bool GetDebugMode()
         {
-            return new Lazy<bool>(() =>
+            try
             {
-                try
-                {
-                    var assembliesInDebug = AppDomainAssemblyTypeScanner
-                        .TypesOf<INancyModule>(ScanMode.ExcludeNancy)
-                        .Select(x => x.Assembly.GetCustomAttributes(typeof(DebuggableAttribute), true))
-                        .Where(x => x.Length != 0);
+                var assembliesInDebug = AppDomainAssemblyTypeScanner
+                    .TypesOf<INancyModule>(ScanMode.ExcludeNancy)
+                    .Select(x => x.Assembly.GetCustomAttributes(typeof(DebuggableAttribute), true))
+                    .Where(x => x.Length != 0);
 
-                    return assembliesInDebug.Any(d => ((DebuggableAttribute)d[0]).IsJITTrackingEnabled);
-                }
-                catch
-                {
-                    return false;
-                }
-            });
+                return assembliesInDebug.Any(d => ((DebuggableAttribute)d[0]).IsJITTrackingEnabled);
+            }
+            catch
+            {
+                return false;
+            }
         }
     }
 }

--- a/src/Nancy/DefaultRuntimeEnvironmentInformation.cs
+++ b/src/Nancy/DefaultRuntimeEnvironmentInformation.cs
@@ -1,5 +1,6 @@
 namespace Nancy
 {
+    using System;
     using System.Diagnostics;
     using System.Linq;
     using Nancy.Bootstrapper;
@@ -9,7 +10,7 @@ namespace Nancy
     /// </summary>
     public class DefaultRuntimeEnvironmentInformation : IRuntimeEnvironmentInformation
     {
-        private bool? isDebug;
+        private readonly Lazy<bool> isDebug = GetDebugMode();
 
         /// <summary>
         /// Gets a value indicating if the application is running in debug mode.
@@ -17,24 +18,27 @@ namespace Nancy
         /// <returns><see langword="true"/> if the application is running in debug mode, otherwise <see langword="false"/>.</returns>
         public virtual bool IsDebug
         {
-            get { return this.isDebug ?? (bool)(this.isDebug = GetDebugMode()); }
+            get { return this.isDebug.Value; }
         }
 
-        private static bool GetDebugMode()
+        private static Lazy<bool> GetDebugMode()
         {
-            try
+            return new Lazy<bool>(() =>
             {
-                var assembliesInDebug = AppDomainAssemblyTypeScanner
-                    .TypesOf<INancyModule>(ScanMode.ExcludeNancy)
-                    .Select(x => x.Assembly.GetCustomAttributes(typeof(DebuggableAttribute), true))
-                    .Where(x => x.Length != 0);
+                try
+                {
+                    var assembliesInDebug = AppDomainAssemblyTypeScanner
+                        .TypesOf<INancyModule>(ScanMode.ExcludeNancy)
+                        .Select(x => x.Assembly.GetCustomAttributes(typeof(DebuggableAttribute), true))
+                        .Where(x => x.Length != 0);
 
-                return assembliesInDebug.Any(d => ((DebuggableAttribute)d[0]).IsJITTrackingEnabled);
-            }
-            catch
-            {
-                return false;
-            }
+                    return assembliesInDebug.Any(d => ((DebuggableAttribute)d[0]).IsJITTrackingEnabled);
+                }
+                catch
+                {
+                    return false;
+                }
+            });
         }
     }
 }

--- a/src/Nancy/DefaultRuntimeEnvironmentInformation.cs
+++ b/src/Nancy/DefaultRuntimeEnvironmentInformation.cs
@@ -1,0 +1,40 @@
+namespace Nancy
+{
+    using System.Diagnostics;
+    using System.Linq;
+    using Nancy.Bootstrapper;
+
+    /// <summary>
+    /// Default implementation of the <see cref="IRuntimeEnvironmentInformation"/> interface.
+    /// </summary>
+    public class DefaultRuntimeEnvironmentInformation : IRuntimeEnvironmentInformation
+    {
+        private bool? isDebug;
+
+        /// <summary>
+        /// Gets a value indicating if the application is running in debug mode.
+        /// </summary>
+        /// <returns><see langword="true"/> if the application is running in debug mode, otherwise <see langword="false"/>.</returns>
+        public virtual bool IsDebug
+        {
+            get { return this.isDebug ?? (bool)(this.isDebug = GetDebugMode()); }
+        }
+
+        private static bool GetDebugMode()
+        {
+            try
+            {
+                var assembliesInDebug = AppDomainAssemblyTypeScanner
+                    .TypesOf<INancyModule>(ScanMode.ExcludeNancy)
+                    .Select(x => x.Assembly.GetCustomAttributes(typeof(DebuggableAttribute), true))
+                    .Where(x => x.Length != 0);
+
+                return assembliesInDebug.Any(d => ((DebuggableAttribute)d[0]).IsJITTrackingEnabled);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/Nancy/IRuntimeEnvironmentInformation.cs
+++ b/src/Nancy/IRuntimeEnvironmentInformation.cs
@@ -1,0 +1,14 @@
+namespace Nancy
+{
+    /// <summary>
+    /// Defines functionality for getting information about the runtime execution environment.
+    /// </summary>
+    public interface IRuntimeEnvironmentInformation
+    {
+        /// <summary>
+        /// Gets a value indicating if the application is running in debug mode.
+        /// </summary>
+        /// <returns><see langword="true"/> if the application is running in debug mode, otherwise <see langword="false"/>.</returns>
+        bool IsDebug { get; }
+    }
+}

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -157,6 +157,7 @@
     <Compile Include="Culture\ICultureService.cs" />
     <Compile Include="DefaultResponseFormatterFactory.cs" />
     <Compile Include="DefaultRootPathProvider.cs" />
+    <Compile Include="DefaultRuntimeEnvironmentInformation.cs" />
     <Compile Include="DefaultSerializerFactory.cs" />
     <Compile Include="DefaultStaticContentProvider.cs" />
     <Compile Include="Diagnostics\DefaultRequestTraceFactory.cs" />
@@ -192,6 +193,7 @@
     <Compile Include="Helpers\CacheHelpers.cs" />
     <Compile Include="Helpers\ExceptionExtensions.cs" />
     <Compile Include="IncludeInNancyAssemblyScanningAttribute.cs" />
+    <Compile Include="IRuntimeEnvironmentInformation.cs" />
     <Compile Include="ISerializerFactory.cs" />
     <Compile Include="IStaticContentProvider.cs" />
     <Compile Include="Json\Converters\TupleConverter.cs" />


### PR DESCRIPTION
The idea for `IRuntimeEnvironmentInformation` is to give us a place to stick information about the runtime environment. Currently it contains support for knowing if the application is being run in debug or not. 

This is the first step for splitting up the `StaticConfiguration` class. It will be rewritten once we change over to instance based scanning.

**PS** This does not remove the same functionality in `StaticConfiguration` - that will happen one at a time when `StaticConfiguration` is split up, but we need this in place first.