### PR TITLE
Legacy nancy module

### DIFF
--- a/src/Nancy.Demo.Authentication.Basic/MainModule.cs
+++ b/src/Nancy.Demo.Authentication.Basic/MainModule.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nancy.Demo.Authentication.Basic
 {
-    public class MainModule : NancyModule
+    public class MainModule : LegacyNancyModule
     {
         public MainModule()
         {

--- a/src/Nancy.Demo.Authentication.Basic/SecureModule.cs
+++ b/src/Nancy.Demo.Authentication.Basic/SecureModule.cs
@@ -2,7 +2,7 @@
 {
     using Nancy.Security;
 
-    public class SecureModule : NancyModule
+    public class SecureModule : LegacyNancyModule
     {
         public SecureModule() : base("/secure")
         {

--- a/src/Nancy.Demo.Authentication.Forms/MainModule.cs
+++ b/src/Nancy.Demo.Authentication.Forms/MainModule.cs
@@ -6,7 +6,7 @@ namespace Nancy.Demo.Authentication.Forms
     using Nancy.Authentication.Forms;
     using Nancy.Extensions;
 
-    public class MainModule : NancyModule
+    public class MainModule : LegacyNancyModule
     {
         public MainModule()
         {

--- a/src/Nancy.Demo.Authentication.Forms/PartlySecureModule.cs
+++ b/src/Nancy.Demo.Authentication.Forms/PartlySecureModule.cs
@@ -3,7 +3,7 @@ namespace Nancy.Demo.Authentication.Forms
     using Nancy.Demo.Authentication.Forms.Models;
     using Nancy.Security;
 
-    public class PartlySecureModule : NancyModule
+    public class PartlySecureModule : LegacyNancyModule
     {
         public PartlySecureModule()
             : base("/partlysecure")

--- a/src/Nancy.Demo.Authentication.Forms/SecureModule.cs
+++ b/src/Nancy.Demo.Authentication.Forms/SecureModule.cs
@@ -3,7 +3,7 @@ namespace Nancy.Demo.Authentication.Forms
     using Nancy.Demo.Authentication.Forms.Models;
     using Nancy.Security;
 
-    public class SecureModule : NancyModule
+    public class SecureModule : LegacyNancyModule
     {
         public SecureModule() : base("/secure")
         {

--- a/src/Nancy.Demo.Authentication.Stateless/AuthModule.cs
+++ b/src/Nancy.Demo.Authentication.Stateless/AuthModule.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nancy.Demo.Authentication.Stateless
 {
-    public class AuthModule : NancyModule
+    public class AuthModule : LegacyNancyModule
     {
         public AuthModule() : base("/auth/")
         {

--- a/src/Nancy.Demo.Authentication.Stateless/RootModule.cs
+++ b/src/Nancy.Demo.Authentication.Stateless/RootModule.cs
@@ -1,6 +1,6 @@
 namespace Nancy.Demo.Authentication.Stateless
 {
-    public class RootModule : NancyModule
+    public class RootModule : LegacyNancyModule
     {
         public RootModule()
         {

--- a/src/Nancy.Demo.Authentication.Stateless/SecureModule.cs
+++ b/src/Nancy.Demo.Authentication.Stateless/SecureModule.cs
@@ -3,7 +3,7 @@ namespace Nancy.Demo.Authentication.Stateless
     using Nancy.Demo.Authentication.Stateless.Models;
     using Nancy.Security;
 
-    public class SecureModule : NancyModule
+    public class SecureModule : LegacyNancyModule
     {
         //by this time, the api key should have already been pulled out of our querystring
         //and, using the api key, an identity assigned to our NancyContext

--- a/src/Nancy.Demo.Authentication/AnotherVerySecureModule.cs
+++ b/src/Nancy.Demo.Authentication/AnotherVerySecureModule.cs
@@ -8,7 +8,7 @@ namespace Nancy.Demo.Authentication
     /// <summary>
     /// A module that only people with SuperSecure clearance are allowed to access
     /// </summary>
-    public class AnotherVerySecureModule : NancyModule
+    public class AnotherVerySecureModule : LegacyNancyModule
     {
         public AnotherVerySecureModule() : base("/superSecure")
         {

--- a/src/Nancy.Demo.Authentication/MainModule.cs
+++ b/src/Nancy.Demo.Authentication/MainModule.cs
@@ -1,6 +1,6 @@
 namespace Nancy.Demo.Authentication
 {
-    public class MainModule : NancyModule
+    public class MainModule : LegacyNancyModule
     {
         public MainModule()
         {

--- a/src/Nancy.Demo.Authentication/SecureModule.cs
+++ b/src/Nancy.Demo.Authentication/SecureModule.cs
@@ -3,7 +3,7 @@ namespace Nancy.Demo.Authentication
     using Nancy.Demo.Authentication.Models;
     using Nancy.Security;
 
-    public class SecureModule : NancyModule
+    public class SecureModule : LegacyNancyModule
     {
         public SecureModule() : base("/secure")
         {

--- a/src/Nancy.Demo.Bootstrapper.Aspnet/DependencyModule.cs
+++ b/src/Nancy.Demo.Bootstrapper.Aspnet/DependencyModule.cs
@@ -2,7 +2,7 @@
 {
     using Nancy.Demo.Bootstrapping.Aspnet.Models;
 
-    public class DependencyModule : NancyModule
+    public class DependencyModule : LegacyNancyModule
     {
         private readonly IApplicationDependency applicationDependency;
         private readonly IRequestDependency requestDependency;

--- a/src/Nancy.Demo.Caching/MainModule.cs
+++ b/src/Nancy.Demo.Caching/MainModule.cs
@@ -4,7 +4,7 @@ namespace Nancy.Demo.Caching
 
     using Nancy.Demo.Caching.CachingExtensions;
 
-    public class MainModule : NancyModule
+    public class MainModule : LegacyNancyModule
     {
         public MainModule()
         {

--- a/src/Nancy.Demo.ConstraintRouting/ConstraintRoutingModule.cs
+++ b/src/Nancy.Demo.ConstraintRouting/ConstraintRoutingModule.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nancy.Demo.ModelBinding
 {
-    public class ConstraintRoutingModule : NancyModule
+    public class ConstraintRoutingModule : LegacyNancyModule
     {
         public ConstraintRoutingModule()
         {

--- a/src/Nancy.Demo.Hosting.Aspnet/DependencyModule.cs
+++ b/src/Nancy.Demo.Hosting.Aspnet/DependencyModule.cs
@@ -2,7 +2,7 @@
 {
     using Nancy.Demo.Hosting.Aspnet.Models;
 
-    public class DependencyModule : NancyModule
+    public class DependencyModule : LegacyNancyModule
     {
         private readonly IApplicationDependency applicationDependency;
         private readonly IRequestDependency requestDependency;

--- a/src/Nancy.Demo.Hosting.Aspnet/MainModule.cs
+++ b/src/Nancy.Demo.Hosting.Aspnet/MainModule.cs
@@ -8,7 +8,7 @@ namespace Nancy.Demo.Hosting.Aspnet
     using Nancy.Routing;
     using Nancy.Security;
 
-    public class MainModule : NancyModule
+    public class MainModule : LegacyNancyModule
     {
         public MainModule(IRouteCacheProvider routeCacheProvider, INancyEnvironment environment)
         {

--- a/src/Nancy.Demo.Hosting.Owin/MainModule.cs
+++ b/src/Nancy.Demo.Hosting.Owin/MainModule.cs
@@ -3,7 +3,7 @@
     using System.Collections.Generic;
     using Nancy.Owin;
 
-    public class MainModule : NancyModule
+    public class MainModule : LegacyNancyModule
     {
         public MainModule()
         {

--- a/src/Nancy.Demo.Hosting.Self/TestModule.cs
+++ b/src/Nancy.Demo.Hosting.Self/TestModule.cs
@@ -4,7 +4,7 @@ namespace Nancy.Demo.Hosting.Self
 
     using Nancy.Demo.Hosting.Self.Models;
 
-    public class TestModule : NancyModule
+    public class TestModule : LegacyNancyModule
     {
         public TestModule()
         {

--- a/src/Nancy.Demo.MarkdownViewEngine/Modules/HomeModule.cs
+++ b/src/Nancy.Demo.MarkdownViewEngine/Modules/HomeModule.cs
@@ -7,7 +7,7 @@ namespace Nancy.Demo.MarkdownViewEngine.Modules
 
     using Nancy.ViewEngines;
 
-    public class HomeModule : NancyModule
+    public class HomeModule : LegacyNancyModule
     {
         private readonly IViewLocationProvider viewLocationProvider;
 

--- a/src/Nancy.Demo.ModelBinding/CustomersModule.cs
+++ b/src/Nancy.Demo.ModelBinding/CustomersModule.cs
@@ -6,7 +6,7 @@ namespace Nancy.BindingDemo
     using Nancy.Demo.ModelBinding.Models;
     using Nancy.ModelBinding;
 
-    public class CustomersModule : NancyModule
+    public class CustomersModule : LegacyNancyModule
     {
         public CustomersModule()
             : base("/customers")

--- a/src/Nancy.Demo.ModelBinding/EventsModule.cs
+++ b/src/Nancy.Demo.ModelBinding/EventsModule.cs
@@ -6,7 +6,7 @@ namespace Nancy.Demo.ModelBinding
     using Nancy.Demo.ModelBinding.Models;
     using Nancy.ModelBinding;
 
-    public class EventsModule : NancyModule
+    public class EventsModule : LegacyNancyModule
     {
         public EventsModule()
             : base("/events")

--- a/src/Nancy.Demo.ModelBinding/JsonModule.cs
+++ b/src/Nancy.Demo.ModelBinding/JsonModule.cs
@@ -5,7 +5,7 @@ namespace Nancy.Demo.ModelBinding
     using Nancy.Demo.ModelBinding.Models;
     using Nancy.ModelBinding;
 
-    public class JsonModule : NancyModule
+    public class JsonModule : LegacyNancyModule
     {
         public JsonModule()
         {

--- a/src/Nancy.Demo.ModelBinding/MainModule.cs
+++ b/src/Nancy.Demo.ModelBinding/MainModule.cs
@@ -1,6 +1,6 @@
 namespace Nancy.Demo.ModelBinding
 {
-    public class MainModule : NancyModule
+    public class MainModule : LegacyNancyModule
     {
         public MainModule()
         {

--- a/src/Nancy.Demo.ModelBinding/XmlModule.cs
+++ b/src/Nancy.Demo.ModelBinding/XmlModule.cs
@@ -5,7 +5,7 @@ namespace Nancy.Demo.ModelBinding
     using Nancy.Demo.ModelBinding.Models;
     using Nancy.ModelBinding;
 
-    public class XmlModule : NancyModule
+    public class XmlModule : LegacyNancyModule
     {
         public XmlModule()
         {

--- a/src/Nancy.Demo.Razor.Localization/Modules/HomeModule.cs
+++ b/src/Nancy.Demo.Razor.Localization/Modules/HomeModule.cs
@@ -2,7 +2,7 @@
 {
     using System.Globalization;
 
-    public class HomeModule : NancyModule
+    public class HomeModule : LegacyNancyModule
     {
         public HomeModule()
         {

--- a/src/Nancy.Demo.SparkViewEngine/FifthElement/FifthElementModule.cs
+++ b/src/Nancy.Demo.SparkViewEngine/FifthElement/FifthElementModule.cs
@@ -1,6 +1,6 @@
 namespace Nancy.Demo.SparkViewEngine.FifthElement
 {
-    public class FifthElementModule : NancyModule
+    public class FifthElementModule : LegacyNancyModule
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="INancyModule"/> class.

--- a/src/Nancy.Demo.SparkViewEngine/MainModule.cs
+++ b/src/Nancy.Demo.SparkViewEngine/MainModule.cs
@@ -1,6 +1,6 @@
 namespace Nancy.Demo.SparkViewEngine
 {
-    public class MainModule : NancyModule
+    public class MainModule : LegacyNancyModule
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="INancyModule"/> class.

--- a/src/Nancy.Demo.SuperSimpleViewEngine/MainModule.cs
+++ b/src/Nancy.Demo.SuperSimpleViewEngine/MainModule.cs
@@ -2,7 +2,7 @@ namespace Nancy.Demo.SuperSimpleViewEngine
 {
     using Nancy.Demo.SuperSimpleViewEngine.Models;
 
-    public class MainModule : NancyModule
+    public class MainModule : LegacyNancyModule
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="INancyModule"/> class.

--- a/src/Nancy.Demo.Validation/CustomersModule.cs
+++ b/src/Nancy.Demo.Validation/CustomersModule.cs
@@ -7,7 +7,7 @@ namespace Nancy.Demo.Validation
     using Nancy.ModelBinding;
     using Nancy.Validation;
 
-    public class CustomersModule : NancyModule
+    public class CustomersModule : LegacyNancyModule
     {
         public CustomersModule() : base("/customers")
         {

--- a/src/Nancy.Demo.Validation/MainModule.cs
+++ b/src/Nancy.Demo.Validation/MainModule.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nancy.Demo.Validation
 {
-    public class MainModule : NancyModule
+    public class MainModule : LegacyNancyModule
     {
         public MainModule()
         {

--- a/src/Nancy.Demo.Validation/ProductsModule.cs
+++ b/src/Nancy.Demo.Validation/ProductsModule.cs
@@ -4,7 +4,7 @@
     using Nancy.ModelBinding;
     using Nancy.Validation;
 
-    public class ProductsModule : NancyModule
+    public class ProductsModule : LegacyNancyModule
     {
         public ProductsModule() : base("/products")
         {

--- a/src/Nancy.Hosting.Self.Tests/TestModule.cs
+++ b/src/Nancy.Hosting.Self.Tests/TestModule.cs
@@ -3,7 +3,7 @@
     using System;
     using System.IO;
 
-    public class TestModule : NancyModule
+    public class TestModule : LegacyNancyModule
     {
         public TestModule()
         {

--- a/src/Nancy.Metadata.Modules.Tests/DefaultMetadataModuleConventionsFixture.cs
+++ b/src/Nancy.Metadata.Modules.Tests/DefaultMetadataModuleConventionsFixture.cs
@@ -20,7 +20,7 @@
         {
             // Given
             var convention = this.conventions.ElementAt(0);
-            var module = new FakeNancyModule();
+            var module = new FakeLegacyNancyModule();
             var metadataModules = new[] { new FakeNancyMetadataModule() };
 
             // When
@@ -37,7 +37,7 @@
         {
             // Given
             var convention = this.conventions.ElementAt(1);
-            var module = new FakeNancyModule();
+            var module = new FakeLegacyNancyModule();
             var metadataModules = new[] { new Metadata.FakeNancyMetadataModule() };
 
             // When

--- a/src/Nancy.Metadata.Modules.Tests/DefaultMetadataModuleConventionsFixture.cs
+++ b/src/Nancy.Metadata.Modules.Tests/DefaultMetadataModuleConventionsFixture.cs
@@ -21,7 +21,7 @@
             // Given
             var convention = this.conventions.ElementAt(0);
             var module = new FakeLegacyNancyModule();
-            var metadataModules = new[] { new FakeNancyMetadataModule() };
+            var metadataModules = new[] { new FakeLegacyNancyMetadataModule() };
 
             // When
             var result = convention.Invoke(
@@ -38,7 +38,7 @@
             // Given
             var convention = this.conventions.ElementAt(1);
             var module = new FakeLegacyNancyModule();
-            var metadataModules = new[] { new Metadata.FakeNancyMetadataModule() };
+            var metadataModules = new[] { new Metadata.FakeLegacyNancyMetadataModule() };
 
             // When
             var result = convention.Invoke(
@@ -54,8 +54,8 @@
         {
             // Given
             var convention = this.conventions.ElementAt(2);
-            var module = new Modules.FakeNancyModule();
-            var metadataModules = new[] { new Metadata.FakeNancyMetadataModule() };
+            var module = new Modules.FakeLegacyNancyModule();
+            var metadataModules = new[] { new Metadata.FakeLegacyNancyMetadataModule() };
 
             // When
             var result = convention.Invoke(

--- a/src/Nancy.Metadata.Modules.Tests/FakeLegacyNancyMetadataModule.cs
+++ b/src/Nancy.Metadata.Modules.Tests/FakeLegacyNancyMetadataModule.cs
@@ -1,0 +1,6 @@
+﻿namespace Nancy.Metadata.Modules.Tests
+{
+    public class FakeLegacyNancyMetadataModule : MetadataModule<string>
+    {
+    }
+}

--- a/src/Nancy.Metadata.Modules.Tests/FakeLegacyNancyModule.cs
+++ b/src/Nancy.Metadata.Modules.Tests/FakeLegacyNancyModule.cs
@@ -2,13 +2,13 @@
 {
     using System;
 
-    public class FakeNancyModule : NancyModule
+    public class FakeLegacyNancyModule : LegacyNancyModule
     {
-        public FakeNancyModule()
+        public FakeLegacyNancyModule()
         {
         }
 
-        public FakeNancyModule(Action<FakeNancyModuleConfigurator> closure)
+        public FakeLegacyNancyModule(Action<FakeNancyModuleConfigurator> closure)
         {
             var configurator = 
                 new FakeNancyModuleConfigurator(this);
@@ -18,9 +18,9 @@
 
         public class FakeNancyModuleConfigurator
         {
-            private readonly NancyModule module;
+            private readonly LegacyNancyModule module;
 
-            public FakeNancyModuleConfigurator(NancyModule module)
+            public FakeNancyModuleConfigurator(LegacyNancyModule module)
             {
                 this.module = module;
             }

--- a/src/Nancy.Metadata.Modules.Tests/FakeNancyMetadataModule.cs
+++ b/src/Nancy.Metadata.Modules.Tests/FakeNancyMetadataModule.cs
@@ -1,6 +1,0 @@
-﻿namespace Nancy.Metadata.Modules.Tests
-{
-    public class FakeNancyMetadataModule : MetadataModule<string>
-    {
-    }
-}

--- a/src/Nancy.Metadata.Modules.Tests/Metadata/FakeLegacyNancyMetadataModule.cs
+++ b/src/Nancy.Metadata.Modules.Tests/Metadata/FakeLegacyNancyMetadataModule.cs
@@ -1,0 +1,6 @@
+﻿namespace Nancy.Metadata.Modules.Tests.Metadata
+{
+    public class FakeLegacyNancyMetadataModule : MetadataModule<string>
+    {
+    }
+}

--- a/src/Nancy.Metadata.Modules.Tests/Metadata/FakeNancyMetadataModule.cs
+++ b/src/Nancy.Metadata.Modules.Tests/Metadata/FakeNancyMetadataModule.cs
@@ -1,6 +1,0 @@
-﻿namespace Nancy.Metadata.Modules.Tests.Metadata
-{
-    public class FakeNancyMetadataModule : MetadataModule<string>
-    {
-    }
-}

--- a/src/Nancy.Metadata.Modules.Tests/MetadataModuleFixture.cs
+++ b/src/Nancy.Metadata.Modules.Tests/MetadataModuleFixture.cs
@@ -14,7 +14,7 @@
         public MetadataModuleFixture()
         {
             this.route = new RouteDescription("NamedDescription", "GET", "/things", ctx => true);
-            this.metadataModule = new FakeNancyMetadataModule();
+            this.metadataModule = new FakeLegacyNancyMetadataModule();
         }
 
         [Fact]

--- a/src/Nancy.Metadata.Modules.Tests/MetadataModuleRouteMetadataProviderFixture.cs
+++ b/src/Nancy.Metadata.Modules.Tests/MetadataModuleRouteMetadataProviderFixture.cs
@@ -11,7 +11,7 @@
     {
         private readonly MetadataModuleRouteMetadataProvider provider;
         private readonly INancyModule module;
-        private readonly FakeNancyMetadataModule metadataModule;
+        private readonly FakeLegacyNancyMetadataModule metadataModule;
         private readonly RouteDescription route;
         private readonly IMetadataModuleResolver resolver;
         private const string Metadata = "metadata";
@@ -21,7 +21,7 @@
             this.resolver = A.Fake<IMetadataModuleResolver>();
             this.module = A.Fake<INancyModule>();
             this.route = new RouteDescription("NamedDescription", "GET", "/things", ctx => true);
-            this.metadataModule = new FakeNancyMetadataModule();
+            this.metadataModule = new FakeLegacyNancyMetadataModule();
             this.metadataModule.Describe[this.route.Name] = desc => { return Metadata; };
 
             this.provider = new MetadataModuleRouteMetadataProvider(this.resolver);

--- a/src/Nancy.Metadata.Modules.Tests/Modules/FakeLegacyNancyModule.cs
+++ b/src/Nancy.Metadata.Modules.Tests/Modules/FakeLegacyNancyModule.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nancy.Metadata.Modules.Tests.Modules
 {
-    public class FakeNancyModule : NancyModule
+    public class FakeLegacyNancyModule : LegacyNancyModule
     {
     }
 }

--- a/src/Nancy.Metadata.Modules.Tests/Nancy.Metadata.Modules.Tests.csproj
+++ b/src/Nancy.Metadata.Modules.Tests/Nancy.Metadata.Modules.Tests.csproj
@@ -83,12 +83,12 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="DefaultMetadataModuleConventionsFixture.cs" />
-    <Compile Include="FakeNancyMetadataModule.cs" />
+    <Compile Include="FakeLegacyNancyMetadataModule.cs" />
     <Compile Include="FakeLegacyNancyModule.cs" />
     <Compile Include="MetadataModuleFixture.cs" />
     <Compile Include="MetadataModuleRouteMetadataProviderFixture.cs" />
-    <Compile Include="Metadata\FakeNancyMetadataModule.cs" />
-    <Compile Include="Modules\FakeNancyModule.cs" />
+    <Compile Include="Metadata\FakeLegacyNancyMetadataModule.cs" />
+    <Compile Include="Modules\FakeLegacyNancyModule.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nancy.Metadata.Modules\Nancy.Metadata.Modules.csproj">

--- a/src/Nancy.Metadata.Modules.Tests/Nancy.Metadata.Modules.Tests.csproj
+++ b/src/Nancy.Metadata.Modules.Tests/Nancy.Metadata.Modules.Tests.csproj
@@ -84,7 +84,7 @@
     </Compile>
     <Compile Include="DefaultMetadataModuleConventionsFixture.cs" />
     <Compile Include="FakeNancyMetadataModule.cs" />
-    <Compile Include="FakeNancyModule.cs" />
+    <Compile Include="FakeLegacyNancyModule.cs" />
     <Compile Include="MetadataModuleFixture.cs" />
     <Compile Include="MetadataModuleRouteMetadataProviderFixture.cs" />
     <Compile Include="Metadata\FakeNancyMetadataModule.cs" />

--- a/src/Nancy.Owin.Tests/AppBuilderExtensionsFixture.cs
+++ b/src/Nancy.Owin.Tests/AppBuilderExtensionsFixture.cs
@@ -32,7 +32,7 @@
         }
 #endif
 
-        public class TestModule : NancyModule
+        public class TestModule : LegacyNancyModule
         {
             public TestModule()
             {

--- a/src/Nancy.Testing.Tests/BrowserDefaultsFixture.cs
+++ b/src/Nancy.Testing.Tests/BrowserDefaultsFixture.cs
@@ -167,7 +167,7 @@
             Assert.Equal(this.captureRequestModule.CapturedRequest.Query.testKey.Value, "testValue");
         }
 
-        public class CaptureRequestModule : NancyModule
+        public class CaptureRequestModule : LegacyNancyModule
         {
             public Request CapturedRequest;
 

--- a/src/Nancy.Testing.Tests/BrowserFixture.cs
+++ b/src/Nancy.Testing.Tests/BrowserFixture.cs
@@ -596,7 +596,7 @@ namespace Nancy.Testing.Tests
             public Category Category { get; set; }
         }
 
-        public class EchoModule : NancyModule
+        public class EchoModule : LegacyNancyModule
         {
             public EchoModule()
             {

--- a/src/Nancy.Testing.Tests/CaseSensitivityFixture.cs
+++ b/src/Nancy.Testing.Tests/CaseSensitivityFixture.cs
@@ -128,7 +128,7 @@
             }
         }
 
-        public class MainModule : NancyModule
+        public class MainModule : LegacyNancyModule
         {
             public MainModule()
             {

--- a/src/Nancy.Testing.Tests/ConfigurableBootstrapperDependenciesTests.cs
+++ b/src/Nancy.Testing.Tests/ConfigurableBootstrapperDependenciesTests.cs
@@ -161,7 +161,7 @@
             Assert.Contains(_dataFromFake2, bodyAsString);
         }
 
-        public class ModuleWithOneDependency : NancyModule
+        public class ModuleWithOneDependency : LegacyNancyModule
         {
             public ModuleWithOneDependency(ITestDependency dependency)
                 : base("/1dependency")
@@ -173,7 +173,7 @@
             }
         }
 
-        public class ModuleWithTwoDependencies : NancyModule
+        public class ModuleWithTwoDependencies : LegacyNancyModule
         {
             public ModuleWithTwoDependencies(ITestDependency dependency, ITestDependency2 dependency2)
                 : base("/2dependencies")

--- a/src/Nancy.Testing.Tests/ConfigurableBootstrapperFixture.cs
+++ b/src/Nancy.Testing.Tests/ConfigurableBootstrapperFixture.cs
@@ -212,7 +212,7 @@
             }
         }
 
-        private class BlowUpModule : NancyModule
+        private class BlowUpModule : LegacyNancyModule
         {
             public BlowUpModule()
             {

--- a/src/Nancy.Testing.Tests/TestingViewExtensions/GetModulePathExtensionMethodTests.cs
+++ b/src/Nancy.Testing.Tests/TestingViewExtensions/GetModulePathExtensionMethodTests.cs
@@ -39,7 +39,7 @@ namespace Nancy.Testing.Tests.TestingViewExtensions
             Assert.Equal("", response.GetModulePath());
         }
 
-        internal class TestModuleWithLongModulePath : NancyModule
+        internal class TestModuleWithLongModulePath : LegacyNancyModule
         {
             public TestModuleWithLongModulePath()
                 : base("/a/long/path")
@@ -48,7 +48,7 @@ namespace Nancy.Testing.Tests.TestingViewExtensions
             }
         }
 
-        internal class ModuleWithoutModulePath : NancyModule
+        internal class ModuleWithoutModulePath : LegacyNancyModule
         {
             public ModuleWithoutModulePath()
             {

--- a/src/Nancy.Testing.Tests/TestingViewExtensions/TestingViewFactoryTestModule.cs
+++ b/src/Nancy.Testing.Tests/TestingViewExtensions/TestingViewFactoryTestModule.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nancy.Testing.Tests.TestingViewExtensions
 {
-    public class TestingViewFactoryTestModule : NancyModule
+    public class TestingViewFactoryTestModule : LegacyNancyModule
     {
         private const string VIEW_PATH = "TestingViewExtensions/ViewFactoryTest.sshtml";
 

--- a/src/Nancy.Testing/ConfigurableNancyModule.cs
+++ b/src/Nancy.Testing/ConfigurableNancyModule.cs
@@ -5,7 +5,7 @@
     /// <summary>
     /// Provides a way to define a Nancy module though an API.
     /// </summary>
-    public class ConfigurableNancyModule : NancyModule
+    public class ConfigurableNancyModule : LegacyNancyModule
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigurableNancyModule"/> class.

--- a/src/Nancy.Testing/ConfigurableNancyModule.cs
+++ b/src/Nancy.Testing/ConfigurableNancyModule.cs
@@ -95,7 +95,7 @@
             /// <param name="action">The action that should be invoked by the route.</param>
             /// <returns>An instance to the current <see cref="ConfigurableNancyModuleConfigurator"/>.</returns>
             /// <remarks>This will add a route with a condition that is always evaluates to <see langword="true"/>.</remarks>
-            public ConfigurableNancyModuleConfigurator Delete(string path, Func<dynamic, NancyModule, dynamic> action)
+            public ConfigurableNancyModuleConfigurator Delete(string path, Func<dynamic, LegacyNancyModule, dynamic> action)
             {
                 return this.Delete(path, condition => true, action);
             }
@@ -107,7 +107,7 @@
             /// <param name="condition">The condition that has to be fulfilled in order for the route to be invoked</param>
             /// <param name="action">The action that should be invoked by the route.</param>
             /// <returns>An instance to the current <see cref="ConfigurableNancyModuleConfigurator"/>.</returns>
-            public ConfigurableNancyModuleConfigurator Delete(string path, Func<NancyContext, bool> condition, Func<dynamic, NancyModule, dynamic> action)
+            public ConfigurableNancyModuleConfigurator Delete(string path, Func<NancyContext, bool> condition, Func<dynamic, LegacyNancyModule, dynamic> action)
             {
                 this.module.Delete[path, GetSafeRouteCondition(condition)] = GetSafeRouteAction(action);
                 return this;
@@ -131,7 +131,7 @@
             /// <param name="action">The action that should be invoked by the route.</param>
             /// <returns>An instance to the current <see cref="ConfigurableNancyModuleConfigurator"/>.</returns>
             /// <remarks>This will add a route with a condition that is always evaluates to <see langword="true"/>.</remarks>
-            public ConfigurableNancyModuleConfigurator Get(string path, Func<dynamic, NancyModule, dynamic> action)
+            public ConfigurableNancyModuleConfigurator Get(string path, Func<dynamic, LegacyNancyModule, dynamic> action)
             {
                 return this.Get(path, condition => true, action);
             }
@@ -143,7 +143,7 @@
             /// <param name="condition">The condition that has to be fulfilled in order for the route to be invoked</param>
             /// <param name="action">The action that should be invoked by the route.</param>
             /// <returns>An instance to the current <see cref="ConfigurableNancyModuleConfigurator"/>.</returns>
-            public ConfigurableNancyModuleConfigurator Get(string path, Func<NancyContext, bool> condition, Func<dynamic, NancyModule, dynamic> action)
+            public ConfigurableNancyModuleConfigurator Get(string path, Func<NancyContext, bool> condition, Func<dynamic, LegacyNancyModule, dynamic> action)
             {
                 this.module.Get[path, GetSafeRouteCondition(condition)] = GetSafeRouteAction(action);
                 return this;
@@ -167,7 +167,7 @@
             /// <param name="action">The action that should be invoked by the route.</param>
             /// <returns>An instance to the current <see cref="ConfigurableNancyModuleConfigurator"/>.</returns>
             /// <remarks>This will add a route with a condition that is always evaluates to <see langword="true"/>.</remarks>
-            public ConfigurableNancyModuleConfigurator Patch(string path, Func<dynamic, NancyModule, dynamic> action)
+            public ConfigurableNancyModuleConfigurator Patch(string path, Func<dynamic, LegacyNancyModule, dynamic> action)
             {
                 return this.Patch(path, condition => true, action);
             }
@@ -179,7 +179,7 @@
             /// <param name="condition">The condition that has to be fulfilled in order for the route to be invoked</param>
             /// <param name="action">The action that should be invoked by the route.</param>
             /// <returns>An instance to the current <see cref="ConfigurableNancyModuleConfigurator"/>.</returns>
-            public ConfigurableNancyModuleConfigurator Patch(string path, Func<NancyContext, bool> condition, Func<dynamic, NancyModule, dynamic> action)
+            public ConfigurableNancyModuleConfigurator Patch(string path, Func<NancyContext, bool> condition, Func<dynamic, LegacyNancyModule, dynamic> action)
             {
                 this.module.Patch[path, GetSafeRouteCondition(condition)] = GetSafeRouteAction(action);
                 return this;
@@ -203,7 +203,7 @@
             /// <param name="action">The action that should be invoked by the route.</param>
             /// <returns>An instance to the current <see cref="ConfigurableNancyModuleConfigurator"/>.</returns>
             /// <remarks>This will add a route with a condition that is always evaluates to <see langword="true"/>.</remarks>
-            public ConfigurableNancyModuleConfigurator Post(string path, Func<dynamic, NancyModule, dynamic> action)
+            public ConfigurableNancyModuleConfigurator Post(string path, Func<dynamic, LegacyNancyModule, dynamic> action)
             {
                 return this.Post(path, condition => true, action);
             }
@@ -215,7 +215,7 @@
             /// <param name="condition">The condition that has to be fulfilled in order for the route to be invoked</param>
             /// <param name="action">The action that should be invoked by the route.</param>
             /// <returns>An instance to the current <see cref="ConfigurableNancyModuleConfigurator"/>.</returns>
-            public ConfigurableNancyModuleConfigurator Post(string path, Func<NancyContext, bool> condition, Func<dynamic, NancyModule, dynamic> action)
+            public ConfigurableNancyModuleConfigurator Post(string path, Func<NancyContext, bool> condition, Func<dynamic, LegacyNancyModule, dynamic> action)
             {
                 this.module.Post[path, GetSafeRouteCondition(condition)] = GetSafeRouteAction(action);
                 return this;
@@ -239,7 +239,7 @@
             /// <param name="action">The action that should be invoked by the route.</param>
             /// <returns>An instance to the current <see cref="ConfigurableNancyModuleConfigurator"/>.</returns>
             /// <remarks>This will add a route with a condition that is always evaluates to <see langword="true"/>.</remarks>
-            public ConfigurableNancyModuleConfigurator Put(string path, Func<dynamic, NancyModule, dynamic> action)
+            public ConfigurableNancyModuleConfigurator Put(string path, Func<dynamic, LegacyNancyModule, dynamic> action)
             {
                 return this.Put(path, condition => true, action);
             }
@@ -251,7 +251,7 @@
             /// <param name="condition">The condition that has to be fulfilled in order for the route to be invoked</param>
             /// <param name="action">The action that should be invoked by the route.</param>
             /// <returns>An instance to the current <see cref="ConfigurableNancyModuleConfigurator"/>.</returns>
-            public ConfigurableNancyModuleConfigurator Put(string path, Func<NancyContext, bool> condition, Func<dynamic, NancyModule, dynamic> action)
+            public ConfigurableNancyModuleConfigurator Put(string path, Func<NancyContext, bool> condition, Func<dynamic, LegacyNancyModule, dynamic> action)
             {
                 this.module.Post[path, GetSafeRouteCondition(condition)] = GetSafeRouteAction(action);
                 return this;
@@ -275,7 +275,7 @@
             /// <param name="action">The action that should be invoked by the route.</param>
             /// <returns>An instance to the current <see cref="ConfigurableNancyModuleConfigurator"/>.</returns>
             /// <remarks>This will add a route with a condition that is always evaluates to <see langword="true"/>.</remarks>
-            public ConfigurableNancyModuleConfigurator Options(string path, Func<dynamic, NancyModule, dynamic> action)
+            public ConfigurableNancyModuleConfigurator Options(string path, Func<dynamic, LegacyNancyModule, dynamic> action)
             {
                 return this.Options(path, condition => true, action);
             }
@@ -287,13 +287,13 @@
             /// <param name="condition">The condition that has to be fulfilled in order for the route to be invoked</param>
             /// <param name="action">The action that should be invoked by the route.</param>
             /// <returns>An instance to the current <see cref="ConfigurableNancyModuleConfigurator"/>.</returns>
-            public ConfigurableNancyModuleConfigurator Options(string path, Func<NancyContext, bool> condition, Func<dynamic, NancyModule, dynamic> action)
+            public ConfigurableNancyModuleConfigurator Options(string path, Func<NancyContext, bool> condition, Func<dynamic, LegacyNancyModule, dynamic> action)
             {
                 this.module.Options[path, GetSafeRouteCondition(condition)] = GetSafeRouteAction(action);
                 return this;
             }
 
-            private Func<dynamic, dynamic> GetSafeRouteAction(Func<dynamic, NancyModule, dynamic> action)
+            private Func<dynamic, dynamic> GetSafeRouteAction(Func<dynamic, LegacyNancyModule, dynamic> action)
             {
                 if (action == null)
                 {

--- a/src/Nancy.Tests.Functional/Modules/AbsoluteUrlTestModule.cs
+++ b/src/Nancy.Tests.Functional/Modules/AbsoluteUrlTestModule.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nancy.Tests.Functional.Modules
 {
-    public class AbsoluteUrlTestModule : NancyModule
+    public class AbsoluteUrlTestModule : LegacyNancyModule
     {
         public AbsoluteUrlTestModule()
         {

--- a/src/Nancy.Tests.Functional/Modules/CookieModule.cs
+++ b/src/Nancy.Tests.Functional/Modules/CookieModule.cs
@@ -4,7 +4,7 @@ namespace Nancy.Tests.Functional.Modules
 {
     using Nancy.Cookies;
 
-    public class CookieModule : NancyModule
+    public class CookieModule : LegacyNancyModule
     {
         public CookieModule()
         {

--- a/src/Nancy.Tests.Functional/Modules/JsonpTestModule.cs
+++ b/src/Nancy.Tests.Functional/Modules/JsonpTestModule.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nancy.Tests.Functional.Modules
 {
-    public class JsonpTestModule : NancyModule
+    public class JsonpTestModule : LegacyNancyModule
     {
         public JsonpTestModule() : base("/test")
         {

--- a/src/Nancy.Tests.Functional/Modules/PerRouteAuthModule.cs
+++ b/src/Nancy.Tests.Functional/Modules/PerRouteAuthModule.cs
@@ -2,7 +2,7 @@
 {
     using Nancy.Security;
 
-    public class PerRouteAuthModule : NancyModule
+    public class PerRouteAuthModule : LegacyNancyModule
     {
         public PerRouteAuthModule()
         {

--- a/src/Nancy.Tests.Functional/Modules/RazorTestModule.cs
+++ b/src/Nancy.Tests.Functional/Modules/RazorTestModule.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nancy.Tests.Functional.Modules
 {
-    public class RazorTestModule : NancyModule
+    public class RazorTestModule : LegacyNancyModule
     {
         public RazorTestModule()
         {

--- a/src/Nancy.Tests.Functional/Modules/RazorWithTracingTestModule.cs
+++ b/src/Nancy.Tests.Functional/Modules/RazorWithTracingTestModule.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nancy.Tests.Functional.Modules
 {
-    public class RazorWithTracingTestModule : NancyModule
+    public class RazorWithTracingTestModule : LegacyNancyModule
     {
         public RazorWithTracingTestModule()
         {

--- a/src/Nancy.Tests.Functional/Modules/SerializeTestModule.cs
+++ b/src/Nancy.Tests.Functional/Modules/SerializeTestModule.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nancy.Tests.Functional.Modules
 {
-    public class SerializeTestModule : NancyModule
+    public class SerializeTestModule : LegacyNancyModule
     {
         public SerializeTestModule()
         {

--- a/src/Nancy.Tests.Functional/Modules/SerializerTestModule.cs
+++ b/src/Nancy.Tests.Functional/Modules/SerializerTestModule.cs
@@ -4,7 +4,7 @@
     using System.Globalization;
     using Nancy.ModelBinding;
 
-    public class SerializerTestModule : NancyModule
+    public class SerializerTestModule : LegacyNancyModule
     {
         public SerializerTestModule()
         {

--- a/src/Nancy.Tests.Functional/Modules/ThrowingModule.cs
+++ b/src/Nancy.Tests.Functional/Modules/ThrowingModule.cs
@@ -2,7 +2,7 @@
 {
     using System;
 
-    public class ThrowingModule : NancyModule
+    public class ThrowingModule : LegacyNancyModule
     {
         public ThrowingModule()
         {

--- a/src/Nancy.Tests.Functional/Tests/AsyncExceptionTests.cs
+++ b/src/Nancy.Tests.Functional/Tests/AsyncExceptionTests.cs
@@ -39,7 +39,7 @@
         }
     }
 
-    public class MyModule : NancyModule
+    public class MyModule : LegacyNancyModule
     {
         public MyModule()
         {

--- a/src/Nancy.Tests.Functional/Tests/BasicRouteInvocationsFixture.cs
+++ b/src/Nancy.Tests.Functional/Tests/BasicRouteInvocationsFixture.cs
@@ -134,7 +134,7 @@
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
-        public class BasicRouteInvocationsModule : NancyModule
+        public class BasicRouteInvocationsModule : LegacyNancyModule
         {
             public BasicRouteInvocationsModule()
             {
@@ -160,7 +160,7 @@
             }
         }
 
-        public class BasicRouteInvocationsModuleWithHead : NancyModule
+        public class BasicRouteInvocationsModuleWithHead : LegacyNancyModule
         {
             public BasicRouteInvocationsModuleWithHead()
             {

--- a/src/Nancy.Tests.Functional/Tests/ContentNegotiationFixture.cs
+++ b/src/Nancy.Tests.Functional/Tests/ContentNegotiationFixture.cs
@@ -734,7 +734,7 @@ namespace Nancy.Tests.Functional.Tests
             Assert.Equal(contentType, result.ContentType);
         }
 
-        private static Func<dynamic, NancyModule, dynamic> CreateNegotiatedResponse(Action<Negotiator> action = null)
+        private static Func<dynamic, LegacyNancyModule, dynamic> CreateNegotiatedResponse(Action<Negotiator> action = null)
         {
             return (parameters, module) =>
                 {

--- a/src/Nancy.Tests.Functional/Tests/ContentNegotiationFixture.cs
+++ b/src/Nancy.Tests.Functional/Tests/ContentNegotiationFixture.cs
@@ -832,7 +832,7 @@ namespace Nancy.Tests.Functional.Tests
             }
         }
 
-        private class NegotiationModule : NancyModule
+        private class NegotiationModule : LegacyNancyModule
         {
             public NegotiationModule()
             {

--- a/src/Nancy.Tests.Functional/Tests/MethodRewriteFixture.cs
+++ b/src/Nancy.Tests.Functional/Tests/MethodRewriteFixture.cs
@@ -100,7 +100,7 @@ namespace Nancy.Tests.Functional.Tests
         }
     }
 
-    public class MethodRewriteModule : NancyModule
+    public class MethodRewriteModule : LegacyNancyModule
     {
         public MethodRewriteModule()
         {

--- a/src/Nancy.Tests.Functional/Tests/ModelBindingTests.cs
+++ b/src/Nancy.Tests.Functional/Tests/ModelBindingTests.cs
@@ -48,7 +48,7 @@
         }
     }
 
-    public class ModelBindingModule : NancyModule
+    public class ModelBindingModule : LegacyNancyModule
     {
         public ModelBindingModule()
         {
@@ -63,7 +63,7 @@
         }
     }
 
-    public class MixedSourceModelBindingModule : NancyModule
+    public class MixedSourceModelBindingModule : LegacyNancyModule
     {
         public MixedSourceModelBindingModule()
         {

--- a/src/Nancy.Tests.Functional/Tests/RouteConstraintTests.cs
+++ b/src/Nancy.Tests.Functional/Tests/RouteConstraintTests.cs
@@ -93,7 +93,7 @@
             }
         }
     }
-    public class RouteConstraintsModule : NancyModule
+    public class RouteConstraintsModule : LegacyNancyModule
     {
         public RouteConstraintsModule()
         {

--- a/src/Nancy.Tests/Fakes/FakeLegacyNancyModuleNoRoutes.cs
+++ b/src/Nancy.Tests/Fakes/FakeLegacyNancyModuleNoRoutes.cs
@@ -1,0 +1,6 @@
+﻿namespace Nancy.Tests.Fakes
+{
+    public class FakeLegacyNancyModuleNoRoutes : LegacyNancyModule
+    {
+    }
+}

--- a/src/Nancy.Tests/Fakes/FakeNancyModule.cs
+++ b/src/Nancy.Tests/Fakes/FakeNancyModule.cs
@@ -2,7 +2,7 @@
 {
     using System;
 
-    public class FakeNancyModule : NancyModule
+    public class FakeNancyModule : LegacyNancyModule
     {
         public FakeNancyModule()
         {
@@ -18,9 +18,9 @@
 
         public class FakeNancyModuleConfigurator
         {
-            private readonly NancyModule module;
+            private readonly LegacyNancyModule module;
 
-            public FakeNancyModuleConfigurator(NancyModule module)
+            public FakeNancyModuleConfigurator(LegacyNancyModule module)
             {
                 this.module = module;
             }

--- a/src/Nancy.Tests/Fakes/FakeNancyModuleWithBasePath.cs
+++ b/src/Nancy.Tests/Fakes/FakeNancyModuleWithBasePath.cs
@@ -2,7 +2,7 @@ namespace Nancy.Tests.Fakes
 {
     using System;
 
-    public class FakeNancyModuleWithBasePath : NancyModule
+    public class FakeNancyModuleWithBasePath : LegacyNancyModule
     {
         public FakeNancyModuleWithBasePath() : base("/fake")
         {

--- a/src/Nancy.Tests/Fakes/FakeNancyModuleWithPreAndPostHooks.cs
+++ b/src/Nancy.Tests/Fakes/FakeNancyModuleWithPreAndPostHooks.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nancy.Tests.Fakes
 {
-    public class FakeNancyModuleWithPreAndPostHooks : NancyModule
+    public class FakeNancyModuleWithPreAndPostHooks : LegacyNancyModule
     {
         public FakeNancyModuleWithPreAndPostHooks()
         {

--- a/src/Nancy.Tests/Fakes/FakeNancyModuleWithoutBasePath.cs
+++ b/src/Nancy.Tests/Fakes/FakeNancyModuleWithoutBasePath.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nancy.Tests.Fakes
 {
-    public class FakeNancyModuleWithoutBasePath : NancyModule
+    public class FakeNancyModuleWithoutBasePath : LegacyNancyModule
     {
         public FakeNancyModuleWithoutBasePath()
         {

--- a/src/Nancy.Tests/Nancy.Tests.csproj
+++ b/src/Nancy.Tests/Nancy.Tests.csproj
@@ -116,6 +116,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Fakes\FakeLegacyNancyModuleNoRoutes.cs" />
     <Compile Include="Fakes\PersonWithAgeField.cs" />
     <Compile Include="Fakes\StructModel.cs" />
     <Compile Include="Helpers\ExceptionExtensionsFixture.cs" />
@@ -227,6 +228,7 @@
     <Compile Include="Unit\NancyCookieFixture.cs" />
     <Compile Include="Unit\NancyEngineFixture.cs" />
     <Compile Include="Unit\NancyMiddlewareFixture.cs" />
+    <Compile Include="Unit\LegacyNancyModuleFixture.cs" />
     <Compile Include="Unit\NancyModuleFixture.cs" />
     <Compile Include="Unit\AfterPipelineFixture.cs" />
     <Compile Include="Unit\BeforePipelineFixture.cs" />

--- a/src/Nancy.Tests/NoAppStartupsFixture.cs
+++ b/src/Nancy.Tests/NoAppStartupsFixture.cs
@@ -108,7 +108,7 @@
             }
         }
 
-        public class NoAppStartupsModule : NancyModule
+        public class NoAppStartupsModule : LegacyNancyModule
         {
             public NoAppStartupsModule(INoAppStartupsTestDependency dependency)
             {

--- a/src/Nancy.Tests/Unit/LegacyNancyModuleFixture.cs
+++ b/src/Nancy.Tests/Unit/LegacyNancyModuleFixture.cs
@@ -229,7 +229,7 @@ namespace Nancy.Tests.Unit
             this.module.Routes.First().Description.Name.ShouldEqual("Foo");
         }
 
-        private class CustomModulePathModule : NancyModule
+        private class CustomModulePathModule : LegacyNancyModule
         {
             public CustomModulePathModule(string modulePath)
                 : base(modulePath)
@@ -237,16 +237,16 @@ namespace Nancy.Tests.Unit
             }
         }
 
-        private class CustomNancyModule : NancyModule
+        private class CustomNancyModule : LegacyNancyModule
         {
             public new CustomRouteBuilder Get
             {
                 get { return new CustomRouteBuilder("GET", this); }
             }
 
-            public class CustomRouteBuilder : RouteBuilder
+            public class CustomRouteBuilder : LegacyRouteBuilder
             {
-                public CustomRouteBuilder(string method, NancyModule parentModule)
+                public CustomRouteBuilder(string method, LegacyNancyModule parentModule)
                     : base(method, parentModule)
                 {
                 }

--- a/src/Nancy.Tests/Unit/LegacyNancyModuleFixture.cs
+++ b/src/Nancy.Tests/Unit/LegacyNancyModuleFixture.cs
@@ -1,0 +1,267 @@
+namespace Nancy.Tests.Unit
+{
+    using System;
+    using System.Linq;
+
+    using Nancy.Tests.Fakes;
+
+    using Xunit;
+
+    public class LegacyNancyModuleFixture
+    {
+        private readonly LegacyNancyModule module;
+
+        public LegacyNancyModuleFixture()
+        {
+            this.module = new FakeLegacyNancyModuleNoRoutes();
+        }
+
+        [Fact]
+        public void Adds_route_when_get_indexer_used()
+        {
+            // Given, When
+            this.module.Get["/test"] = d => null;
+
+            // Then
+            this.module.Routes.Count().ShouldEqual(1);
+        }
+
+        [Fact]
+        public void Adds_route_when_put_indexer_used()
+        {
+            // Given, When
+            this.module.Put["/test"] = d => null;
+
+            // Then
+            this.module.Routes.Count().ShouldEqual(1);
+        }
+
+        [Fact]
+        public void Adds_route_when_post_indexer_used()
+        {
+            // Given, When
+            this.module.Post["/test"] = d => null;
+
+            // Then
+            this.module.Routes.Count().ShouldEqual(1);
+        }
+
+        [Fact]
+        public void Adds_route_when_delete_indexer_used()
+        {
+            // Given, When
+            this.module.Delete["/test"] = d => null;
+
+            // Then
+            this.module.Routes.Count().ShouldEqual(1);
+        }
+
+        [Fact]
+        public void Adds_route_when_options_indexer_userd()
+        {
+            // Given, When
+            this.module.Options["/test"] = d => null;
+
+            // Then
+            this.module.Routes.Count().ShouldEqual(1);
+        }
+
+        [Fact]
+        public void Should_store_route_with_specified_path_when_route_indexer_is_invoked_with_a_path_but_no_condition()
+        {
+            // Given, When
+            this.module.Get["/test"] = d => null;
+
+            // Then
+            module.Routes.First().Description.Path.ShouldEqual("/test");
+        }
+
+        [Fact]
+        public void Should_store_route_with_specified_path_when_route_indexer_is_invoked_with_a_path_and_condition()
+        {
+            // Given
+            Func<NancyContext, bool> condition = r => true;
+
+            // When
+            this.module.Get["/test", condition] = d => null;
+
+            // Then
+            module.Routes.First().Description.Path.ShouldEqual("/test");
+        }
+
+        [Fact]
+        public void Should_store_route_with_null_condition_when_route_indexer_is_invoked_without_a_condition()
+        {
+            // Given, When
+            this.module.Get["/test"] = d => null;
+
+            // Then
+            module.Routes.First().Description.Condition.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Should_store_route_with_condition_when_route_indexer_is_invoked_with_a_condition()
+        {
+            // Given
+            Func<NancyContext, bool> condition = r => true;
+
+            // When
+            this.module.Get["/test", condition] = d => null;
+
+            // Then
+            module.Routes.First().Description.Condition.ShouldBeSameAs(condition);
+        }
+
+        [Fact]
+        public void Should_add_route_with_get_method_when_added_using_get_indexer()
+        {
+            // Given, When
+            this.module.Get["/test"] = d => null;
+
+            // Then
+            module.Routes.First().Description.Method.ShouldEqual("GET");
+        }
+
+        [Fact]
+        public void Should_add_route_with_put_method_when_added_using_get_indexer()
+        {
+            // Given, When
+            this.module.Put["/test"] = d => null;
+
+            // Then
+            module.Routes.First().Description.Method.ShouldEqual("PUT");
+        }
+
+        [Fact]
+        public void Should_add_route_with_post_method_when_added_using_get_indexer()
+        {
+            // Given, When
+            this.module.Post["/test"] = d => null;
+
+            // Then
+            module.Routes.First().Description.Method.ShouldEqual("POST");
+        }
+
+        [Fact]
+        public void Should_add_route_with_delete_method_when_added_using_get_indexer()
+        {
+            // Given, When
+            this.module.Delete["/test"] = d => null;
+
+            // Then
+            module.Routes.First().Description.Method.ShouldEqual("DELETE");
+        }
+
+        [Fact]
+        public void Should_store_route_combine_with_base_path_if_one_specified()
+        {
+            // Given
+            var moduleWithBasePath = new FakeNancyModuleWithBasePath();
+
+            // When
+            moduleWithBasePath.Get["/NewRoute"] = d => null;
+
+            // Then
+            moduleWithBasePath.Routes.Last().Description.Path.ShouldEqual("/fake/NewRoute");
+        }
+
+        [Fact]
+        public void Should_add_leading_slash_to_route_if_missing()
+        {
+            // Given
+            var moduleWithBasePath = new FakeNancyModuleWithBasePath();
+
+            // When
+            moduleWithBasePath.Get["test"] = d => null;
+
+            // Then
+            moduleWithBasePath.Routes.Last().Description.Path.ShouldEqual("/fake/test");
+        }
+
+        [Fact]
+        public void Should_store_two_routes_when_registering_single_get_method()
+        {
+            // Given
+            var moduleWithBasePath = new CustomNancyModule();
+
+            // When
+            moduleWithBasePath.Get["/Test1", "/Test2"] = d => null;
+
+            // Then
+            moduleWithBasePath.Routes.First().Description.Path.ShouldEqual("/Test1");
+            moduleWithBasePath.Routes.Last().Description.Path.ShouldEqual("/Test2");
+        }
+
+        [Fact]
+        public void Should_store_single_route_when_calling_non_overridden_post_from_sub_module()
+        {
+            // Given
+            var moduleWithBasePath = new CustomNancyModule();
+
+            // When
+            moduleWithBasePath.Post["/Test1"] = d => null;
+
+            // Then
+            moduleWithBasePath.Routes.Last().Description.Path.ShouldEqual("/Test1");
+        }
+
+        [Fact]
+        public void Should_not_throw_when_null_passed_as_modulepath()
+        {
+            // Given
+            var moduleWithNullPath = new CustomModulePathModule(null);
+
+            // Then
+            Assert.DoesNotThrow(() =>
+            {
+                moduleWithNullPath.Post["/Test1"] = d => null;
+            });
+        }
+
+        [Fact]
+        public void Adds_named_route_when_named_indexer_used()
+        {
+            // Given, When
+            this.module.Get["Foo", "/test"] = d => null;
+
+            // Then
+            this.module.Routes.Count().ShouldEqual(1);
+            this.module.Routes.First().Description.Name.ShouldEqual("Foo");
+        }
+
+        private class CustomModulePathModule : NancyModule
+        {
+            public CustomModulePathModule(string modulePath)
+                : base(modulePath)
+            {
+            }
+        }
+
+        private class CustomNancyModule : NancyModule
+        {
+            public new CustomRouteBuilder Get
+            {
+                get { return new CustomRouteBuilder("GET", this); }
+            }
+
+            public class CustomRouteBuilder : RouteBuilder
+            {
+                public CustomRouteBuilder(string method, NancyModule parentModule)
+                    : base(method, parentModule)
+                {
+                }
+
+                public Func<dynamic, dynamic> this[params string[] paths]
+                {
+                    set
+                    {
+                        foreach (var path in paths)
+                        {
+                            this.AddRoute(String.Empty, path, null, value);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Nancy.Tests/Unit/NancyModuleFixture.cs
+++ b/src/Nancy.Tests/Unit/NancyModuleFixture.cs
@@ -20,7 +20,7 @@ namespace Nancy.Tests.Unit
         public void Adds_route_when_get_indexer_used()
         {
             // Given, When
-            this.module.Get["/test"] = d => null;
+            this.module.Get["/test"] = async (_, __) => null;
 
             // Then
             this.module.Routes.Count().ShouldEqual(1);
@@ -30,7 +30,7 @@ namespace Nancy.Tests.Unit
         public void Adds_route_when_put_indexer_used()
         {
             // Given, When
-            this.module.Put["/test"] = d => null;
+            this.module.Put["/test"] = async (_, __) => null;
 
             // Then
             this.module.Routes.Count().ShouldEqual(1);
@@ -40,7 +40,7 @@ namespace Nancy.Tests.Unit
         public void Adds_route_when_post_indexer_used()
         {
             // Given, When
-            this.module.Post["/test"] = d => null;
+            this.module.Post["/test"] = async (_, __) => null;
 
             // Then
             this.module.Routes.Count().ShouldEqual(1);
@@ -50,7 +50,7 @@ namespace Nancy.Tests.Unit
         public void Adds_route_when_delete_indexer_used()
         {
             // Given, When
-            this.module.Delete["/test"] = d => null;
+            this.module.Delete["/test"] = async (_, __) => null;
 
             // Then
             this.module.Routes.Count().ShouldEqual(1);
@@ -60,7 +60,7 @@ namespace Nancy.Tests.Unit
         public void Adds_route_when_options_indexer_userd()
         {
             // Given, When
-            this.module.Options["/test"] = d => null;
+            this.module.Options["/test"] = async (_, __) => null;
 
             // Then
             this.module.Routes.Count().ShouldEqual(1);
@@ -70,7 +70,7 @@ namespace Nancy.Tests.Unit
         public void Should_store_route_with_specified_path_when_route_indexer_is_invoked_with_a_path_but_no_condition()
         {
             // Given, When
-            this.module.Get["/test"] = d => null;
+            this.module.Get["/test"] = async (_, __) => null;
 
             // Then
             module.Routes.First().Description.Path.ShouldEqual("/test");
@@ -83,7 +83,7 @@ namespace Nancy.Tests.Unit
             Func<NancyContext, bool> condition = r => true;
 
             // When
-            this.module.Get["/test", condition] = d => null;
+            this.module.Get["/test", condition] = async (_, __) => null;
 
             // Then
             module.Routes.First().Description.Path.ShouldEqual("/test");
@@ -93,7 +93,7 @@ namespace Nancy.Tests.Unit
         public void Should_store_route_with_null_condition_when_route_indexer_is_invoked_without_a_condition()
         {
             // Given, When
-            this.module.Get["/test"] = d => null;
+            this.module.Get["/test"] = async (_, __) => null;
 
             // Then
             module.Routes.First().Description.Condition.ShouldBeNull();
@@ -106,7 +106,7 @@ namespace Nancy.Tests.Unit
             Func<NancyContext, bool> condition = r => true;
 
             // When
-            this.module.Get["/test", condition] = d => null;
+            this.module.Get["/test", condition] = async (_, __) => null;
 
             // Then
             module.Routes.First().Description.Condition.ShouldBeSameAs(condition);
@@ -116,7 +116,7 @@ namespace Nancy.Tests.Unit
         public void Should_add_route_with_get_method_when_added_using_get_indexer()
         {
             // Given, When
-            this.module.Get["/test"] = d => null;
+            this.module.Get["/test"] = async (_, __) => null;
 
             // Then
             module.Routes.First().Description.Method.ShouldEqual("GET");
@@ -126,7 +126,7 @@ namespace Nancy.Tests.Unit
         public void Should_add_route_with_put_method_when_added_using_get_indexer()
         {
             // Given, When
-            this.module.Put["/test"] = d => null;
+            this.module.Put["/test"] = async (_, __) => null;
 
             // Then
             module.Routes.First().Description.Method.ShouldEqual("PUT");
@@ -136,7 +136,7 @@ namespace Nancy.Tests.Unit
         public void Should_add_route_with_post_method_when_added_using_get_indexer()
         {
             // Given, When
-            this.module.Post["/test"] = d => null;
+            this.module.Post["/test"] = async(_, __) => null;
 
             // Then
             module.Routes.First().Description.Method.ShouldEqual("POST");
@@ -146,7 +146,7 @@ namespace Nancy.Tests.Unit
         public void Should_add_route_with_delete_method_when_added_using_get_indexer()
         {
             // Given, When
-            this.module.Delete["/test"] = d => null;
+            this.module.Delete["/test"] = async (_, __) => null;
 
             // Then
             module.Routes.First().Description.Method.ShouldEqual("DELETE");
@@ -199,7 +199,7 @@ namespace Nancy.Tests.Unit
             var moduleWithBasePath = new CustomNancyModule();
 
             // When
-            moduleWithBasePath.Post["/Test1"] = d => null;
+            moduleWithBasePath.Post["/Test1"] = async (_, __) => null;
 
             // Then
             moduleWithBasePath.Routes.Last().Description.Path.ShouldEqual("/Test1");
@@ -214,7 +214,7 @@ namespace Nancy.Tests.Unit
             // Then
             Assert.DoesNotThrow(() =>
             {
-                moduleWithNullPath.Post["/Test1"] = d => null;
+                moduleWithNullPath.Post["/Test1"] = async (_, __) => null;
             });
         }
 
@@ -222,7 +222,7 @@ namespace Nancy.Tests.Unit
         public void Adds_named_route_when_named_indexer_used()
         {
             // Given, When
-            this.module.Get["Foo", "/test"] = d => null;
+            this.module.Get["Foo", "/test"] = async (_, __) => null;
 
             // Then
             this.module.Routes.Count().ShouldEqual(1);
@@ -257,7 +257,7 @@ namespace Nancy.Tests.Unit
                     {
                         foreach (var path in paths)
                         {
-                            this.AddRoute(String.Empty, path, null, value);
+                            this.AddRoute(String.Empty, path, null, async (p, __) => value.Invoke(p));
                         }
                     }
                 }

--- a/src/Nancy.Tests/Unit/Routing/ConstraintNodeRouteResolverFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/ConstraintNodeRouteResolverFixture.cs
@@ -381,7 +381,7 @@
             result.Body.AsString().ShouldEqual("CaseInsensitive");
         }
         
-        private class TestModule : NancyModule
+        private class TestModule : LegacyNancyModule
         {
             public TestModule()
             {

--- a/src/Nancy.Tests/Unit/Routing/ConstraintNodeRouteScoringFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/ConstraintNodeRouteScoringFixture.cs
@@ -30,7 +30,7 @@
             result.Body.AsString().ShouldEqual("capture");
         }
 
-        private class TestModule : NancyModule
+        private class TestModule : LegacyNancyModule
         {
             public TestModule()
             {

--- a/src/Nancy.Tests/Unit/Routing/DefaultNancyModuleBuilderFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/DefaultNancyModuleBuilderFixture.cs
@@ -15,7 +15,7 @@
         private readonly DefaultNancyModuleBuilder builder;
         private readonly IResponseFormatterFactory responseFormatterFactory;
         private readonly IViewFactory viewFactory;
-        private readonly NancyModule module;
+        private readonly FakeNancyModule module;
         private readonly IModelBinderLocator modelBinderLocator;
         private readonly IModelValidatorLocator validatorLocator;
 

--- a/src/Nancy.Tests/Unit/Routing/DefaultRouteResolverFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/DefaultRouteResolverFixture.cs
@@ -426,7 +426,7 @@
             return !caseSensitive || !isUpperCase;
         }
 
-        private class MethodNotAllowedModule : NancyModule
+        private class MethodNotAllowedModule : LegacyNancyModule
         {
             public MethodNotAllowedModule()
             {
@@ -436,7 +436,7 @@
             }
         }
 
-        private class NoRootModule : NancyModule
+        private class NoRootModule : LegacyNancyModule
         {
             public NoRootModule()
             {
@@ -444,7 +444,7 @@
             }
         }
 
-        private class TestModule : NancyModule
+        private class TestModule : LegacyNancyModule
         {
             public TestModule()
             {

--- a/src/Nancy.Tests/Unit/Routing/RouteCacheFixture.cs
+++ b/src/Nancy.Tests/Unit/Routing/RouteCacheFixture.cs
@@ -181,7 +181,7 @@
                 new IRouteMetadataProvider[0]);
 
             // Then
-            A.CallTo(() => descriptionProvider.GetDescription(A<NancyModule>._, expectedPath)).MustHaveHappened();
+            A.CallTo(() => descriptionProvider.GetDescription(A<LegacyNancyModule>._, expectedPath)).MustHaveHappened();
         }
 
         [Fact]

--- a/src/Nancy.ViewEngines.DotLiquid.Tests/Functional/PartialRenderingFixture.cs
+++ b/src/Nancy.ViewEngines.DotLiquid.Tests/Functional/PartialRenderingFixture.cs
@@ -57,7 +57,7 @@ namespace Nancy.ViewEngines.DotLiquid.Tests.Functional
         }
     }
 
-    public class PartialRenderingModule : NancyModule
+    public class PartialRenderingModule : LegacyNancyModule
     {
         public PartialRenderingModule()
         {

--- a/src/Nancy/Diagnostics/Modules/InfoModule.cs
+++ b/src/Nancy/Diagnostics/Modules/InfoModule.cs
@@ -14,12 +14,12 @@
         public InfoModule(IRootPathProvider rootPathProvider, NancyInternalConfiguration configuration)
             : base("/info")
         {
-            Get["/"] = _ =>
+            Get["/"] = async (_, __) =>
             {
                 return View["Info"];
             };
 
-            Get["/data"] = _ =>
+            Get["/data"] = async (_, __) =>
             {
                 dynamic data = new ExpandoObject();
 

--- a/src/Nancy/Diagnostics/Modules/InteractiveModule.cs
+++ b/src/Nancy/Diagnostics/Modules/InteractiveModule.cs
@@ -15,12 +15,12 @@
         {
             this.interactiveDiagnostics = interactiveDiagnostics;
 
-            Get["/"] = _ =>
+            Get["/"] = async (_, __) =>
             {
                 return View["InteractiveDiagnostics"];
             };
 
-            Get["/providers"] = _ =>
+            Get["/providers"] = async (_, __) =>
             {
                 var providers = this.interactiveDiagnostics
                     .AvailableDiagnostics
@@ -37,7 +37,7 @@
                 return this.Response.AsJson(providers);
             };
 
-            Get["/providers/{providerName}"] = ctx =>
+            Get["/providers/{providerName}"] = async (ctx, __) =>
             {
                 var providerName =
                     HttpUtility.UrlDecode((string)ctx.providerName);
@@ -67,7 +67,7 @@
                 return this.Response.AsJson(methods);
             };
 
-            Get["/providers/{providerName}/{methodName}"] = ctx =>
+            Get["/providers/{providerName}/{methodName}"] = async (ctx, __) =>
             {
                 var providerName =
                     HttpUtility.UrlDecode((string)ctx.providerName);
@@ -89,7 +89,7 @@
                 return this.Response.AsJson(new { Result = this.interactiveDiagnostics.ExecuteDiagnostic(method, arguments) });
             };
 
-            Get["/templates/{providerName}/{methodName}"] = ctx =>
+            Get["/templates/{providerName}/{methodName}"] = async (ctx, __) =>
             {
                 var providerName =
                     HttpUtility.UrlDecode((string)ctx.providerName);

--- a/src/Nancy/Diagnostics/Modules/MainModule.cs
+++ b/src/Nancy/Diagnostics/Modules/MainModule.cs
@@ -4,12 +4,12 @@
     {
         public MainModule()
         {
-            Get["/"] = _ =>
+            Get["/"] = async (_, __) =>
             {
                 return View["Dashboard"];
             };
 
-            Post["/"] = _ => this.Response.AsRedirect("~/");
+            Post["/"] = async (_, __) => this.Response.AsRedirect("~/");
         }
     }
 }

--- a/src/Nancy/Diagnostics/Modules/SettingsModule.cs
+++ b/src/Nancy/Diagnostics/Modules/SettingsModule.cs
@@ -15,7 +15,7 @@
         public SettingsModule()
             : base("/settings")
         {
-            Get["/"] = _ =>
+            Get["/"] = async (_, __) =>
             {
                 var properties = Types.SelectMany(t => t.GetProperties(BindingFlags.Static | BindingFlags.Public))
                                       .Where(x => x.PropertyType == typeof(bool));
@@ -36,7 +36,7 @@
                 return View["Settings", model];
             };
 
-            Post["/"] = parameters => {
+            Post["/"] = async (_, __) => {
 
                 var model =
                     this.Bind<SettingsModel>();

--- a/src/Nancy/Diagnostics/Modules/TraceModule.cs
+++ b/src/Nancy/Diagnostics/Modules/TraceModule.cs
@@ -12,17 +12,17 @@
         {
             this.sessionProvider = sessionProvider;
 
-            Get["/"] = _ =>
+            Get["/"] = async (_, __) =>
             {
                 return View["RequestTracing"];
             };
 
-            Get["/sessions"] = _ =>
+            Get["/sessions"] = async (_, __) =>
             {
                 return this.Response.AsJson(this.sessionProvider.GetSessions().Select(s => new { Id = s.Id }).ToArray());
             };
 
-            Get["/sessions/{id}"] = ctx =>
+            Get["/sessions/{id}"] = async (ctx, __) =>
             {
                 Guid id;
                 if (!Guid.TryParse(ctx.Id, out id))

--- a/src/Nancy/LegacyNancyModule.cs
+++ b/src/Nancy/LegacyNancyModule.cs
@@ -1,0 +1,386 @@
+namespace Nancy
+{
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Nancy.Configuration;
+    using Nancy.ModelBinding;
+    using Nancy.Responses.Negotiation;
+    using Nancy.Routing;
+    using Nancy.Session;
+    using Nancy.Validation;
+    using Nancy.ViewEngines;
+
+    /// <summary>
+    /// Basic class containing the functionality for defining routes and actions in Nancy.
+    /// </summary>
+    [Obsolete("LegacyNancyModule is a compatibility shim that will be removed in a future release. Please migrate to the 'async only' NancyModule.")]
+    public abstract class LegacyNancyModule : INancyModule, IHideObjectMembers
+    {
+        private readonly List<Route> routes;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NancyModule"/> class.
+        /// </summary>
+        protected LegacyNancyModule()
+            : this(String.Empty)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NancyModule"/> class.
+        /// </summary>
+        /// <param name="modulePath">A <see cref="string"/> containing the root relative path that all paths in the module will be a subset of.</param>
+        protected LegacyNancyModule(string modulePath)
+        {
+            this.After = new AfterPipeline();
+            this.Before = new BeforePipeline();
+            this.OnError = new ErrorPipeline();
+
+            this.ModulePath = modulePath;
+            this.routes = new List<Route>();
+        }
+
+        /// <summary>
+        /// Non-model specific data for rendering in the response
+        /// </summary>
+        public dynamic ViewBag
+        {
+            get
+            {
+                return this.Context == null ? null : this.Context.ViewBag;
+            }
+        }
+
+        public dynamic Text
+        {
+            get { return this.Context.Text; }
+        }
+
+        /// <summary>
+        /// Gets <see cref="LegacyRouteBuilder"/> for declaring actions for DELETE requests.
+        /// </summary>
+        /// <value>A <see cref="LegacyRouteBuilder"/> instance.</value>
+        public LegacyRouteBuilder Delete
+        {
+            get { return new LegacyRouteBuilder("DELETE", this); }
+        }
+
+        /// <summary>
+        /// Gets <see cref="LegacyRouteBuilder"/> for declaring actions for GET requests.
+        /// </summary>
+        /// <value>A <see cref="LegacyRouteBuilder"/> instance.</value>
+        public LegacyRouteBuilder Get
+        {
+            get { return new LegacyRouteBuilder("GET", this); }
+        }
+
+        /// <summary>
+        /// Gets <see cref="LegacyRouteBuilder"/> for declaring actions for HEAD requests.
+        /// </summary>
+        /// <value>A <see cref="LegacyRouteBuilder"/> instance.</value>
+        public LegacyRouteBuilder Head
+        {
+            get { return new LegacyRouteBuilder("HEAD", this); }
+        }
+
+        /// <summary>
+        /// Gets <see cref="LegacyRouteBuilder"/> for declaring actions for OPTIONS requests.
+        /// </summary>
+        /// <value>A <see cref="LegacyRouteBuilder"/> instance.</value>
+        public LegacyRouteBuilder Options
+        {
+            get { return new LegacyRouteBuilder("OPTIONS", this); }
+        }
+
+        /// <summary>
+        /// Gets <see cref="LegacyRouteBuilder"/> for declaring actions for PATCH requests.
+        /// </summary>
+        /// <value>A <see cref="LegacyRouteBuilder"/> instance.</value>
+        public LegacyRouteBuilder Patch
+        {
+            get { return new LegacyRouteBuilder("PATCH", this); }
+        }
+
+        /// <summary>
+        /// Gets <see cref="LegacyRouteBuilder"/> for declaring actions for POST requests.
+        /// </summary>
+        /// <value>A <see cref="LegacyRouteBuilder"/> instance.</value>
+        public LegacyRouteBuilder Post
+        {
+            get { return new LegacyRouteBuilder("POST", this); }
+        }
+
+        /// <summary>
+        /// Gets <see cref="LegacyRouteBuilder"/> for declaring actions for PUT requests.
+        /// </summary>
+        /// <value>A <see cref="LegacyRouteBuilder"/> instance.</value>
+        public LegacyRouteBuilder Put
+        {
+            get { return new LegacyRouteBuilder("PUT", this); }
+        }
+
+        /// <summary>
+        /// Get the root path of the routes in the current module.
+        /// </summary>
+        /// <value>
+        /// A <see cref="T:System.String" /> containing the root path of the module or <see langword="null" />
+        /// if no root path should be used.</value><remarks>All routes will be relative to this root path.
+        /// </remarks>
+        public string ModulePath { get; protected set; }
+
+        /// <summary>
+        /// Gets all declared routes by the module.
+        /// </summary>
+        /// <value>A <see cref="IEnumerable{T}"/> instance, containing all <see cref="Route"/> instances declared by the module.</value>
+        /// <remarks>This is automatically set by Nancy at runtime.</remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual IEnumerable<Route> Routes
+        {
+            get { return this.routes.AsReadOnly(); }
+        }
+
+        /// <summary>
+        /// Gets the current session.
+        /// </summary>
+        public ISession Session
+        {
+            get { return this.Request.Session; }
+        }
+
+        /// <summary>
+        /// Renders a view from inside a route handler.
+        /// </summary>
+        /// <value>A <see cref="ViewRenderer"/> instance that is used to determine which view that should be rendered.</value>
+        public ViewRenderer View
+        {
+            get { return new ViewRenderer(this); }
+        }
+
+        /// <summary>
+        /// Used to negotiate the content returned based on Accepts header.
+        /// </summary>
+        /// <value>A <see cref="Negotiator"/> instance that is used to negotiate the content returned.</value>
+        public Negotiator Negotiate
+        {
+            get { return new Negotiator(this.Context); }
+        }
+
+        /// <summary>
+        /// Gets or sets the validator locator.
+        /// </summary>
+        /// <remarks>This is automatically set by Nancy at runtime.</remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public IModelValidatorLocator ValidatorLocator { get; set; }
+
+        /// <summary>
+        /// Gets or sets an <see cref="Request"/> instance that represents the current request.
+        /// </summary>
+        /// <value>An <see cref="Request"/> instance.</value>
+        public virtual Request Request
+        {
+            get { return this.Context.Request; }
+            set { this.Context.Request = value; }
+        }
+
+        /// <summary>
+        /// The extension point for accessing the view engines in Nancy.
+        /// </summary><value>An <see cref="IViewFactory" /> instance.</value>
+        /// <remarks>This is automatically set by Nancy at runtime.</remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public IViewFactory ViewFactory { get; set; }
+
+        /// <summary><para>
+        /// The post-request hook
+        /// </para><para>
+        /// The post-request hook is called after the response is created by the route execution.
+        /// It can be used to rewrite the response or add/remove items from the context.
+        /// </para>
+        /// <remarks>This is automatically set by Nancy at runtime.</remarks>
+        /// </summary>
+        public AfterPipeline After { get; set; }
+
+        /// <summary>
+        /// <para>
+        /// The pre-request hook
+        /// </para>
+        /// <para>
+        /// The PreRequest hook is called prior to executing a route. If any item in the
+        /// pre-request pipeline returns a response then the route is not executed and the
+        /// response is returned.
+        /// </para>
+        /// <remarks>This is automatically set by Nancy at runtime.</remarks>
+        /// </summary>
+        public BeforePipeline Before { get; set; }
+
+        /// <summary>
+        /// <para>
+        /// The error hook
+        /// </para>
+        /// <para>
+        /// The error hook is called if an exception is thrown at any time during executing
+        /// the PreRequest hook, a route and the PostRequest hook. It can be used to set
+        /// the response and/or finish any ongoing tasks (close database session, etc).
+        /// </para>
+        /// <remarks>This is automatically set by Nancy at runtime.</remarks>
+        /// </summary>
+        public ErrorPipeline OnError { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current Nancy context
+        /// </summary>
+        /// <value>A <see cref="NancyContext" /> instance.</value>
+        /// <remarks>This is automatically set by Nancy at runtime.</remarks>
+        public NancyContext Context { get; set; }
+
+        /// <summary>
+        /// An extension point for adding support for formatting response contents.
+        /// </summary><value>This property will always return <see langword="null" /> because it acts as an extension point.</value><remarks>Extension methods to this property should always return <see cref="P:Nancy.NancyModuleBase.Response" /> or one of the types that can implicitly be types into a <see cref="P:Nancy.NancyModuleBase.Response" />.</remarks>
+        public IResponseFormatter Response { get; set; }
+
+        /// <summary>
+        /// Gets or sets the model binder locator
+        /// </summary>
+        /// <remarks>This is automatically set by Nancy at runtime.</remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public IModelBinderLocator ModelBinderLocator { get; set; }
+
+        /// <summary>
+        /// Gets or sets the model validation result
+        /// </summary>
+        /// <remarks>This is automatically set by Nancy at runtime when you run validation.</remarks>
+        public virtual ModelValidationResult ModelValidationResult
+        {
+            get { return this.Context == null ? null : this.Context.ModelValidationResult; }
+            set
+            {
+                if (this.Context != null)
+                {
+                    this.Context.ModelValidationResult = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Helper class for configuring a route handler in a module.
+        /// </summary>
+        public class LegacyRouteBuilder : IHideObjectMembers
+        {
+            private readonly string method;
+            private readonly LegacyNancyModule parentModule;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="LegacyRouteBuilder"/> class.
+            /// </summary>
+            /// <param name="method">The HTTP request method that the route should be available for.</param>
+            /// <param name="parentModule">The <see cref="INancyModule"/> that the route is being configured for.</param>
+            public LegacyRouteBuilder(string method, LegacyNancyModule parentModule)
+            {
+                this.method = method;
+                this.parentModule = parentModule;
+            }
+
+            /// <summary>
+            /// Defines a Nancy route for the specified <paramref name="path"/>.
+            /// </summary>
+            /// <value>A delegate that is used to invoke the route.</value>
+            public Func<dynamic, dynamic> this[string path]
+            {
+                set { this.AddRoute(string.Empty, path, null, value); }
+            }
+
+            /// <summary>
+            /// Defines a Nancy route for the specified <paramref name="path"/> and <paramref name="condition"/>.
+            /// </summary>
+            /// <value>A delegate that is used to invoke the route.</value>
+            public Func<dynamic, dynamic> this[string path, Func<NancyContext, bool> condition]
+            {
+                set { this.AddRoute(string.Empty, path, condition, value); }
+            }
+
+            /// <summary>
+            /// Defines an async route for the specified <paramref name="path"/>
+            /// </summary>
+            public Func<dynamic, CancellationToken, Task<dynamic>> this[string path, bool runAsync]
+            {
+                set { this.AddRoute(string.Empty, path, null, value); }
+            }
+
+            /// <summary>
+            /// Defines an async route for the specified <paramref name="path"/> and <paramref name="condition"/>.
+            /// </summary>
+            public Func<dynamic, CancellationToken, Task<dynamic>> this[string path, Func<NancyContext, bool> condition, bool runAsync]
+            {
+                set { this.AddRoute(string.Empty, path, condition, value); }
+            }
+
+            /// <summary>
+            /// Defines a Nancy route for the specified <paramref name="path"/> and <paramref name="name"/>
+            /// </summary>
+            /// <value>A delegate that is used to invoke the route.</value>
+            public Func<dynamic, dynamic> this[string name, string path]
+            {
+                set { this.AddRoute(name, path, null, value); }
+            }
+
+            /// <summary>
+            /// Defines a Nancy route for the specified <paramref name="path"/>, <paramref name="condition"/> and <paramref name="name"/>
+            /// </summary>
+            /// <value>A delegate that is used to invoke the route.</value>
+            public Func<dynamic, dynamic> this[string name, string path, Func<NancyContext, bool> condition]
+            {
+                set { this.AddRoute(name, path, condition, value); }
+            }
+
+            /// <summary>
+            /// Defines an async route for the specified <paramref name="path"/> and <paramref name="name"/>
+            /// </summary>
+            public Func<dynamic, CancellationToken, Task<dynamic>> this[string name, string path, bool runAsync]
+            {
+                set { this.AddRoute(name, path, null, value); }
+            }
+
+            /// <summary>
+            /// Defines an async route for the specified <paramref name="path"/>, <paramref name="condition"/> and <paramref name="name"/>
+            /// </summary>
+            public Func<dynamic, CancellationToken, Task<dynamic>> this[string name, string path, Func<NancyContext, bool> condition, bool runAsync]
+            {
+                set { this.AddRoute(name, path, condition, value); }
+            }
+
+            protected void AddRoute(string name, string path, Func<NancyContext, bool> condition, Func<dynamic, dynamic> value)
+            {
+                var fullPath = GetFullPath(path);
+
+                this.parentModule.routes.Add(Route.FromSync(name, this.method, fullPath, condition, value));
+            }
+
+            protected void AddRoute(string name, string path, Func<NancyContext, bool> condition, Func<dynamic, CancellationToken, Task<dynamic>> value)
+            {
+                var fullPath = GetFullPath(path);
+
+                this.parentModule.routes.Add(new Route(name, this.method, fullPath, condition, value));
+            }
+
+            private string GetFullPath(string path)
+            {
+                var relativePath = (path ?? string.Empty).Trim('/');
+                var parentPath = (this.parentModule.ModulePath ?? string.Empty).Trim('/');
+
+                if (string.IsNullOrEmpty(parentPath))
+                {
+                    return string.Concat("/", relativePath);
+                }
+
+                if (string.IsNullOrEmpty(relativePath))
+                {
+                    return string.Concat("/", parentPath);
+                }
+
+                return string.Concat("/", parentPath, "/", relativePath);
+            }
+        }
+    }
+}

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -212,6 +212,7 @@
     <Compile Include="ModelBinding\PropertyBindingException.cs" />
     <Compile Include="INancyModule.cs" />
     <Compile Include="NancyEngineExtensions.cs" />
+    <Compile Include="LegacyNancyModule.cs" />
     <Compile Include="NegotiatorExtensions.cs" />
     <Compile Include="Owin\DelegateExtensions.cs" />
     <Compile Include="Owin\NancyContextExtensions.cs" />

--- a/src/Nancy/NancyModule.cs
+++ b/src/Nancy/NancyModule.cs
@@ -282,24 +282,6 @@ namespace Nancy
             }
 
             /// <summary>
-            /// Defines a Nancy route for the specified <paramref name="path"/>.
-            /// </summary>
-            /// <value>A delegate that is used to invoke the route.</value>
-            public Func<dynamic, dynamic> this[string path]
-            {
-                set { this.AddRoute(string.Empty, path, null, value); }
-            }
-
-            /// <summary>
-            /// Defines a Nancy route for the specified <paramref name="path"/> and <paramref name="condition"/>.
-            /// </summary>
-            /// <value>A delegate that is used to invoke the route.</value>
-            public Func<dynamic, dynamic> this[string path, Func<NancyContext, bool> condition]
-            {
-                set { this.AddRoute(string.Empty, path, condition, value); }
-            }
-
-            /// <summary>
             /// Defines an async route for the specified <paramref name="path"/>
             /// </summary>
             public Func<dynamic, CancellationToken, Task<dynamic>> this[string path, bool runAsync]
@@ -313,24 +295,6 @@ namespace Nancy
             public Func<dynamic, CancellationToken, Task<dynamic>> this[string path, Func<NancyContext, bool> condition, bool runAsync]
             {
                 set { this.AddRoute(string.Empty, path, condition, value); }
-            }
-
-            /// <summary>
-            /// Defines a Nancy route for the specified <paramref name="path"/> and <paramref name="name"/>
-            /// </summary>
-            /// <value>A delegate that is used to invoke the route.</value>
-            public Func<dynamic, dynamic> this[string name, string path]
-            {
-                set { this.AddRoute(name, path, null, value); }
-            }
-
-            /// <summary>
-            /// Defines a Nancy route for the specified <paramref name="path"/>, <paramref name="condition"/> and <paramref name="name"/>
-            /// </summary>
-            /// <value>A delegate that is used to invoke the route.</value>
-            public Func<dynamic, dynamic> this[string name, string path, Func<NancyContext, bool> condition]
-            {
-                set { this.AddRoute(name, path, condition, value); }
             }
 
             /// <summary>

--- a/src/Nancy/NancyModule.cs
+++ b/src/Nancy/NancyModule.cs
@@ -284,7 +284,7 @@ namespace Nancy
             /// <summary>
             /// Defines an async route for the specified <paramref name="path"/>
             /// </summary>
-            public Func<dynamic, CancellationToken, Task<dynamic>> this[string path, bool runAsync]
+            public Func<dynamic, CancellationToken, Task<dynamic>> this[string path]
             {
                 set { this.AddRoute(string.Empty, path, null, value); }
             }
@@ -292,7 +292,7 @@ namespace Nancy
             /// <summary>
             /// Defines an async route for the specified <paramref name="path"/> and <paramref name="condition"/>.
             /// </summary>
-            public Func<dynamic, CancellationToken, Task<dynamic>> this[string path, Func<NancyContext, bool> condition, bool runAsync]
+            public Func<dynamic, CancellationToken, Task<dynamic>> this[string path, Func<NancyContext, bool> condition]
             {
                 set { this.AddRoute(string.Empty, path, condition, value); }
             }
@@ -300,7 +300,7 @@ namespace Nancy
             /// <summary>
             /// Defines an async route for the specified <paramref name="path"/> and <paramref name="name"/>
             /// </summary>
-            public Func<dynamic, CancellationToken, Task<dynamic>> this[string name, string path, bool runAsync]
+            public Func<dynamic, CancellationToken, Task<dynamic>> this[string name, string path]
             {
                 set { this.AddRoute(name, path, null, value); }
             }
@@ -308,7 +308,7 @@ namespace Nancy
             /// <summary>
             /// Defines an async route for the specified <paramref name="path"/>, <paramref name="condition"/> and <paramref name="name"/>
             /// </summary>
-            public Func<dynamic, CancellationToken, Task<dynamic>> this[string name, string path, Func<NancyContext, bool> condition, bool runAsync]
+            public Func<dynamic, CancellationToken, Task<dynamic>> this[string name, string path, Func<NancyContext, bool> condition]
             {
                 set { this.AddRoute(name, path, condition, value); }
             }

--- a/src/Nancy/NancyModule.cs
+++ b/src/Nancy/NancyModule.cs
@@ -349,13 +349,6 @@ namespace Nancy
                 set { this.AddRoute(name, path, condition, value); }
             }
 
-            protected void AddRoute(string name, string path, Func<NancyContext, bool> condition, Func<dynamic, dynamic> value)
-            {
-                var fullPath = GetFullPath(path);
-
-                this.parentModule.routes.Add(Route.FromSync(name, this.method, fullPath, condition, value));
-            }
-
             protected void AddRoute(string name, string path, Func<NancyContext, bool> condition, Func<dynamic, CancellationToken, Task<dynamic>> value)
             {
                 var fullPath = GetFullPath(path);

--- a/src/Nancy/Routing/Route.cs
+++ b/src/Nancy/Routing/Route.cs
@@ -81,7 +81,7 @@
         /// <param name="description"></param>
         /// <param name="syncFunc">The action that should take place when the route is invoked.</param>
         /// <returns>A Route instance</returns>
-        [Obsolete("Sync routes are deprecated (see LegacyNancyModule")]
+        [Obsolete("Sync routes are deprecated (see LegacyNancyModule)")]
         public static Route FromSync(RouteDescription description, Func<dynamic, dynamic> syncFunc)
         {
             return new Route(description, Wrap(syncFunc));
@@ -95,7 +95,7 @@
         /// <param name="condition">A condition that needs to be satisfied inorder for the route to be eligiable for invocation.</param>
         /// <param name="syncFunc">The action that should take place when the route is invoked.</param>
         /// <returns>A Route instance</returns>
-        [Obsolete("Sync routes are deprecated (see LegacyNancyModule")]
+        [Obsolete("Sync routes are deprecated (see LegacyNancyModule)")]
         public static Route FromSync(string method, string path, Func<NancyContext, bool> condition, Func<dynamic, dynamic> syncFunc)
         {
             return FromSync(string.Empty, method, path, condition, syncFunc);
@@ -110,7 +110,7 @@
         /// <param name="condition">A condition that needs to be satisfied inorder for the route to be eligible for invocation.</param>
         /// <param name="syncFunc">The action that should take place when the route is invoked.</param>
         /// <returns>A Route instance</returns>
-        [Obsolete("Sync routes are deprecated (see LegacyNancyModule")]
+        [Obsolete("Sync routes are deprecated (see LegacyNancyModule)")]
         public static Route FromSync(string name, string method, string path, Func<NancyContext, bool> condition, Func<dynamic, dynamic> syncFunc)
         {
             return FromSync(new RouteDescription(name, method, path, condition), syncFunc);

--- a/src/Nancy/Routing/Route.cs
+++ b/src/Nancy/Routing/Route.cs
@@ -81,6 +81,7 @@
         /// <param name="description"></param>
         /// <param name="syncFunc">The action that should take place when the route is invoked.</param>
         /// <returns>A Route instance</returns>
+        [Obsolete("Sync routes are deprecated (see LegacyNancyModule")]
         public static Route FromSync(RouteDescription description, Func<dynamic, dynamic> syncFunc)
         {
             return new Route(description, Wrap(syncFunc));
@@ -94,6 +95,7 @@
         /// <param name="condition">A condition that needs to be satisfied inorder for the route to be eligiable for invocation.</param>
         /// <param name="syncFunc">The action that should take place when the route is invoked.</param>
         /// <returns>A Route instance</returns>
+        [Obsolete("Sync routes are deprecated (see LegacyNancyModule")]
         public static Route FromSync(string method, string path, Func<NancyContext, bool> condition, Func<dynamic, dynamic> syncFunc)
         {
             return FromSync(string.Empty, method, path, condition, syncFunc);
@@ -108,6 +110,7 @@
         /// <param name="condition">A condition that needs to be satisfied inorder for the route to be eligible for invocation.</param>
         /// <param name="syncFunc">The action that should take place when the route is invoked.</param>
         /// <returns>A Route instance</returns>
+        [Obsolete("Sync routes are deprecated (see LegacyNancyModule")]
         public static Route FromSync(string name, string method, string path, Func<NancyContext, bool> condition, Func<dynamic, dynamic> syncFunc)
         {
             return FromSync(new RouteDescription(name, method, path, condition), syncFunc);


### PR DESCRIPTION
**TL;DR** - Find/replace `NancyModule` with `LegacyNancyModule` for backwards compatibility.

The "old" `NancyModule` is now `LegacyNancyModule` and marked with an `ObsoleteAttribute`, this can be continued to be used for the immediate future, but the new `NancyModule`, which has async "only" routing, is the new standard moving forwards. The new `NancyModule` route definitions are the same as the old `NancyModule` "async" definitions, but without the pointless boolean on the end, e.g. this:

```c#
Get["/", true] = async (_, __) => "foo";
```

Becomes:

```c#
Get["/"] = async (_, __) => "foo";
```

The initial plan was to use some kind of inheritance to handle the `LegacyNancyModule`, but this isn't possible as it would hit the same issue of only differing on return type as the original async `NancyModule` work.

All the demos have been updated to use `LegacyNancyModule` rather than reworked to use the new one - this should serve as a reminder that we do need to remove it at some point :)

In addition to this work we could also do with `Task<dynamic>` versions of `View`, `Negotiate` etc., although some of those might be tricky as we may hit the "can't differ by return type" issue again so we need to have a think about that.