### PR TITLE
Migrated tracing settings from StaticConfiguration to the new config API

### DIFF
--- a/src/Nancy.Demo.Hosting.Aspnet/DemoBootstrapper.cs
+++ b/src/Nancy.Demo.Hosting.Aspnet/DemoBootstrapper.cs
@@ -36,6 +36,10 @@
                 slidingTimeout: 30,
                 cryptographyConfiguration: CryptographyConfiguration.NoEncryption);
 
+            environment.Tracing(
+                enabled: true,
+                displayErrorTraces: true);
+
             environment.MyConfig("Hello World");
         }
 
@@ -58,8 +62,6 @@
         {
             base.ApplicationStartup(container, pipelines);
 
-            StaticConfiguration.EnableRequestTracing = true;
-            StaticConfiguration.DisableErrorTraces = false;
             Csrf.Enable(pipelines);
 
             this.Conventions.StaticContentsConventions.Add(StaticContentConventionBuilder.AddDirectory("moo", "Content"));

--- a/src/Nancy.Testing.Tests/ContextExtensionsTests.cs
+++ b/src/Nancy.Testing.Tests/ContextExtensionsTests.cs
@@ -102,6 +102,10 @@ namespace Nancy.Testing.Tests
             // Given
             var environment = new DefaultNancyEnvironment();
             environment.AddValue(XmlConfiguration.Default);
+            environment.Tracing(
+                enabled: true,
+                displayErrorTraces: true);
+
             var response = new XmlResponse<Model>(new Model() { Dummy = "Data" }, new DefaultXmlSerializer(environment), environment);
             var context = new NancyContext() { Response = response };
 
@@ -129,12 +133,16 @@ namespace Nancy.Testing.Tests
 
         private static INancyEnvironment GetTestingEnvironment()
         {
-            var envionment =
+            var environment =
                 new DefaultNancyEnvironment();
 
-            envionment.AddValue(JsonConfiguration.Default);
+            environment.Tracing(
+                enabled: true,
+                displayErrorTraces: true);
 
-            return envionment;
+            environment.AddValue(JsonConfiguration.Default);
+
+            return environment;
         }
 
         public class Model

--- a/src/Nancy.Testing.Tests/ContextExtensionsTests.cs
+++ b/src/Nancy.Testing.Tests/ContextExtensionsTests.cs
@@ -140,7 +140,7 @@ namespace Nancy.Testing.Tests
                 enabled: true,
                 displayErrorTraces: true);
 
-            environment.AddValue(JsonConfiguration.Default);
+            environment.Json();
 
             return environment;
         }

