### PR TITLE
Started migrating routing configuration to the new configuration API

### DIFF
--- a/src/Nancy.Testing/StaticConfigurationContext.cs
+++ b/src/Nancy.Testing/StaticConfigurationContext.cs
@@ -19,8 +19,6 @@ namespace Nancy.Testing
         {
             this.existingConfiguration.CaseSensitive = StaticConfiguration.CaseSensitive;
             this.existingConfiguration.DisableErrorTraces = StaticConfiguration.DisableErrorTraces;
-            this.existingConfiguration.DisableMethodNotAllowedResponses = StaticConfiguration.DisableMethodNotAllowedResponses;
-            this.existingConfiguration.EnableHeadRouting = StaticConfiguration.EnableHeadRouting;
             this.existingConfiguration.EnableRequestTracing = StaticConfiguration.EnableRequestTracing;
             this.existingConfiguration.RequestQueryFormMultipartLimit = StaticConfiguration.RequestQueryFormMultipartLimit;
 
@@ -44,8 +42,6 @@ namespace Nancy.Testing
         {
             StaticConfiguration.CaseSensitive = values.CaseSensitive;
             StaticConfiguration.DisableErrorTraces = values.DisableErrorTraces;
-            StaticConfiguration.DisableMethodNotAllowedResponses = values.DisableMethodNotAllowedResponses;
-            StaticConfiguration.EnableHeadRouting = values.EnableHeadRouting;
             StaticConfiguration.EnableRequestTracing = values.EnableRequestTracing;
             StaticConfiguration.RequestQueryFormMultipartLimit = values.RequestQueryFormMultipartLimit;
         }
@@ -58,10 +54,6 @@ namespace Nancy.Testing
             public bool CaseSensitive { get; set; }
 
             public bool DisableErrorTraces { get; set; }
-
-            public bool DisableMethodNotAllowedResponses { get; set; }
-
-            public bool EnableHeadRouting { get; set; }
 
             public bool EnableRequestTracing { get; set; }
 

--- a/src/Nancy.Tests.Functional/Tests/BasicRouteInvocationsFixture.cs
+++ b/src/Nancy.Tests.Functional/Tests/BasicRouteInvocationsFixture.cs
@@ -184,8 +184,14 @@
         public async Task Should_use_head_response_values_for_basic_head_request()
         {
             // Given
-            StaticConfiguration.EnableHeadRouting = true;
-            var browser = new Browser(with => with.Module<BasicRouteInvocationsModuleWithHead>());
+            var browser = new Browser(with =>
+            {
+                with.Module<BasicRouteInvocationsModuleWithHead>();
+                with.Configure(env =>
+                {
+                    env.Routing(explicitHeadRouting: true);
+                });
+            });
 
             // When
             var response = await browser.Head("/");
@@ -195,8 +201,6 @@
             Assert.Equal("text/html", response.ContentType);
             Assert.Equal(string.Empty, response.Body.AsString());
             Assert.Equal("HEAD!", response.ReasonPhrase);
-
-            StaticConfiguration.EnableHeadRouting = false;
         }
     }
 }

