### PR TITLE
Fixes #2157 with RequestStream.AsString extension modifying stream's position

### DIFF
--- a/src/Nancy.Tests/Nancy.Tests.csproj
+++ b/src/Nancy.Tests/Nancy.Tests.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Unit\Diagnostics\DiagnosticsHookFixture.cs" />
     <Compile Include="Unit\Diagnostics\InteractiveDiagnosticsFixture.cs" />
     <Compile Include="Unit\ErrorHandling\DefaultStatusCodeHandlerFixture.cs" />
+    <Compile Include="Unit\Extensions\RequestStreamExtensionsFixture.cs" />
     <Compile Include="Unit\Extensions\TypeExtensionsFixture.cs" />
     <Compile Include="Unit\FormatterExtensionsFixture.cs" />
     <Compile Include="Unit\Helpers\HttpUtilityFixture.cs" />

--- a/src/Nancy.Tests/Unit/Extensions/RequestStreamExtensionsFixture.cs
+++ b/src/Nancy.Tests/Unit/Extensions/RequestStreamExtensionsFixture.cs
@@ -1,0 +1,35 @@
+﻿namespace Nancy.Tests.Unit.Extensions
+{
+    using System.Collections.Generic;
+
+    using Nancy.Extensions;
+    using Nancy.Tests.Fakes;
+
+    using Xunit;
+
+    public class RequestStreamExtensionsFixture
+    {
+        [Fact]
+        public void AsString_should_always_start_from_position_0_and_reset_it_afterwards()
+        {
+            // Given 
+            var innerStream = new System.IO.MemoryStream();
+            var streamWriter = new System.IO.StreamWriter(innerStream, System.Text.Encoding.UTF8);
+
+            streamWriter.Write("fake request body");
+            streamWriter.Flush();
+
+            var requestStream = Nancy.IO.RequestStream.FromStream(innerStream);
+
+            long initialPosition = 3;
+            requestStream.Position = initialPosition;
+
+            // When
+            string result = requestStream.AsString(System.Text.Encoding.UTF8);
+
+            // Then
+            Assert.Equal("fake request body", result);
+            Assert.Equal(initialPosition, requestStream.Position);
+        }
+    }
+}

--- a/src/Nancy/Extensions/RequestStreamExtensions.cs
+++ b/src/Nancy/Extensions/RequestStreamExtensions.cs
@@ -20,7 +20,15 @@
         {
             using (var reader = new StreamReader(stream, encoding ?? Encoding.UTF8))
             {
-                return reader.ReadToEnd();
+                long initialPosition = stream.Position;
+
+                stream.Position = 0;
+
+                string request = reader.ReadToEnd();
+
+                stream.Position = initialPosition;
+
+                return request;
             }
         }
     }


### PR DESCRIPTION
Changes RequestStream.AsString extension method to not modify the stream's position.

Fixes #2157 