### PR TITLE
Reset negotiation context on error to avoid invalid cast exception

### DIFF
--- a/src/Nancy.Tests/Unit/ErrorHandling/DefaultStatusCodeHandlerFixture.cs
+++ b/src/Nancy.Tests/Unit/ErrorHandling/DefaultStatusCodeHandlerFixture.cs
@@ -189,5 +189,20 @@ namespace Nancy.Tests.Unit.ErrorHandling
             // Then
             Assert.Equal("text/html", context.Response.ContentType);
         }
+
+        [Fact]
+        public void Should_reset_negotiation_context()
+        {
+            // Given
+            var context = new NancyContext();
+            var negotiationContext = new NegotiationContext { ViewName = "Index" };
+            context.NegotiationContext = negotiationContext;
+
+            // When
+            this.statusCodeHandler.Handle(HttpStatusCode.InternalServerError, context);
+
+            // Then
+            Assert.Equal(context.NegotiationContext.ViewName, null);
+        }
     }
 }

--- a/src/Nancy/ErrorHandling/DefaultStatusCodeHandler.cs
+++ b/src/Nancy/ErrorHandling/DefaultStatusCodeHandler.cs
@@ -71,6 +71,10 @@ namespace Nancy.ErrorHandling
                 return;
             }
 
+            // Reset negotiation context to avoid any downstream cast exceptions 
+            // from swapping a view model with a `DefaultStatusCodeHandlerResult`
+            context.NegotiationContext = new NegotiationContext();
+
             var result = new DefaultStatusCodeHandlerResult(statusCode, this.errorMessages[statusCode], StaticConfiguration.DisableErrorTraces ? DisableErrorTracesTrueMessage : context.GetExceptionDetails());
             try
             {


### PR DESCRIPTION
This commit resolves issue https://github.com/NancyFx/Nancy/issues/2122. Whenever an error occurs and a specific view is requested through `Negotiate.WithView`, an invalid cast exception can occur if the view inherits `NancyRazorViewBase<T>`. The default error handler attempts to negotiate content using the existing negotiation context. You can reproduce this issue in https://github.com/jonathanfoster/nancy-demo-errorhandlerinvalidcastexception.