--- a/src/Nancy.Tests/Unit/Routing/DefaultRouteResolverFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/DefaultRouteResolverFixture.cs
@@ -358,8 +358,14 @@
         public async Task Should_return_405_if_requested_method_is_not_permitted_but_others_are_available_and_not_disabled()
         {
             // Given
-            StaticConfiguration.DisableMethodNotAllowedResponses = false;
-            var browser = new Browser(with => with.Module<MethodNotAllowedModule>());
+            var browser = new Browser(with =>
+            {
+                with.Module<MethodNotAllowedModule>();
+                with.Configure(env =>
+                {
+                    env.Routing(disableMethodNotAllowedResponses: false);
+                });
+            });
 
             // When
             var result = await browser.Get("/");
@@ -372,8 +378,14 @@
         public async Task Should_not_return_405_if_requested_method_is_not_permitted_but_others_are_available_and_disabled()
         {
             // Given
-            StaticConfiguration.DisableMethodNotAllowedResponses = true;
-            var browser = new Browser(with => with.Module<MethodNotAllowedModule>());
+            var browser = new Browser(with =>
+            {
+                with.Module<MethodNotAllowedModule>();
+                with.Configure(env =>
+                {
+                    env.Routing(disableMethodNotAllowedResponses: true);
+                });
+            });
 
             // When
             var result = await browser.Get("/");
@@ -386,8 +398,14 @@
         public async Task Should_set_allowed_method_on_response_when_returning_405()
         {
             // Given
-            StaticConfiguration.DisableMethodNotAllowedResponses = false;
-            var browser = new Browser(with => with.Module<MethodNotAllowedModule>());
+            var browser = new Browser(with =>
+            {
+                with.Module<MethodNotAllowedModule>();
+                with.Configure(env =>
+                {
+                    env.Routing(disableMethodNotAllowedResponses: false);
+                });
+            });
 
             // When
             var result = await browser.Get("/");

--- a/src/Nancy/DefaultNancyContextFactory.cs
+++ b/src/Nancy/DefaultNancyContextFactory.cs
@@ -13,6 +13,7 @@ namespace Nancy
         private readonly ICultureService cultureService;
         private readonly IRequestTraceFactory requestTraceFactory;
         private readonly ITextResource textResource;
+        private readonly INancyEnvironment environment;
 
         /// <summary>
         /// Creates a new instance of the <see cref="DefaultNancyContextFactory"/> class.
@@ -20,11 +21,13 @@ namespace Nancy
         /// <param name="cultureService">An <see cref="ICultureService"/> instance.</param>
         /// <param name="requestTraceFactory">An <see cref="IRequestTraceFactory"/> instance.</param>
         /// <param name="textResource">An <see cref="ITextResource"/> instance.</param>
-        public DefaultNancyContextFactory(ICultureService cultureService, IRequestTraceFactory requestTraceFactory, ITextResource textResource)
+        /// <param name="environment">An <see cref="INancyEnvironment"/> instance.</param>
+        public DefaultNancyContextFactory(ICultureService cultureService, IRequestTraceFactory requestTraceFactory, ITextResource textResource, INancyEnvironment environment)
         {
             this.cultureService = cultureService;
             this.requestTraceFactory = requestTraceFactory;
             this.textResource = textResource;
+            this.environment = environment;
         }
 
         /// <summary>
@@ -40,6 +43,7 @@ namespace Nancy
             context.Request = request;
             context.Culture = this.cultureService.DetermineCurrentCulture(context);
             context.Text = new TextResourceFinder(this.textResource, context);
+            context.Environment = this.environment;
 
             // Move this to DefaultRequestTrace.
             context.Trace.TraceLog.WriteLog(s => s.AppendLine("New Request Started"));

--- a/src/Nancy/DefaultRouteConfigurationProvider.cs
+++ b/src/Nancy/DefaultRouteConfigurationProvider.cs
@@ -1,0 +1,19 @@
+namespace Nancy
+{
+    using Nancy.Configuration;
+
+    /// <summary>
+    /// Provides the default configuration for <see cref="RouteConfiguration"/>.
+    /// </summary>
+    public class DefaultRouteConfigurationProvider : NancyDefaultConfigurationProvider<RouteConfiguration>
+    {
+        /// <summary>
+        /// Gets the default configuration instance to register in the <see cref="INancyEnvironment"/>.
+        /// </summary>
+        /// <remarks>Will return <see cref="ViewConfiguration.Default"/>.</remarks>
+        public override RouteConfiguration GetDefaultConfiguration()
+        {
+            return RouteConfiguration.Default;
+        }
+    }
+}

--- a/src/Nancy/Diagnostics/DiagnosticsHook.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsHook.cs
@@ -44,7 +44,7 @@ namespace Nancy.Diagnostics
 
             var diagnosticsRouteCache = new RouteCache(
                 diagnosticsModuleCatalog,
-                new DefaultNancyContextFactory(cultureService, requestTraceFactory, textResource),
+                new DefaultNancyContextFactory(cultureService, requestTraceFactory, textResource, diagnosticsEnvironment),
                 new DefaultRouteSegmentExtractor(),
                 new DefaultRouteDescriptionProvider(),
                 cultureService,

--- a/src/Nancy/Diagnostics/DiagnosticsHook.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsHook.cs
@@ -54,7 +54,8 @@ namespace Nancy.Diagnostics
                 diagnosticsModuleCatalog,
                 new DiagnosticsModuleBuilder(rootPathProvider, modelBinderLocator, diagnosticsEnvironment, environment),
                 diagnosticsRouteCache,
-                new RouteResolverTrie(new TrieNodeFactory(routeSegmentConstraints)));
+                new RouteResolverTrie(new TrieNodeFactory(routeSegmentConstraints)),
+                diagnosticsEnvironment);
 
             var serializer = new DefaultObjectSerializer();
 

--- a/src/Nancy/Diagnostics/DiagnosticsHook.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsHook.cs
@@ -44,7 +44,7 @@ namespace Nancy.Diagnostics
 
             var diagnosticsRouteCache = new RouteCache(
                 diagnosticsModuleCatalog,
-                new DefaultNancyContextFactory(cultureService, requestTraceFactory, textResource, diagnosticsEnvironment),
+                new DefaultNancyContextFactory(cultureService, requestTraceFactory, textResource, environment),
                 new DefaultRouteSegmentExtractor(),
                 new DefaultRouteDescriptionProvider(),
                 cultureService,
@@ -55,7 +55,7 @@ namespace Nancy.Diagnostics
                 new DiagnosticsModuleBuilder(rootPathProvider, modelBinderLocator, diagnosticsEnvironment, environment),
                 diagnosticsRouteCache,
                 new RouteResolverTrie(new TrieNodeFactory(routeSegmentConstraints)),
-                diagnosticsEnvironment);
+                environment);
 
             var serializer = new DefaultObjectSerializer();
 

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -157,6 +157,7 @@
     <Compile Include="Culture\ICultureService.cs" />
     <Compile Include="DefaultResponseFormatterFactory.cs" />
     <Compile Include="DefaultRootPathProvider.cs" />
+    <Compile Include="DefaultRouteConfigurationProvider.cs" />
     <Compile Include="DefaultRuntimeEnvironmentInformation.cs" />
     <Compile Include="DefaultSerializerFactory.cs" />
     <Compile Include="DefaultStaticContentProvider.cs" />
@@ -259,6 +260,8 @@
     <Compile Include="Responses\DefaultJsonSerializer.cs" />
     <Compile Include="Responses\DefaultXmlSerializer.cs" />
     <Compile Include="Responses\TextResponse.cs" />
+    <Compile Include="RouteConfiguration.cs" />
+    <Compile Include="RouteConfigurationExtensions.cs" />
     <Compile Include="Routing\Constraints\AlphaRouteSegmentConstraint.cs" />
     <Compile Include="Routing\Constraints\BoolRouteSegmentConstraint.cs" />
     <Compile Include="Routing\Constraints\CustomDateTimeRouteSegmentConstraint.cs" />

--- a/src/Nancy/NancyContext.cs
+++ b/src/Nancy/NancyContext.cs
@@ -6,7 +6,7 @@ namespace Nancy
     using System.Globalization;
     using System.Linq;
     using System.Security.Claims;
-
+    using Nancy.Configuration;
     using Nancy.Diagnostics;
     using Nancy.Responses.Negotiation;
     using Nancy.Routing;
@@ -115,6 +115,12 @@ namespace Nancy
         /// Gets or sets the dynamic object used to locate text resources.
         /// </summary>
         public dynamic Text { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="INancyEnvironment"/>.
+        /// </summary>
+        /// <value>An <see cref="INancyEnvironment"/> instance.</value>
+        public INancyEnvironment Environment { get; set; }
 
         /// <summary>
         /// Disposes any disposable items in the <see cref="Items"/> dictionary.

--- a/src/Nancy/NancyModule.cs
+++ b/src/Nancy/NancyModule.cs
@@ -86,7 +86,7 @@ namespace Nancy
             {
                 if (!StaticConfiguration.EnableHeadRouting)
                 {
-                    throw new InvalidOperationException("Explicit HEAD routing is disabled. Set StaticConfiguration.EnableHeadRouting to enable.");
+                    throw new InvalidOperationException("Explicit HEAD routing is disabled. Set RouteConfiguration.ExplicitHeadRouting to enable.");
                 }
 
                 return new RouteBuilder("HEAD", this);

--- a/src/Nancy/NancyModule.cs
+++ b/src/Nancy/NancyModule.cs
@@ -5,7 +5,7 @@ namespace Nancy
     using System.ComponentModel;
     using System.Threading;
     using System.Threading.Tasks;
-
+    using Nancy.Configuration;
     using Nancy.ModelBinding;
     using Nancy.Responses.Negotiation;
     using Nancy.Routing;
@@ -84,7 +84,7 @@ namespace Nancy
         {
             get
             {
-                if (!StaticConfiguration.EnableHeadRouting)
+                if (!this.Context.Environment.GetValue<RouteConfiguration>().ExplicitHeadRouting)
                 {
                     throw new InvalidOperationException("Explicit HEAD routing is disabled. Set RouteConfiguration.ExplicitHeadRouting to enable.");
                 }

--- a/src/Nancy/NancyModule.cs
+++ b/src/Nancy/NancyModule.cs
@@ -82,15 +82,7 @@ namespace Nancy
         /// <value>A <see cref="RouteBuilder"/> instance.</value>
         public RouteBuilder Head
         {
-            get
-            {
-                if (!this.Context.Environment.GetValue<RouteConfiguration>().ExplicitHeadRouting)
-                {
-                    throw new InvalidOperationException("Explicit HEAD routing is disabled. Set RouteConfiguration.ExplicitHeadRouting to enable.");
-                }
-
-                return new RouteBuilder("HEAD", this);
-            }
+            get { return new RouteBuilder("HEAD", this); }
         }
 
         /// <summary>

--- a/src/Nancy/RouteConfiguration.cs
+++ b/src/Nancy/RouteConfiguration.cs
@@ -1,0 +1,38 @@
+namespace Nancy
+{
+    /// <summary>
+    /// Configuration for the default routing.
+    /// </summary>
+    public class RouteConfiguration
+    {
+        /// <summary>
+        /// A default instance of the <see cref="ViewConfiguration"/> class.
+        /// </summary>
+        public static readonly RouteConfiguration Default = new RouteConfiguration(
+            disableMethodNotAllowedResponses: false,
+            explicitHeadRouting: false);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="disableMethodNotAllowedResponses"></param>
+        /// <param name="explicitHeadRouting"></param>
+        public RouteConfiguration(bool disableMethodNotAllowedResponses = false, bool explicitHeadRouting = false)
+        {
+            this.DisableMethodNotAllowedResponses = disableMethodNotAllowedResponses;
+            this.ExplicitHeadRouting = explicitHeadRouting;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether or not to respond with 405 responses.
+        /// </summary>
+        /// <value><see langword="true"/>If 405 responses are allowed, otherwise <see langword="false"/>.</value>
+        public bool DisableMethodNotAllowedResponses { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether or not to route HEAD requests explicitly.
+        /// </summary>
+        /// <value><see langword="true"/>If explicit HEAD route requests are allowed, otherwise <see langword="false"/>.</value>
+        public bool ExplicitHeadRouting { get; private set; }
+    }
+}

--- a/src/Nancy/RouteConfiguration.cs
+++ b/src/Nancy/RouteConfiguration.cs
@@ -13,10 +13,10 @@ namespace Nancy
             explicitHeadRouting: false);
 
         /// <summary>
-        ///
+        /// Initializes a new instance of the <see cref="RouteConfiguration"/> class.
         /// </summary>
-        /// <param name="disableMethodNotAllowedResponses"></param>
-        /// <param name="explicitHeadRouting"></param>
+        /// <param name="disableMethodNotAllowedResponses">Determins is 405 responses are allowed.</param>
+        /// <param name="explicitHeadRouting">Enabled support for explicit HEAD route declarations.</param>
         public RouteConfiguration(bool disableMethodNotAllowedResponses = false, bool explicitHeadRouting = false)
         {
             this.DisableMethodNotAllowedResponses = disableMethodNotAllowedResponses;

--- a/src/Nancy/RouteConfigurationExtensions.cs
+++ b/src/Nancy/RouteConfigurationExtensions.cs
@@ -1,0 +1,23 @@
+namespace Nancy
+{
+    using Nancy.Configuration;
+
+    /// <summary>
+    /// Contains <see cref="RouteConfiguration"/> configuration extensions for <see cref="INancyEnvironment"/>.
+    /// </summary>
+    public static class RouteConfigurationExtensions
+    {
+        /// <summary>
+        /// Configures <see cref="RouteConfiguration"/>.
+        /// </summary>
+        /// <param name="environment"><see cref="INancyEnvironment"/> that should be configured.</param>
+        /// <param name="disableMethodNotAllowedResponses"><see langword="true"/>If 405 responses are allowed, otherwise <see langword="false"/>.</param>
+        /// <param name="explicitHeadRouting"><see langword="true"/>If explicit HEAD route requests are allowed, otherwise <see langword="false"/>.</param>
+        public static void Routing(this INancyEnvironment environment, bool? disableMethodNotAllowedResponses = false, bool? explicitHeadRouting = false)
+        {
+            environment.AddValue(new RouteConfiguration(
+                disableMethodNotAllowedResponses: disableMethodNotAllowedResponses ?? RouteConfiguration.Default.DisableMethodNotAllowedResponses,
+                explicitHeadRouting: explicitHeadRouting ?? RouteConfiguration.Default.ExplicitHeadRouting));
+        }
+    }
+}

--- a/src/Nancy/Routing/DefaultRouteResolver.cs
+++ b/src/Nancy/Routing/DefaultRouteResolver.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using Helpers;
+    using Nancy.Configuration;
     using Trie;
 
     /// <summary>
@@ -15,22 +16,25 @@
         private readonly INancyModuleBuilder moduleBuilder;
         private readonly IRouteCache routeCache;
         private readonly IRouteResolverTrie trie;
+        private readonly RouteConfiguration configuration;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultRouteResolver"/> class, using
         /// the provided <paramref name="catalog"/>, <paramref name="moduleBuilder"/>,
         /// <paramref name="routeCache"/> and <paramref name="trie"/>.
         /// </summary>
-        /// <param name="catalog">A <see cref="INancyModuleCatalog"/> instance.</param>
-        /// <param name="moduleBuilder">A <see cref="INancyModuleBuilder"/> instance.</param>
-        /// <param name="routeCache">A <see cref="IRouteCache"/> instance.</param>
-        /// <param name="trie">A <see cref="IRouteResolverTrie"/> instance.</param>
-        public DefaultRouteResolver(INancyModuleCatalog catalog, INancyModuleBuilder moduleBuilder, IRouteCache routeCache, IRouteResolverTrie trie)
+        /// <param name="catalog">An <see cref="INancyModuleCatalog"/> instance.</param>
+        /// <param name="moduleBuilder">An <see cref="INancyModuleBuilder"/> instance.</param>
+        /// <param name="routeCache">An <see cref="IRouteCache"/> instance.</param>
+        /// <param name="trie">An <see cref="IRouteResolverTrie"/> instance.</param>
+        /// <param name="environment">An <see cref="INancyEnvironment"/> instance.</param>
+        public DefaultRouteResolver(INancyModuleCatalog catalog, INancyModuleBuilder moduleBuilder, IRouteCache routeCache, IRouteResolverTrie trie, INancyEnvironment environment)
         {
             this.catalog = catalog;
             this.moduleBuilder = moduleBuilder;
             this.routeCache = routeCache;
             this.trie = trie;
+            this.configuration = environment.GetValue<RouteConfiguration>();
 
             this.BuildTrie();
         }
@@ -57,7 +61,7 @@
                     return BuildOptionsResult(allowedMethods, context);
                 }
 
-                return IsMethodNotAllowed(allowedMethods) ?
+                return this.IsMethodNotAllowed(allowedMethods) ?
                     BuildMethodNotAllowedResult(context, allowedMethods) :
                     GetNotFoundResult(context);
             }
@@ -85,9 +89,9 @@
             return new ResolveResult(route, new DynamicDictionary(), null, null, null);
         }
 
-        private static bool IsMethodNotAllowed(IEnumerable<string> allowedMethods)
+        private bool IsMethodNotAllowed(IEnumerable<string> allowedMethods)
         {
-            return allowedMethods.Any() && !StaticConfiguration.DisableMethodNotAllowedResponses;
+            return allowedMethods.Any() && !this.configuration.DisableMethodNotAllowedResponses;
         }
 
         private static bool IsOptionsRequest(NancyContext context)
@@ -155,12 +159,12 @@
             };
         }
 
-        private static string GetMethod(NancyContext context)
+        private string GetMethod(NancyContext context)
         {
             var requestedMethod =
                 context.Request.Method;
 
-            if (!StaticConfiguration.EnableHeadRouting)
+            if (!this.configuration.ExplicitHeadRouting)
             {
                 return requestedMethod.Equals("HEAD", StringComparison.OrdinalIgnoreCase) ?
                     "GET" :

--- a/src/Nancy/StaticConfiguration.cs
+++ b/src/Nancy/StaticConfiguration.cs
@@ -38,22 +38,10 @@ namespace Nancy
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether or not to respond with 405 responses
-        /// </summary>
-        [Description("Disables 405 responses from being sent to the client.")]
-        public static bool DisableMethodNotAllowedResponses { get; set; }
-
-        /// <summary>
         /// Gets or sets a value indicating whether or not to enable case sensitivity in query, parameters (DynamicDictionary) and model binding. Enable this to conform with RFC3986.
         /// </summary>
         [Description("Enable case sensitivity in query, parameters (DynamicDictionary) and model binding. Enable this to conform with RFC3986.")]
         public static bool CaseSensitive { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether or not to route HEAD requests explicitly.
-        /// </summary>
-        [Description("Enables explicit HEAD routing and disables the usage of GET routes for HEAD requests.")]
-        public static bool EnableHeadRouting { get; set; }
 
         /// <summary>
         /// Gets a value indicating whether we are running in debug mode or not.

--- a/src/Nancy/ViewConfiguration.cs
+++ b/src/Nancy/ViewConfiguration.cs
@@ -19,8 +19,8 @@ namespace Nancy
         /// <summary>
         /// Initializes a new instance of the <see cref="ViewConfiguration"/> class.
         /// </summary>
-        /// <param name="runtimeViewDiscovery"></param>
-        /// <param name="runtimeViewUpdates"></param>
+        /// <param name="runtimeViewDiscovery">Determines if views can be discovered during runtime.</param>
+        /// <param name="runtimeViewUpdates">Determines if views can be updated during runtime.</param>
         public ViewConfiguration(bool runtimeViewDiscovery = false, bool runtimeViewUpdates = false)
         {
             this.RuntimeViewDiscovery = runtimeViewDiscovery;


### PR DESCRIPTION
Moved routing configurations over to the new configuration as part of #2000 

1. Added `RouteConfiguration`, `RouteConfigurationExtensions` and `DefaultRouteConfigurationProvider`
1. Renamed `EnableHeadRouting` to `ExplicitHeadRouting` when it was moved
1. Removed routing related settings from `StaticConfiguration`
1. Removed `HEAD` routing configuration check in `NancyModule.Head` (see discussion below)
1. Added the `INancyEnvironment` onto `NancyContext` :warning: 

### Old description

Currently what's left is to figure out the best approach to get the `INancyEnvironment` into `NancyModule` because it is currently used by the [Head](https://github.com/NancyFx/Nancy/blob/master/src/Nancy/NancyModule.cs#L87) declaration to throw an exception if you try to declare `HEAD` route while it's disabled

I think our options are one of the following

1. Add it to `INancyModule` (feels icky)
2. Add it to `NancyContext` (feels less icky, and makes it accessible wherever the context is)
3. Remove the check & exception from `NancyModule`

I think option 3 is the most compelling because the [DefaultRouteResolve](https://github.com/NancyFx/Nancy/blob/master/src/Nancy/Routing/DefaultRouteResolver.cs#L163) also makes use of the setting to determine if it should translate `HEAD` requests into `GET` requests. Removing the check & exception would  only mean that you'd not get an exception (which is a bit weird anyway) if you try to declare `HEAD` requests while it's disabled.. it will just mean they'll never been able to be called until you toggle the setting