### PR TITLE
Update ModelValidationResult.cs

### DIFF
--- a/src/Nancy/Validation/ModelValidationResult.cs
+++ b/src/Nancy/Validation/ModelValidationResult.cs
@@ -86,6 +86,16 @@
 
                     output[name].Add(result);
                 }
+                
+                if (!result.MemberNames.Any() && !string.IsNullOrEmpty(result.ErrorMessage))
+                {
+                    if (!output.ContainsKey(""))
+                    {
+                        output.Add("", new List<ModelValidationError>());
+                    }
+
+                    output[""].Add(result);
+                }
             }
 
             return output;

--- a/src/Nancy/Validation/ModelValidationResult.cs
+++ b/src/Nancy/Validation/ModelValidationResult.cs
@@ -89,12 +89,12 @@
                 
                 if (!result.MemberNames.Any() && !string.IsNullOrEmpty(result.ErrorMessage))
                 {
-                    if (!output.ContainsKey(""))
+                    if (!output.ContainsKey(string.Empty))
                     {
-                        output.Add("", new List<ModelValidationError>());
+                        output.Add(string.Empty, new List<ModelValidationError>());
                     }
 
-                    output[""].Add(result);
+                    output[string.Empty].Add(result);
                 }
             }
 


### PR DESCRIPTION
Fix bug:
if entity implement `IValidatableObject` but yield return has no assign `memberNames` like this:

```C#
public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
{
     if (this.Id > 100)
     {
          yield return new ValidationResult("The Id cannot be greater than 100");
     }
 }
```

the `ModelValidationResult.IsValid` is `true`.
I fix this bug
