### PR TITLE
Change disposal of CancellationTokenSource to after task is complete

### DIFF
--- a/src/Nancy.Tests/Unit/NancyEngineFixture.cs
+++ b/src/Nancy.Tests/Unit/NancyEngineFixture.cs
@@ -676,6 +676,48 @@ namespace Nancy.Tests.Unit
             result.Items["ERROR_EXCEPTION"].ShouldBeOfType<RequestExecutionException>();
         }
 
+	    [Fact]
+	    public void Should_Not_Dispose_Cancellation_Token_Before_Task_is_complete()
+	    {
+			// Given
+			var resolvedRoute = new ResolveResult(
+			   new FakeRoute(),
+			   DynamicDictionary.Empty,
+			   null,
+			   null,
+			   null);
+
+			A.CallTo(() => resolver.Resolve(A<NancyContext>.Ignored)).Returns(resolvedRoute);
+
+			CancellationToken? cancellationToken = null;
+			
+			A.CallTo(() => this.requestDispatcher.Dispatch(context, A<CancellationToken>._))
+			    .ReturnsLazily<Task<Response>, NancyContext, CancellationToken>((x, y) => Task.Run(async () =>
+			    {
+				    for (int i = 0; i < 2; i++)
+					    await Task.Delay(1, y);
+
+				    cancellationToken = y;
+
+				    return response;
+			    }));
+
+
+			var pipelines = new Pipelines { OnError = null };
+			engine.RequestPipelinesFactory = (ctx) => pipelines;
+
+			var request = new Request("GET", "/", "http");
+
+			// When
+			var result = this.engine.HandleRequest(request);
+
+			// Then
+			result.Items.Keys.Contains("ERROR_EXCEPTION").ShouldBeFalse();
+
+		    var exception = Record.Exception(() => !cancellationToken.HasValue || cancellationToken.Value.WaitHandle != null);
+			exception.ShouldBeOfType<ObjectDisposedException>();
+	    }
+
         [Fact]
         public void Should_persist_original_exception_in_requestexecutionexception_when_pipeline_is_null()
         {

--- a/src/Nancy/NancyEngine.cs
+++ b/src/Nancy/NancyEngine.cs
@@ -101,61 +101,63 @@
         /// <returns>The task object representing the asynchronous operation.</returns>
         public Task<NancyContext> HandleRequest(Request request, Func<NancyContext, NancyContext> preRequest, CancellationToken cancellationToken)
         {
-            using (var cts = CancellationTokenSource.CreateLinkedTokenSource(this.engineDisposedCts.Token, cancellationToken))
+	        var cts = CancellationTokenSource.CreateLinkedTokenSource(this.engineDisposedCts.Token, cancellationToken);
+            cts.Token.ThrowIfCancellationRequested();
+
+            var tcs = new TaskCompletionSource<NancyContext>();
+
+            if (request == null)
             {
-                cts.Token.ThrowIfCancellationRequested();
+                throw new ArgumentNullException("request", "The request parameter cannot be null.");
+            }
 
-                var tcs = new TaskCompletionSource<NancyContext>();
+            var context = this.contextFactory.Create(request);
 
-                if (request == null)
-                {
-                    throw new ArgumentNullException("request", "The request parameter cannot be null.");
-                }
+            if (preRequest != null)
+            {
+                context = preRequest(context);
+            }
 
-                var context = this.contextFactory.Create(request);
-
-                if (preRequest != null)
-                {
-                    context = preRequest(context);
-                }
-
-                var staticContentResponse = this.staticContentProvider.GetContent(context);
-                if (staticContentResponse != null)
-                {
-                    context.Response = staticContentResponse;
-                    tcs.SetResult(context);
-                    return tcs.Task;
-                }
-
-                var pipelines = this.RequestPipelinesFactory.Invoke(context);
-
-                var lifeCycleTask = this.InvokeRequestLifeCycle(context, cts.Token, pipelines);
-
-                lifeCycleTask.WhenCompleted(
-                    completeTask =>
-                    {
-                        try
-                        {
-                            this.CheckStatusCodeHandler(completeTask.Result);
-
-                            this.SaveTraceInformation(completeTask.Result);
-                        }
-                        catch (Exception ex)
-                        {
-                            tcs.SetException(ex);
-                            return;
-                        }
-
-                        tcs.SetResult(completeTask.Result);
-                    },
-                    errorTask =>
-                    {
-                        tcs.SetException(errorTask.Exception);
-                    },
-                    true);
-
+            var staticContentResponse = this.staticContentProvider.GetContent(context);
+            if (staticContentResponse != null)
+            {
+                context.Response = staticContentResponse;
+                tcs.SetResult(context);
                 return tcs.Task;
             }
+
+            var pipelines = this.RequestPipelinesFactory.Invoke(context);
+
+            var lifeCycleTask = this.InvokeRequestLifeCycle(context, cts.Token, pipelines);
+
+            lifeCycleTask.WhenCompleted(
+                completeTask =>
+                {
+	                try
+	                {
+		                this.CheckStatusCodeHandler(completeTask.Result);
+
+		                this.SaveTraceInformation(completeTask.Result);
+	                }
+	                catch (Exception ex)
+	                {
+		                tcs.SetException(ex);
+		                return;
+	                }
+	                finally
+	                {
+		                cts.Dispose();
+	                }
+
+                    tcs.SetResult(completeTask.Result);
+                },
+                errorTask =>
+                {
+		            tcs.SetException(errorTask.Exception);
+                },
+                true);
+
+            return tcs.Task;
         }
 
         /// <summary>


### PR DESCRIPTION
The previous implementation was allowing the disposal of the `CancellationTokenSource` to occur before the `lifeCycleTask` was actually complete.  I moved the disposal to the `completeTask` continuation so it would only be disposed when the task was complete.

Also included is a test that can detect this in the future and also verifies that the token is disposed after the call.

I also ran through the memory leak test in pull request #2128 and (assuming I had my CLI commands correct for dotMemoryUnit) it passed.