--- a/src/Nancy.Testing/StaticConfigurationContext.cs
+++ b/src/Nancy.Testing/StaticConfigurationContext.cs
@@ -18,8 +18,6 @@ namespace Nancy.Testing
         public StaticConfigurationContext(Action<StaticConfigurationValues> closure)
         {
             this.existingConfiguration.CaseSensitive = StaticConfiguration.CaseSensitive;
-            this.existingConfiguration.DisableErrorTraces = StaticConfiguration.DisableErrorTraces;
-            this.existingConfiguration.EnableRequestTracing = StaticConfiguration.EnableRequestTracing;
             this.existingConfiguration.RequestQueryFormMultipartLimit = StaticConfiguration.RequestQueryFormMultipartLimit;
 
             var temporaryConfiguration =
@@ -41,8 +39,6 @@ namespace Nancy.Testing
         private static void AssignStaticConfigurationValues(StaticConfigurationValues values)
         {
             StaticConfiguration.CaseSensitive = values.CaseSensitive;
-            StaticConfiguration.DisableErrorTraces = values.DisableErrorTraces;
-            StaticConfiguration.EnableRequestTracing = values.EnableRequestTracing;
             StaticConfiguration.RequestQueryFormMultipartLimit = values.RequestQueryFormMultipartLimit;
         }
 
@@ -52,10 +48,6 @@ namespace Nancy.Testing
         public class StaticConfigurationValues
         {
             public bool CaseSensitive { get; set; }
-
-            public bool DisableErrorTraces { get; set; }
-
-            public bool EnableRequestTracing { get; set; }
 
             public int RequestQueryFormMultipartLimit { get; set; }
         }

--- a/src/Nancy.Tests.Functional/Modules/RazorWithTracingTestModule.cs
+++ b/src/Nancy.Tests.Functional/Modules/RazorWithTracingTestModule.cs
@@ -4,7 +4,6 @@
     {
         public RazorWithTracingTestModule()
         {
-            StaticConfiguration.EnableRequestTracing = true;
             Get["/tracing/razor-viewbag"] = _ =>
                 {
                     this.ViewBag.Name = "Bob";

--- a/src/Nancy.Tests/Unit/DefaultSerializerFactoryFixture.cs
+++ b/src/Nancy.Tests/Unit/DefaultSerializerFactoryFixture.cs
@@ -166,7 +166,7 @@
                 enabled: true,
                 displayErrorTraces: true);
 
-            environment.AddValue(JsonConfiguration.Default);
+            environment.Json();
 
             return environment;
         }

--- a/src/Nancy.Tests/Unit/DefaultSerializerFactoryFixture.cs
+++ b/src/Nancy.Tests/Unit/DefaultSerializerFactoryFixture.cs
@@ -159,12 +159,16 @@
 
         private static INancyEnvironment GetTestingEnvironment()
         {
-            var envionment =
+            var environment =
                 new DefaultNancyEnvironment();
 
-            envionment.AddValue(JsonConfiguration.Default);
+            environment.Tracing(
+                enabled: true,
+                displayErrorTraces: true);
 
-            return envionment;
+            environment.AddValue(JsonConfiguration.Default);
+
+            return environment;
         }
 
         internal class ExceptionThrowingSerializer : ISerializer

--- a/src/Nancy.Tests/Unit/ErrorHandling/DefaultStatusCodeHandlerFixture.cs
+++ b/src/Nancy.Tests/Unit/ErrorHandling/DefaultStatusCodeHandlerFixture.cs
@@ -3,6 +3,7 @@ namespace Nancy.Tests.Unit.ErrorHandling
     using System;
     using System.IO;
     using FakeItEasy;
+    using Nancy.Configuration;
     using Nancy.ErrorHandling;
     using Nancy.Responses.Negotiation;
     using Nancy.ViewEngines;
@@ -16,8 +17,15 @@ namespace Nancy.Tests.Unit.ErrorHandling
 
         public DefaultStatusCodeHandlerFixture()
         {
+            var environment =
+                new DefaultNancyEnvironment();
+
+            environment.Tracing(
+                enabled: true,
+                displayErrorTraces: true);
+
             this.responseNegotiator = A.Fake<IResponseNegotiator>();
-            this.statusCodeHandler = new DefaultStatusCodeHandler(this.responseNegotiator);
+            this.statusCodeHandler = new DefaultStatusCodeHandler(this.responseNegotiator, environment);
         }
 
         [Theory]

--- a/src/Nancy.Tests/Unit/JsonFormatterExtensionsFixtures.cs
+++ b/src/Nancy.Tests/Unit/JsonFormatterExtensionsFixtures.cs
@@ -89,6 +89,10 @@ namespace Nancy.Tests.Unit
 
             envionment.AddValue(JsonConfiguration.Default);
 
+            envionment.Tracing(
+                enabled: true,
+                displayErrorTraces: true);
+
             return envionment;
         }
     }

