### PR TITLE
SwitchoverStream does not work when %TEMP% is full

### DIFF
--- a/src/Nancy/IO/RequestStream.cs
+++ b/src/Nancy/IO/RequestStream.cs
@@ -358,9 +358,21 @@
 
         private static FileStream CreateTemporaryFileStream()
         {
-            var filePath = Path.GetTempFileName();
+            // we could use Path.GetTempFilePath() but this is problematic on Windows and more so on Mono
+            // symptoms will show when this method has been called > 65k times
+            // see docs: https://msdn.microsoft.com/en-us/library/system.io.path.gettempfilename(v=vs.110).aspx
+            // comments on Win32 implementation: https://msdn.microsoft.com/en-us/library/windows/desktop/aa364991(v=vs.85).aspx
+            // mono implementation: https://github.com/mono/mono/blob/master/mcs/class/corlib/System.IO/Path.cs#L490
 
-            return new FileStream(filePath, FileMode.Create, FileAccess.ReadWrite, FileShare.None, 8192, StaticConfiguration.AllowFileStreamUploadAsync);
+            var filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".tmp");
+
+            return new FileStream(
+                filePath,
+                FileMode.Create,
+                FileAccess.ReadWrite,
+                FileShare.None,
+                8192,
+                StaticConfiguration.AllowFileStreamUploadAsync);         
         }
 
         private Stream CreateDefaultMemoryStream(long expectedLength)


### PR DESCRIPTION
I'm not sure if this is of much value as I suspect we're in the minority of users to run into this issue - feel free to ignore and close.

The award for most asinine error message surely goes to ```Path.GetTempFileName()``` throwing "The file exists." when %TEMP% has more than 65k items in it.

Catching the exception and wrapping it in one with a useful error message.