### PR TITLE
Added Status Code: HTTP 451 Unavailable For Legal Reasons

### DIFF
--- a/src/Nancy/HttpStatusCode.cs
+++ b/src/Nancy/HttpStatusCode.cs
@@ -211,6 +211,10 @@ namespace Nancy
         /// </summary>
         BlockedByWindowsParentalControls = 450,
         /// <summary>
+        /// 451 UnavailableForLegalReasons
+        /// </summary>
+        UnavailableForLegalReasons = 451,
+        /// <summary>
         /// 499 ClientClosedRequest
         /// </summary>
         ClientClosedRequest = 499,


### PR DESCRIPTION
This status code indicates that the server is denying access to the resource as a consequence of a legal demand.

More Details: https://www.mnot.net/blog/2015/12/18/451