--- a/src/Nancy.Tests/Unit/Responses/DefaultJsonSerializerFixture.cs
+++ b/src/Nancy.Tests/Unit/Responses/DefaultJsonSerializerFixture.cs
@@ -177,13 +177,20 @@
 
         private static INancyEnvironment GetTestableEnvironment()
         {
-            return GetTestableEnvironment(x => x.Json());
+            return GetTestableEnvironment(env =>
+            {
+                env.Json();
+            });
         }
 
         private static INancyEnvironment GetTestableEnvironment(Action<INancyEnvironment> closure)
         {
             var environment =
                 new DefaultNancyEnvironment();
+
+            environment.Tracing(
+                enabled: true,
+                displayErrorTraces: true);
 
             closure.Invoke(environment);
 

--- a/src/Nancy.Tests/Unit/XmlFormatterExtensionsFixtures.cs
+++ b/src/Nancy.Tests/Unit/XmlFormatterExtensionsFixtures.cs
@@ -21,6 +21,9 @@ namespace Nancy.Tests.Unit
             this.rootPathProvider = A.Fake<IRootPathProvider>();
             var environment = new DefaultNancyEnvironment();
             environment.AddValue(XmlConfiguration.Default);
+            environment.Tracing(
+                enabled: true,
+                displayErrorTraces: true);
 
             var serializerFactory =
                 new DefaultSerializerFactory(new ISerializer[] { new DefaultXmlSerializer(environment) });

--- a/src/Nancy.ViewEngines.Razor/NancyRazorErrorView.cs
+++ b/src/Nancy.ViewEngines.Razor/NancyRazorErrorView.cs
@@ -8,6 +8,8 @@
     /// </summary>
     public class NancyRazorErrorView : NancyRazorViewBase
     {
+        private readonly TraceConfiguration traceConfiguration;
+
         private const string DisableErrorTracesTrueMessage = "Error details are currently disabled. Please set <code>StaticConfiguration.DisableErrorTraces = false;</code> to enable.";
 
         private static string template;
@@ -27,7 +29,10 @@
         /// Initializes a new instance of the <see cref="NancyRazorErrorView"/> class.
         /// </summary>
         /// <param name="message">The message.</param>
-        public NancyRazorErrorView(string message) {
+        /// <param name="traceConfiguration">A <see cref="TraceConfiguration"/> instance.</param>
+        public NancyRazorErrorView(string message, TraceConfiguration traceConfiguration)
+        {
+            this.traceConfiguration = traceConfiguration;
             this.Message = message;
         }
 
@@ -41,7 +46,7 @@
         /// </summary>
         public override void Execute()
         {
-            base.WriteLiteral(Template.Replace("[DETAILS]", StaticConfiguration.DisableErrorTraces ? DisableErrorTracesTrueMessage : this.Message));
+            base.WriteLiteral(Template.Replace("[DETAILS]", this.traceConfiguration.DisplayErrorTraces ? this.Message : DisableErrorTracesTrueMessage));
         }
 
         private static string LoadResource(string filename)

--- a/src/Nancy/Bootstrapper/FavIconApplicationStartup.cs
+++ b/src/Nancy/Bootstrapper/FavIconApplicationStartup.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using Nancy.Configuration;
 
     /// <summary>
     /// Application startup task that attempts to locate a favicon. The startup will first scan all
@@ -12,6 +13,7 @@
     /// </summary>
     public class FavIconApplicationStartup : IApplicationStartup
     {
+        private static TraceConfiguration traceConfiguration;
         private static IRootPathProvider rootPathProvider;
         private static byte[] favIcon;
 
@@ -20,9 +22,11 @@
         /// provided <see cref="IRootPathProvider"/> instance.
         /// </summary>
         /// <param name="rootPathProvider">The <see cref="IRootPathProvider"/> that should be used to scan for a favicon.</param>
-        public FavIconApplicationStartup(IRootPathProvider rootPathProvider)
+        /// <param name="environment">An <see cref="INancyEnvironment"/> instance.</param>
+        public FavIconApplicationStartup(IRootPathProvider rootPathProvider, INancyEnvironment environment)
         {
             FavIconApplicationStartup.rootPathProvider = rootPathProvider;
+            FavIconApplicationStartup.traceConfiguration = environment.GetValue<TraceConfiguration>();
         }
 
         /// <summary>
@@ -81,7 +85,7 @@
             }
             catch (Exception e)
             {
-                if (!StaticConfiguration.DisableErrorTraces)
+                if (!traceConfiguration.Enabled)
                 {
                     throw new InvalidDataException("Unable to load favicon", e);
                 }

--- a/src/Nancy/DefaultTraceConfigurationProvider.cs
+++ b/src/Nancy/DefaultTraceConfigurationProvider.cs
@@ -1,0 +1,34 @@
+namespace Nancy
+{
+    using Nancy.Configuration;
+
+    /// <summary>
+    /// Provides the default configuration for <see cref="ViewConfiguration"/>.
+    /// </summary>
+    public class DefaultTraceConfigurationProvider : NancyDefaultConfigurationProvider<TraceConfiguration>
+    {
+        private readonly IRuntimeEnvironmentInformation runtimeEnvironmentInformation;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultTraceConfigurationProvider"/> class.
+        /// </summary>
+        public DefaultTraceConfigurationProvider(IRuntimeEnvironmentInformation runtimeEnvironmentInformation)
+        {
+            this.runtimeEnvironmentInformation = runtimeEnvironmentInformation;
+        }
+
+        /// <summary>
+        /// Gets the default configuration instance to register in the <see cref="INancyEnvironment"/>.
+        /// </summary>
+        /// <returns>The configuration instance</returns>
+        public override TraceConfiguration GetDefaultConfiguration()
+        {
+            var isDebugMode =
+                this.runtimeEnvironmentInformation.IsDebug;
+
+            return new TraceConfiguration(
+                enabled: isDebugMode,
+                displayErrorTraces: isDebugMode);
+        }
+    }
+}

--- a/src/Nancy/Diagnostics/DefaultRequestTraceFactory.cs
+++ b/src/Nancy/Diagnostics/DefaultRequestTraceFactory.cs
@@ -2,12 +2,24 @@ namespace Nancy.Diagnostics
 {
     using System;
     using System.Collections.Generic;
+    using Nancy.Configuration;
 
     /// <summary>
     /// Default implementation of the <see cref="IRequestTraceFactory"/> interface.
     /// </summary>
     public class DefaultRequestTraceFactory : IRequestTraceFactory
     {
+        private readonly TraceConfiguration configuration;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultRequestTraceFactory"/> class.
+        /// </summary>
+        /// <param name="environment">An <see cref="INancyEnvironment"/> instance.</param>
+        public DefaultRequestTraceFactory(INancyEnvironment environment)
+        {
+            this.configuration = environment.GetValue<TraceConfiguration>();
+        }
+
         /// <summary>
         /// Creates an <see cref="IRequestTrace"/> instance.
         /// </summary>
@@ -27,9 +39,9 @@ namespace Nancy.Diagnostics
 
             requestTrace.RequestData = request;
 
-            requestTrace.TraceLog = (StaticConfiguration.DisableErrorTraces) ?
-                (ITraceLog)new NullLog() :
-                (ITraceLog)new DefaultTraceLog();
+            requestTrace.TraceLog = (this.configuration.DisplayErrorTraces) ?
+                (ITraceLog)new DefaultTraceLog() :
+                (ITraceLog)new NullLog();
 
             return requestTrace;
         }

--- a/src/Nancy/Diagnostics/DiagnosticsHook.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsHook.cs
@@ -115,6 +115,9 @@ namespace Nancy.Diagnostics
 
             diagnosticsEnvironment.Json(retainCasing: false);
             diagnosticsEnvironment.AddValue(ViewConfiguration.Default);
+            diagnosticsEnvironment.Tracing(
+                enabled: true,
+                displayErrorTraces: true);
 
             return diagnosticsEnvironment;
         }

--- a/src/Nancy/Diagnostics/DiagnosticsModuleCatalog.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsModuleCatalog.cs
@@ -52,7 +52,7 @@ namespace Nancy.Diagnostics
             diagContainer.Register<IBinder, DefaultBinder>();
             diagContainer.Register<IFieldNameConverter, DefaultFieldNameConverter>();
             diagContainer.Register<BindingDefaults, BindingDefaults>();
-
+            diagContainer.Register<INancyEnvironment>(diagnosticsEnvironment);
             diagContainer.Register<ISerializer>(new DefaultJsonSerializer(diagnosticsEnvironment));
 
             foreach (var diagnosticsProvider in providers)

--- a/src/Nancy/Diagnostics/Modules/InfoModule.cs
+++ b/src/Nancy/Diagnostics/Modules/InfoModule.cs
@@ -7,11 +7,12 @@
     using System.Linq;
     using System.Reflection;
     using Nancy.Bootstrapper;
+    using Nancy.Configuration;
     using Nancy.ViewEngines;
 
     public class InfoModule : DiagnosticModule
     {
-        public InfoModule(IRootPathProvider rootPathProvider, NancyInternalConfiguration configuration)
+        public InfoModule(IRootPathProvider rootPathProvider, NancyInternalConfiguration configuration, INancyEnvironment environment)
             : base("/info")
         {
             Get["/"] = _ =>
@@ -23,9 +24,11 @@
             {
                 dynamic data = new ExpandoObject();
 
+
+
                 data.Nancy = new ExpandoObject();
                 data.Nancy.Version = string.Format("v{0}", this.GetType().Assembly.GetName().Version.ToString());
-                data.Nancy.TracesDisabled = StaticConfiguration.DisableErrorTraces;
+                data.Nancy.TracesDisabled = !environment.GetValue<TraceConfiguration>().DisplayErrorTraces;
                 data.Nancy.CaseSensitivity = StaticConfiguration.CaseSensitive ? "Sensitive" : "Insensitive";
                 data.Nancy.RootPath = rootPathProvider.GetRootPath();
                 data.Nancy.Hosting = GetHosting();

--- a/src/Nancy/ErrorHandling/DefaultStatusCodeHandler.cs
+++ b/src/Nancy/ErrorHandling/DefaultStatusCodeHandler.cs
@@ -4,6 +4,7 @@ namespace Nancy.ErrorHandling
     using System.IO;
     using System.Linq;
     using System.Text;
+    using Nancy.Configuration;
     using Nancy.Extensions;
     using Nancy.IO;
     using Nancy.Responses.Negotiation;
@@ -20,12 +21,14 @@ namespace Nancy.ErrorHandling
         private readonly IDictionary<HttpStatusCode, string> errorPages;
         private readonly IResponseNegotiator responseNegotiator;
         private readonly HttpStatusCode[] supportedStatusCodes = { HttpStatusCode.NotFound, HttpStatusCode.InternalServerError };
+        private readonly TraceConfiguration configuration;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultStatusCodeHandler"/> type.
         /// </summary>
         /// <param name="responseNegotiator">The response negotiator.</param>
-        public DefaultStatusCodeHandler(IResponseNegotiator responseNegotiator)
+        /// <param name="environment">An <see cref="INancyEnvironment"/> instance.</param>
+        public DefaultStatusCodeHandler(IResponseNegotiator responseNegotiator, INancyEnvironment environment)
         {
             this.errorMessages = new Dictionary<HttpStatusCode, string>
             {
@@ -40,6 +43,7 @@ namespace Nancy.ErrorHandling
             };
 
             this.responseNegotiator = responseNegotiator;
+            this.configuration = environment.GetValue<TraceConfiguration>();
         }
 
         /// <summary>
@@ -82,7 +86,7 @@ namespace Nancy.ErrorHandling
             // from swapping a view model with a `DefaultStatusCodeHandlerResult`
             context.NegotiationContext = new NegotiationContext();
 
-            var result = new DefaultStatusCodeHandlerResult(statusCode, this.errorMessages[statusCode], StaticConfiguration.DisableErrorTraces ? DisableErrorTracesTrueMessage : context.GetExceptionDetails());
+            var result = new DefaultStatusCodeHandlerResult(statusCode, this.errorMessages[statusCode], !this.configuration.DisplayErrorTraces ? DisableErrorTracesTrueMessage : context.GetExceptionDetails());
             try
             {
                 context.Response = this.responseNegotiator.NegotiateResponse(result, context);

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -161,6 +161,7 @@
     <Compile Include="DefaultRuntimeEnvironmentInformation.cs" />
     <Compile Include="DefaultSerializerFactory.cs" />
     <Compile Include="DefaultStaticContentProvider.cs" />
+    <Compile Include="DefaultTraceConfigurationProvider.cs" />
     <Compile Include="DefaultViewConfigurationProvider.cs" />
     <Compile Include="Diagnostics\DefaultRequestTraceFactory.cs" />
     <Compile Include="Diagnostics\DefaultTraceLog.cs" />
@@ -363,6 +364,8 @@
     <Compile Include="ResponseExtensions.cs" />
     <Compile Include="RootPathApplicationStartup.cs" />
     <Compile Include="StaticConfiguration.cs" />
+    <Compile Include="TraceConfiguration.cs" />
+    <Compile Include="TraceConfigurationExtensions.cs" />
     <Compile Include="Url.cs" />
     <Compile Include="Validation\CompositeValidator.cs" />
     <Compile Include="Validation\DefaultValidatorLocator.cs" />

--- a/src/Nancy/NancyEngine.cs
+++ b/src/Nancy/NancyEngine.cs
@@ -13,6 +13,7 @@
     using Routing;
 
     using Helpers;
+    using Nancy.Configuration;
     using Responses.Negotiation;
 
     /// <summary>
@@ -30,6 +31,7 @@
         private readonly IStaticContentProvider staticContentProvider;
         private readonly IResponseNegotiator negotiator;
         private readonly CancellationTokenSource engineDisposedCts;
+        private readonly TraceConfiguration traceConfiguration;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NancyEngine"/> class.
@@ -40,12 +42,14 @@
         /// <param name="requestTracing">The request tracing instance.</param>
         /// <param name="staticContentProvider">The provider to use for serving static content</param>
         /// <param name="negotiator">The response negotiator.</param>
+        /// <param name="environment">An <see cref="INancyEnvironment"/> instance.</param>
         public NancyEngine(IRequestDispatcher dispatcher,
             INancyContextFactory contextFactory,
             IEnumerable<IStatusCodeHandler> statusCodeHandlers,
             IRequestTracing requestTracing,
             IStaticContentProvider staticContentProvider,
-            IResponseNegotiator negotiator)
+            IResponseNegotiator negotiator,
+            INancyEnvironment environment)
         {
             if (dispatcher == null)
             {
@@ -84,6 +88,7 @@
             this.staticContentProvider = staticContentProvider;
             this.negotiator = negotiator;
             this.engineDisposedCts = new CancellationTokenSource();
+            this.traceConfiguration = environment.GetValue<TraceConfiguration>();
         }
 
         /// <summary>
@@ -170,8 +175,7 @@
 
         private bool EnableTracing(NancyContext ctx)
         {
-            return StaticConfiguration.EnableRequestTracing &&
-                   !ctx.Items.ContainsKey(DiagnosticsHook.ItemsKey);
+            return this.traceConfiguration.Enabled && !ctx.Items.ContainsKey(DiagnosticsHook.ItemsKey);
         }
 
         private Guid GetDiagnosticsSessionGuid(NancyContext ctx)

--- a/src/Nancy/Responses/DefaultJsonSerializer.cs
+++ b/src/Nancy/Responses/DefaultJsonSerializer.cs
@@ -15,7 +15,8 @@
     {
         private bool? retainCasing;
         private bool? iso8601DateFormat;
-        private readonly JsonConfiguration configuration;
+        private readonly JsonConfiguration jsonConfiguration;
+        private readonly TraceConfiguration traceConfiguration;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultJsonSerializer"/> class,
@@ -24,7 +25,8 @@
         /// <param name="environment">An <see cref="INancyEnvironment"/> instance.</param>
         public DefaultJsonSerializer(INancyEnvironment environment)
         {
-            this.configuration = environment.GetValue<JsonConfiguration>();
+            this.jsonConfiguration = environment.GetValue<JsonConfiguration>();
+            this.traceConfiguration = environment.GetValue<TraceConfiguration>();
         }
 
         /// <summary>
@@ -53,7 +55,7 @@
         /// </summary>
         public bool RetainCasing
         {
-            get { return retainCasing.HasValue ? retainCasing.Value : this.configuration.RetainCasing; }
+            get { return retainCasing.HasValue ? retainCasing.Value : this.jsonConfiguration.RetainCasing; }
             set { retainCasing = value; }
         }
 
@@ -64,7 +66,7 @@
         /// </summary>
         public bool ISO8601DateFormat
         {
-            get { return iso8601DateFormat.HasValue ? iso8601DateFormat.Value : this.configuration.UseISO8601DateFormat; }
+            get { return iso8601DateFormat.HasValue ? iso8601DateFormat.Value : this.jsonConfiguration.UseISO8601DateFormat; }
             set { iso8601DateFormat = value; }
         }
 
@@ -82,14 +84,14 @@
                 var serializer = new JavaScriptSerializer(
                     null,
                     false,
-                    this.configuration.MaxJsonLength,
-                    this.configuration.MaxRecursions,
+                    this.jsonConfiguration.MaxJsonLength,
+                    this.jsonConfiguration.MaxRecursions,
                     RetainCasing,
                     ISO8601DateFormat,
-                    this.configuration.Converters,
-                    this.configuration.PrimitiveConverters);
+                    this.jsonConfiguration.Converters,
+                    this.jsonConfiguration.PrimitiveConverters);
 
-                serializer.RegisterConverters(this.configuration.Converters, this.configuration.PrimitiveConverters);
+                serializer.RegisterConverters(this.jsonConfiguration.Converters, this.jsonConfiguration.PrimitiveConverters);
 
                 try
                 {
@@ -97,7 +99,7 @@
                 }
                 catch (Exception exception)
                 {
-                    if (!StaticConfiguration.DisableErrorTraces)
+                    if (this.traceConfiguration.DisplayErrorTraces)
                     {
                         writer.Write(exception.Message);
                     }

--- a/src/Nancy/Responses/DefaultXmlSerializer.cs
+++ b/src/Nancy/Responses/DefaultXmlSerializer.cs
@@ -15,6 +15,7 @@
     public class DefaultXmlSerializer : ISerializer
     {
         private readonly XmlConfiguration configuration;
+        private readonly TraceConfiguration traceConfiguration;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultXmlSerializer"/> class,
@@ -24,6 +25,7 @@
         public DefaultXmlSerializer(INancyEnvironment environment)
         {
             this.configuration = environment.GetValue<XmlConfiguration>();
+            this.traceConfiguration = environment.GetValue<TraceConfiguration>();
         }
 
         /// <summary>
@@ -69,7 +71,7 @@
             }
             catch (Exception exception)
             {
-                if (!StaticConfiguration.DisableErrorTraces)
+                if (this.traceConfiguration.DisplayErrorTraces)
                 {
                     var bytes = Encoding.UTF8.GetBytes(exception.Message);
                     outputStream.Write(bytes, 0, exception.Message.Length);

--- a/src/Nancy/Responses/Negotiation/ViewProcessor.cs
+++ b/src/Nancy/Responses/Negotiation/ViewProcessor.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
-
+    using Nancy.Configuration;
     using Nancy.ViewEngines;
 
     /// <summary>
@@ -11,15 +11,18 @@
     public class ViewProcessor : IResponseProcessor
     {
         private readonly IViewFactory viewFactory;
+        private readonly TraceConfiguration traceConfiguration;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ViewProcessor"/> class,
         /// with the provided <paramref name="viewFactory"/>.
         /// </summary>
         /// <param name="viewFactory">The view factory that should be used to render views.</param>
-        public ViewProcessor(IViewFactory viewFactory)
+        /// <param name="environment">An <see cref="INancyEnvironment"/> instance.</param>
+        public ViewProcessor(IViewFactory viewFactory, INancyEnvironment environment)
         {
             this.viewFactory = viewFactory;
+            this.traceConfiguration = environment.GetValue<TraceConfiguration>();
         }
 
         /// <summary>
@@ -59,7 +62,9 @@
         {
             var viewResponse = this.viewFactory.RenderView(context.NegotiationContext.ViewName, model, GetViewLocationContext(context));
 
-            return StaticConfiguration.DisableErrorTraces ? viewResponse : new MaterialisingResponse(viewResponse);
+            return this.traceConfiguration.DisplayErrorTraces
+                ? new MaterialisingResponse(viewResponse)
+                : viewResponse;
         }
 
         private static ViewLocationContext GetViewLocationContext(NancyContext context)

--- a/src/Nancy/StaticConfiguration.cs
+++ b/src/Nancy/StaticConfiguration.cs
@@ -9,13 +9,9 @@ namespace Nancy
     public static class StaticConfiguration
     {
         private static bool? isRunningDebug;
-        //private static bool? disableCaches;
-
-        //private static bool? disableErrorTraces;
 
         static StaticConfiguration()
         {
-            //disableErrorTraces = !(disableCaches = IsRunningDebug);
             CaseSensitive = false;
             RequestQueryFormMultipartLimit = 1000;
             AllowFileStreamUploadAsync = true;

--- a/src/Nancy/StaticConfiguration.cs
+++ b/src/Nancy/StaticConfiguration.cs
@@ -9,32 +9,16 @@ namespace Nancy
     public static class StaticConfiguration
     {
         private static bool? isRunningDebug;
-        private static bool? disableCaches;
+        //private static bool? disableCaches;
 
-        private static bool? disableErrorTraces;
+        //private static bool? disableErrorTraces;
 
         static StaticConfiguration()
         {
-            disableErrorTraces = !(disableCaches = IsRunningDebug);
+            //disableErrorTraces = !(disableCaches = IsRunningDebug);
             CaseSensitive = false;
             RequestQueryFormMultipartLimit = 1000;
             AllowFileStreamUploadAsync = true;
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether or not to disable traces in error messages
-        /// </summary>
-        [Description("Disables trace output in the default 500 error pages.")]
-        public static bool DisableErrorTraces
-        {
-            get
-            {
-                return disableErrorTraces ?? (bool)(disableErrorTraces = IsRunningDebug);
-            }
-            set
-            {
-                disableErrorTraces = value;
-            }
         }
 
         /// <summary>
@@ -82,12 +66,6 @@ namespace Nancy
                 return false;
             }
         }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether or not to enable request tracing
-        /// </summary>
-        [Description("Enable request tracing.")]
-        public static bool EnableRequestTracing { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether or not to disable request stream switching

--- a/src/Nancy/TraceConfiguration.cs
+++ b/src/Nancy/TraceConfiguration.cs
@@ -1,0 +1,31 @@
+namespace Nancy
+{
+    /// <summary>
+    /// Configuration for tracing.
+    /// </summary>
+    public class TraceConfiguration
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TraceConfiguration"/> class.
+        /// </summary>
+        /// <param name="enabled">Determines if tracing should be enabled.</param>
+        /// <param name="displayErrorTraces">Determines if traces should be displayed in error messages.</param>
+        public TraceConfiguration(bool enabled, bool displayErrorTraces)
+        {
+            this.Enabled = enabled;
+            this.DisplayErrorTraces = displayErrorTraces;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether or not to enable request tracing.
+        /// </summary>
+        /// <value><see langword="true"/> if tracing should be enabled, otherwise <see langword="false"/>.</value>
+        public bool Enabled { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether or not to display traces in error messages.
+        /// </summary>
+        /// <value><see langword="true"/> traces should be displayed in error messages, otherwise <see langword="false"/>.</value>
+        public bool DisplayErrorTraces { get; private set; }
+    }
+}

--- a/src/Nancy/TraceConfigurationExtensions.cs
+++ b/src/Nancy/TraceConfigurationExtensions.cs
@@ -1,0 +1,23 @@
+namespace Nancy
+{
+    using Nancy.Configuration;
+
+    /// <summary>
+    /// Contains <see cref="TraceConfiguration"/> configuration extensions for <see cref="INancyEnvironment"/>.
+    /// </summary>
+    public static class TraceConfigurationExtensions
+    {
+        /// <summary>
+        /// Configures <see cref="TraceConfiguration"/>.
+        /// </summary>
+        /// <param name="environment"><see cref="INancyEnvironment"/> that should be configured.</param>
+        /// <param name="enabled"><see langword="true"/> if tracing should be enabled, otherwise <see langword="false"/>.</param>
+        /// <param name="displayErrorTraces"><see langword="true"/> traces should be displayed in error messages, otherwise <see langword="false"/>.</param>
+        public static void Tracing(this INancyEnvironment environment, bool enabled, bool displayErrorTraces)
+        {
+            environment.AddValue(new TraceConfiguration(
+                enabled: enabled,
+                displayErrorTraces: displayErrorTraces));
+        }
+    }
+}

--- a/src/Nancy/TraceConfigurationExtensions.cs
+++ b/src/Nancy/TraceConfigurationExtensions.cs
@@ -10,7 +10,7 @@ namespace Nancy
         /// <summary>
         /// Configures <see cref="TraceConfiguration"/>.
         /// </summary>
-        /// <param name="environment"><see cref="INancyEnvironment"/> that should be configured.</param>
+        /// <param name="environment">An <see cref="INancyEnvironment"/> that should be configured.</param>
         /// <param name="enabled"><see langword="true"/> if tracing should be enabled, otherwise <see langword="false"/>.</param>
         /// <param name="displayErrorTraces"><see langword="true"/> traces should be displayed in error messages, otherwise <see langword="false"/>.</param>
         public static void Tracing(this INancyEnvironment environment, bool enabled, bool displayErrorTraces)


### PR DESCRIPTION
Migrated tracing related settings, from `StaticConfiguration` to the new config API.

There is no `TraceConfiguration.Default` because the default configuration rely on being able to tell if we're running in debug mode or not. The old static settings did the same, so the `DefaultTraceConfigurationProvider` class takes a dependency on `IRuntimeEnvironmentInformation` to gain access so `IsDebugMode`

The `INancyEnvironment` extension method for tracing is called `Tracing` and has two, mandatory, configurations; `Enabled` and `DisplayErrorTraces`. Both of these existed on `StaticConfiguration` but was renamed to be more aligned with the fact that they're not in a config entity.

