### PR TITLE
Keep existing reason phrase in DefaultStatusCodeHandler

### DIFF
--- a/src/Nancy.Tests.Functional/Tests/ContentNegotiationFixture.cs
+++ b/src/Nancy.Tests.Functional/Tests/ContentNegotiationFixture.cs
@@ -159,7 +159,7 @@ namespace Nancy.Tests.Functional.Tests
 
                     var negotiator =
                         new Negotiator(context);
-                    negotiator.WithReasonPhrase("The test is passing!");
+                    negotiator.WithReasonPhrase("The test is passing!").WithStatusCode(404);
 
                     return negotiator;
                 });
@@ -167,13 +167,13 @@ namespace Nancy.Tests.Functional.Tests
 
             var brower = new Browser(with =>
             {
+                with.StatusCodeHandler<DefaultStatusCodeHandler>();
                 with.ResponseProcessor<TestProcessor>();
-
                 with.Module(module);
             });
 
             // When
-            var response = brower.Get("/customPhrase");
+            var response = brower.Get("/customPhrase", with => with.Accept("application/json"));
 
             // Then
             Assert.Equal("The test is passing!", response.ReasonPhrase);

--- a/src/Nancy/ErrorHandling/DefaultStatusCodeHandler.cs
+++ b/src/Nancy/ErrorHandling/DefaultStatusCodeHandler.cs
@@ -71,7 +71,14 @@ namespace Nancy.ErrorHandling
                 return;
             }
 
-            // Reset negotiation context to avoid any downstream cast exceptions 
+            Response existingResponse = null;
+
+            if (context.Response != null)
+            {
+                existingResponse = context.Response;
+            }
+
+            // Reset negotiation context to avoid any downstream cast exceptions
             // from swapping a view model with a `DefaultStatusCodeHandlerResult`
             context.NegotiationContext = new NegotiationContext();
 
@@ -80,6 +87,11 @@ namespace Nancy.ErrorHandling
             {
                 context.Response = this.responseNegotiator.NegotiateResponse(result, context);
                 context.Response.StatusCode = statusCode;
+
+                if (existingResponse != null)
+                {
+                    context.Response.ReasonPhrase = existingResponse.ReasonPhrase;
+                }
                 return;
             }
             catch (ViewNotFoundException)


### PR DESCRIPTION
Currently the `DefaultStatusCodeHandler` discards the `ReasonPhrase` property of a potential existing response.

Fixes #2148.