### PR TITLE
Implemented ITypeCatalog and IAssemblyCatalog

### DIFF
--- a/src/Nancy/AppDomainAssemblyCatalog.cs
+++ b/src/Nancy/AppDomainAssemblyCatalog.cs
@@ -1,0 +1,145 @@
+namespace Nancy
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+
+    /// <summary>
+    /// Default implementation of the <see cref="IAssemblyCatalog"/> interface, based on
+    /// retrieving <see cref="Assembly"/> information from <see cref="AppDomain.CurrentDomain"/>.
+    /// </summary>
+    public class AppDomainAssemblyCatalog : IAssemblyCatalog
+    {
+        private readonly Lazy<IReadOnlyCollection<Assembly>> assemblies = new Lazy<IReadOnlyCollection<Assembly>>(GetAllAssemblies);
+
+        /// <summary>
+        /// Gets all <see cref="Assembly"/> instances in the catalog.
+        /// </summary>
+        /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Assembly"/> instances.</returns>
+        public IReadOnlyCollection<Assembly> GetAssemblies()
+        {
+            return this.assemblies.Value;
+        }
+
+        private static IReadOnlyCollection<Assembly> GetAllAssemblies()
+        {
+            EnsureNancyReferencingAssembliesAreLoaded();
+
+            return GetAssembliesInAppDomain();
+        }
+
+        private static IReadOnlyCollection<Assembly> GetAssembliesInAppDomain()
+        {
+            var assemblies = AppDomain.CurrentDomain
+                                      .GetAssemblies()
+                                      .Where(IsNancyReferencingAssembly)
+                                      .Where(assembly => !assembly.IsDynamic)
+                                      .Where(assembly => !assembly.ReflectionOnly)
+                                      .ToArray();
+
+            return new ReadOnlyCollection<Assembly>(assemblies);
+        }
+
+        private static bool IsNancyReferencingAssembly(Assembly assembly)
+        {
+            if (assembly.Equals(typeof(INancyEngine).Assembly))
+            {
+                return true;
+            }
+
+            if (assembly.GetName().Name.Equals("Nancy.Testing", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (assembly.GetReferencedAssemblies().Any(reference => reference.Name.StartsWith("Nancy", StringComparison.OrdinalIgnoreCase)))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static void EnsureNancyReferencingAssembliesAreLoaded()
+        {
+            var assemblyPaths = GetAssembliesInAppDomain()
+                .Select(assembly => assembly.Location)
+                .ToArray();
+
+            foreach (var directory in GetAssemblyDirectories())
+            {
+                var unloadedAssemblies = Directory
+                    .GetFiles(directory, "*.dll")
+                    .Where(file => !assemblyPaths.Contains(file, StringComparer.OrdinalIgnoreCase))
+                    .ToArray();
+
+                foreach (var unloadedAssembly in unloadedAssemblies)
+                {
+                    var reflectionAssembly =
+                        SafeLoadReflectionOnlyAssembly(unloadedAssembly);
+
+                    if (reflectionAssembly == null)
+                    {
+                        continue;
+                    }
+
+                    if (!reflectionAssembly.GetReferencedAssemblies().Any(referece =>referece.Name.StartsWith("Nancy", StringComparison.OrdinalIgnoreCase)))
+                    {
+                        continue;
+                    }
+
+                    SafeLoadAssemblyIntoApplicationDomain(reflectionAssembly);
+                }
+            }
+        }
+
+        private static void SafeLoadAssemblyIntoApplicationDomain(Assembly reflectionAssembly)
+        {
+            try
+            {
+                Assembly.Load(reflectionAssembly.GetName());
+            }
+            catch
+            {
+            }
+        }
+
+        private static Assembly SafeLoadReflectionOnlyAssembly(string assemblyPath)
+        {
+            try
+            {
+                return Assembly.ReflectionOnlyLoadFrom(assemblyPath);
+            }
+            catch (BadImageFormatException)
+            {
+                //the assembly maybe it's not managed code
+            }
+            catch (FileLoadException)
+            {
+                //the assembly might already be loaded
+            }
+
+            return null;
+        }
+
+        private static IEnumerable<string> GetAssemblyDirectories()
+        {
+            var directories = AppDomain.CurrentDomain.SetupInformation.PrivateBinPath != null
+                ? AppDomain.CurrentDomain.SetupInformation.PrivateBinPath.Split(';')
+                : new string[] { };
+
+            foreach (var directory in directories.Where(directory => !string.IsNullOrWhiteSpace(directory)))
+            {
+                yield return directory;
+            }
+
+            if (AppDomain.CurrentDomain.SetupInformation.PrivateBinPathProbe == null)
+            {
+                yield return AppDomain.CurrentDomain.SetupInformation.ApplicationBase;
+            }
+        }
+    }
+}

--- a/src/Nancy/AppDomainAssemblyCatalog.cs
+++ b/src/Nancy/AppDomainAssemblyCatalog.cs
@@ -13,7 +13,8 @@ namespace Nancy
     /// </summary>
     public class AppDomainAssemblyCatalog : IAssemblyCatalog
     {
-        private readonly Lazy<IReadOnlyCollection<Assembly>> assemblies = new Lazy<IReadOnlyCollection<Assembly>>(GetAllAssemblies);
+        private readonly Lazy<IReadOnlyCollection<Assembly>> assemblies =
+            new Lazy<IReadOnlyCollection<Assembly>>(GetAllAssemblies);
 
         /// <summary>
         /// Gets all <see cref="Assembly"/> instances in the catalog.
@@ -34,11 +35,11 @@ namespace Nancy
         private static IReadOnlyCollection<Assembly> GetAssembliesInAppDomain()
         {
             var assemblies = AppDomain.CurrentDomain
-                                      .GetAssemblies()
-                                      .Where(IsNancyReferencingAssembly)
-                                      .Where(assembly => !assembly.IsDynamic)
-                                      .Where(assembly => !assembly.ReflectionOnly)
-                                      .ToArray();
+                .GetAssemblies()
+                .Where(IsNancyReferencingAssembly)
+                .Where(assembly => !assembly.IsDynamic)
+                .Where(assembly => !assembly.ReflectionOnly)
+                .ToArray();
 
             return new ReadOnlyCollection<Assembly>(assemblies);
         }
@@ -86,7 +87,7 @@ namespace Nancy
                         continue;
                     }
 
-                    if (!reflectionAssembly.GetReferencedAssemblies().Any(referece =>referece.Name.StartsWith("Nancy", StringComparison.OrdinalIgnoreCase)))
+                    if (!reflectionAssembly.GetReferencedAssemblies().Any(referece => referece.Name.Equals("Nancy", StringComparison.OrdinalIgnoreCase)))
                     {
                         continue;
                     }
@@ -115,7 +116,7 @@ namespace Nancy
             }
             catch (BadImageFormatException)
             {
-                //the assembly maybe it's not managed code
+                //the assembly maybe it's not managed assembly
             }
             catch (FileLoadException)
             {

--- a/src/Nancy/AppDomainAssemblyCatalog.cs
+++ b/src/Nancy/AppDomainAssemblyCatalog.cs
@@ -12,13 +12,7 @@ namespace Nancy
     /// </summary>
     public class AppDomainAssemblyCatalog : AssemblyCatalogBase
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AppDomainAssemblyCatalog"/> class.
-        /// </summary>
-        public AppDomainAssemblyCatalog()
-        {
-            this.EnsureNancyReferencingAssembliesAreLoaded();
-        }
+        private bool loadedReferencingAssemblies;
 
         /// <summary>
         /// Get all available <see cref="Assembly"/> instances.
@@ -26,6 +20,11 @@ namespace Nancy
         /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Assembly"/> instances.</returns>
         protected override IReadOnlyCollection<Assembly> GetAvailableAssemblies()
         {
+            if (!this.loadedReferencingAssemblies)
+            {
+                this.EnsureNancyReferencingAssembliesAreLoaded();
+            }
+
             return AppDomain.CurrentDomain
                 .GetAssemblies()
                 .Where(assembly => !assembly.IsDynamic)
@@ -35,6 +34,8 @@ namespace Nancy
 
         private void EnsureNancyReferencingAssembliesAreLoaded()
         {
+            this.loadedReferencingAssemblies = true;
+
             var assemblyPaths = this.GetAvailableAssemblies()
                 .Select(assembly => assembly.Location)
                 .ToArray();

--- a/src/Nancy/AssemblyCatalogBase.cs
+++ b/src/Nancy/AssemblyCatalogBase.cs
@@ -1,0 +1,43 @@
+namespace Nancy
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+
+    /// <summary>
+    /// Base class implementation of <see cref="IAssemblyCatalog"/> which adds per-strategy caching.
+    /// </summary>
+    public abstract class AssemblyCatalogBase : IAssemblyCatalog
+    {
+        private readonly Lazy<IReadOnlyCollection<Assembly>> assemblies;
+        private readonly ConcurrentDictionary<AssemblyResolveStrategy, IReadOnlyCollection<Assembly>> cache;
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssemblyCatalogBase"/> class.
+        /// </summary>
+        protected AssemblyCatalogBase()
+        {
+            this.cache = new ConcurrentDictionary<AssemblyResolveStrategy, IReadOnlyCollection<Assembly>>();
+            this.assemblies = new Lazy<IReadOnlyCollection<Assembly>>(this.GetAvailableAssemblies);
+        }
+
+        /// <summary>
+        /// Gets all <see cref="Assembly"/> instances in the catalog.
+        /// </summary>
+        /// <param name="strategy">An <see cref="AssemblyResolveStrategy"/> that should be used when resolving assemblies.</param>
+        /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Assembly"/> instances.</returns>
+        public IReadOnlyCollection<Assembly> GetAssemblies(AssemblyResolveStrategy strategy)
+        {
+            return this.cache.GetOrAdd(strategy, s => this.assemblies.Value.Where(s.Invoke).ToArray());
+        }
+
+        /// <summary>
+        /// Get all available <see cref="Assembly"/> instances.
+        /// </summary>
+        /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Assembly"/> instances.</returns>
+        protected abstract IReadOnlyCollection<Assembly> GetAvailableAssemblies();
+    }
+}

--- a/src/Nancy/AssemblyCatalogBase.cs
+++ b/src/Nancy/AssemblyCatalogBase.cs
@@ -14,7 +14,6 @@ namespace Nancy
         private readonly Lazy<IReadOnlyCollection<Assembly>> assemblies;
         private readonly ConcurrentDictionary<AssemblyResolveStrategy, IReadOnlyCollection<Assembly>> cache;
 
-
         /// <summary>
         /// Initializes a new instance of the <see cref="AssemblyCatalogBase"/> class.
         /// </summary>

--- a/src/Nancy/AssemblyCatalogExtensions.cs
+++ b/src/Nancy/AssemblyCatalogExtensions.cs
@@ -1,0 +1,21 @@
+namespace Nancy
+{
+    using System.Collections.Generic;
+    using System.Reflection;
+
+    /// <summary>
+    ///  Contains extension methods for <see cref="IAssemblyCatalog"/> implementations.
+    /// </summary>
+    public static class AssemblyCatalogExtensions
+    {
+        /// <summary>
+        /// Gets all <see cref="Assembly"/> instances using the <see cref="AssemblyResolveStrategies.All"/> strategy.
+        /// </summary>
+        /// <param name="assemblyCatalog">The <see cref="IAssemblyCatalog"/> instance that the assemblies should be reolved from.</param>
+        /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Assembly"/> instances.</returns>
+        public static IReadOnlyCollection<Assembly> GetAssemblies(this IAssemblyCatalog assemblyCatalog)
+        {
+            return assemblyCatalog.GetAssemblies(AssemblyResolveStrategies.All);
+        }
+    }
+}

--- a/src/Nancy/AssemblyResolveStrategies.cs
+++ b/src/Nancy/AssemblyResolveStrategies.cs
@@ -1,0 +1,42 @@
+namespace Nancy
+{
+    using System;
+    using System.Linq;
+
+    /// <summary>
+    /// Default <see cref="AssemblyResolveStrategy"/> implementations.
+    /// </summary>
+    public class AssemblyResolveStrategies
+    {
+        /// <summary>
+        /// Resolve all available assemblies.
+        /// </summary>
+        public static readonly AssemblyResolveStrategy All = assembly =>
+        {
+            return true;
+        };
+
+        /// <summary>
+        /// Resolves all assemblies that references Nancy.
+        /// </summary>
+        public static readonly AssemblyResolveStrategy NancyReferencing = assembly =>
+        {
+            if (assembly.Equals(typeof(INancyEngine).Assembly))
+            {
+                return true;
+            }
+
+            if (assembly.GetName().Name.Equals("Nancy.Testing", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (assembly.GetReferencedAssemblies().Any(reference => reference.Name.StartsWith("Nancy", StringComparison.OrdinalIgnoreCase)))
+            {
+                return true;
+            }
+
+            return false;
+        };
+    }
+}

--- a/src/Nancy/AssemblyResolveStrategy.cs
+++ b/src/Nancy/AssemblyResolveStrategy.cs
@@ -1,0 +1,11 @@
+namespace Nancy
+{
+    using System.Reflection;
+
+    /// <summary>
+    /// Predicate used to decide if a <see cref="Assembly"/> should be included when resolving assemblies.
+    /// </summary>
+    /// <param name="assembly">The <see cref="Assembly"/> that is being inspected.</param>
+    /// <value><see langword="true"/> if the assembly should be included in the result, otherwise <see langword="false"/>.</value>
+    public delegate bool AssemblyResolveStrategy(Assembly assembly);
+}

--- a/src/Nancy/DefaultTypeCatalog.cs
+++ b/src/Nancy/DefaultTypeCatalog.cs
@@ -1,0 +1,59 @@
+﻿namespace Nancy
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Nancy.Extensions;
+
+    /// <summary>
+    /// Default implementation of the <see cref="ITypeCatalog"/> interface.
+    /// </summary>
+    public class DefaultTypeCatalog : ITypeCatalog
+    {
+        private readonly IAssemblyCatalog assemblyCatalog;
+        private readonly ConcurrentDictionary<Type, IReadOnlyCollection<Type>> cache;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultTypeCatalog"/> class.
+        /// </summary>
+        /// <param name="assemblyCatalog">An <see cref="IAssemblyCatalog"/> instanced, used to get the assemblies that types should be resolved from.</param>
+        public DefaultTypeCatalog(IAssemblyCatalog assemblyCatalog)
+        {
+            this.assemblyCatalog = assemblyCatalog;
+            this.cache = new ConcurrentDictionary<Type, IReadOnlyCollection<Type>>();
+        }
+
+        /// <summary>
+        /// Gets all types that are assignable to the provided <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> that returned types should be assignable to.</param>
+        /// <param name="strategy">A <see cref="TypeResolveStrategy"/> that should be used then retrieving types.</param>
+        /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Type"/> instances.</returns>
+        public IReadOnlyCollection<Type> GetTypesAssignableTo(Type type, TypeResolveStrategy strategy)
+        {
+            return this.cache.GetOrAdd(type, t => this.GetTypesAssignableTo(type)).Where(strategy.Invoke).ToArray();
+        }
+
+        /// <summary>
+        /// Gets all types that are assignable to the provided <typeparamref name="TType"/>.
+        /// </summary>
+        /// <typeparam name="TType">The <see cref="Type"/> that returned types should be assignable to.</typeparam>
+        /// <param name="strategy">A <see cref="TypeResolveStrategy"/> that should be used then retrieving types.</param>
+        /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Type"/> instances.</returns>
+        public IReadOnlyCollection<Type> GetTypesAssignableTo<TType>(TypeResolveStrategy strategy)
+        {
+            return this.GetTypesAssignableTo(typeof(TType), strategy);
+        }
+
+        private IReadOnlyCollection<Type> GetTypesAssignableTo(Type type)
+        {
+            return this.assemblyCatalog
+                            .GetAssemblies()
+                            .SelectMany(assembly => assembly.SafeGetExportedTypes())
+                            .Where(type.IsAssignableFrom)
+                            .Where(t => !t.IsAbstract)
+                            .ToArray();
+        }
+    }
+}

--- a/src/Nancy/DefaultTypeCatalog.cs
+++ b/src/Nancy/DefaultTypeCatalog.cs
@@ -12,6 +12,7 @@
     public class DefaultTypeCatalog : ITypeCatalog
     {
         private readonly IAssemblyCatalog assemblyCatalog;
+
         private readonly ConcurrentDictionary<Type, IReadOnlyCollection<Type>> cache;
 
         /// <summary>
@@ -35,25 +36,14 @@
             return this.cache.GetOrAdd(type, t => this.GetTypesAssignableTo(type)).Where(strategy.Invoke).ToArray();
         }
 
-        /// <summary>
-        /// Gets all types that are assignable to the provided <typeparamref name="TType"/>.
-        /// </summary>
-        /// <typeparam name="TType">The <see cref="Type"/> that returned types should be assignable to.</typeparam>
-        /// <param name="strategy">A <see cref="TypeResolveStrategy"/> that should be used then retrieving types.</param>
-        /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Type"/> instances.</returns>
-        public IReadOnlyCollection<Type> GetTypesAssignableTo<TType>(TypeResolveStrategy strategy)
-        {
-            return this.GetTypesAssignableTo(typeof(TType), strategy);
-        }
-
         private IReadOnlyCollection<Type> GetTypesAssignableTo(Type type)
         {
             return this.assemblyCatalog
-                            .GetAssemblies()
-                            .SelectMany(assembly => assembly.SafeGetExportedTypes())
-                            .Where(type.IsAssignableFrom)
-                            .Where(t => !t.IsAbstract)
-                            .ToArray();
+                .GetAssemblies()
+                .SelectMany(assembly => assembly.SafeGetExportedTypes())
+                .Where(type.IsAssignableFrom)
+                .Where(t => !t.IsAbstract)
+                .ToArray();
         }
     }
 }

--- a/src/Nancy/DefaultTypeCatalog.cs
+++ b/src/Nancy/DefaultTypeCatalog.cs
@@ -12,7 +12,6 @@
     public class DefaultTypeCatalog : ITypeCatalog
     {
         private readonly IAssemblyCatalog assemblyCatalog;
-
         private readonly ConcurrentDictionary<Type, IReadOnlyCollection<Type>> cache;
 
         /// <summary>
@@ -29,7 +28,7 @@
         /// Gets all types that are assignable to the provided <paramref name="type"/>.
         /// </summary>
         /// <param name="type">The <see cref="Type"/> that returned types should be assignable to.</param>
-        /// <param name="strategy">A <see cref="TypeResolveStrategy"/> that should be used then retrieving types.</param>
+        /// <param name="strategy">A <see cref="TypeResolveStrategy"/> that should be used when retrieving types.</param>
         /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Type"/> instances.</returns>
         public IReadOnlyCollection<Type> GetTypesAssignableTo(Type type, TypeResolveStrategy strategy)
         {
@@ -39,7 +38,7 @@
         private IReadOnlyCollection<Type> GetTypesAssignableTo(Type type)
         {
             return this.assemblyCatalog
-                .GetAssemblies()
+                .GetAssemblies(AssemblyResolveStrategies.NancyReferencing)
                 .SelectMany(assembly => assembly.SafeGetExportedTypes())
                 .Where(type.IsAssignableFrom)
                 .Where(t => !t.IsAbstract)

--- a/src/Nancy/IAssemblyCatalog.cs
+++ b/src/Nancy/IAssemblyCatalog.cs
@@ -1,0 +1,17 @@
+namespace Nancy
+{
+    using System.Collections.Generic;
+    using System.Reflection;
+
+    /// <summary>
+    /// Defines the functionality of an assembly catalog.
+    /// </summary>
+    public interface IAssemblyCatalog
+    {
+        /// <summary>
+        /// Gets all <see cref="Assembly"/> instances in the catalog.
+        /// </summary>
+        /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Assembly"/> instances.</returns>
+        IReadOnlyCollection<Assembly> GetAssemblies();
+    }
+}

--- a/src/Nancy/IAssemblyCatalog.cs
+++ b/src/Nancy/IAssemblyCatalog.cs
@@ -11,7 +11,8 @@ namespace Nancy
         /// <summary>
         /// Gets all <see cref="Assembly"/> instances in the catalog.
         /// </summary>
+        /// <param name="strategy">An <see cref="AssemblyResolveStrategy"/> that should be used when resolving assemblies.</param>
         /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Assembly"/> instances.</returns>
-        IReadOnlyCollection<Assembly> GetAssemblies();
+        IReadOnlyCollection<Assembly> GetAssemblies(AssemblyResolveStrategy strategy);
     }
 }

--- a/src/Nancy/ITypeCatalog.cs
+++ b/src/Nancy/ITypeCatalog.cs
@@ -12,7 +12,7 @@
         /// Gets all types that are assignable to the provided <paramref name="type"/>.
         /// </summary>
         /// <param name="type">The <see cref="Type"/> that returned types should be assignable to.</param>
-        /// <param name="strategy">A <see cref="TypeResolveStrategy"/> that should be used then retrieving types.</param>
+        /// <param name="strategy">A <see cref="TypeResolveStrategy"/> that should be used when retrieving types.</param>
         /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Type"/> instances.</returns>
         IReadOnlyCollection<Type> GetTypesAssignableTo(Type type, TypeResolveStrategy strategy);
     }

--- a/src/Nancy/ITypeCatalog.cs
+++ b/src/Nancy/ITypeCatalog.cs
@@ -1,0 +1,27 @@
+﻿namespace Nancy
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Defines the functionality of a type catalog.
+    /// </summary>
+    public interface ITypeCatalog
+    {
+        /// <summary>
+        /// Gets all types that are assignable to the provided <paramref name="type"/>.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> that returned types should be assignable to.</param>
+        /// <param name="strategy">A <see cref="TypeResolveStrategy"/> that should be used then retrieving types.</param>
+        /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Type"/> instances.</returns>
+        IReadOnlyCollection<Type> GetTypesAssignableTo(Type type, TypeResolveStrategy strategy);
+
+        /// <summary>
+        /// Gets all types that are assignable to the provided <typeparamref name="TType"/>.
+        /// </summary>
+        /// <typeparam name="TType">The <see cref="Type"/> that returned types should be assignable to.</typeparam>
+        /// <param name="strategy">A <see cref="TypeResolveStrategy"/> that should be used then retrieving types.</param>
+        /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Type"/> instances.</returns>
+        IReadOnlyCollection<Type> GetTypesAssignableTo<TType>(TypeResolveStrategy strategy);
+    }
+}

--- a/src/Nancy/ITypeCatalog.cs
+++ b/src/Nancy/ITypeCatalog.cs
@@ -15,13 +15,5 @@
         /// <param name="strategy">A <see cref="TypeResolveStrategy"/> that should be used then retrieving types.</param>
         /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Type"/> instances.</returns>
         IReadOnlyCollection<Type> GetTypesAssignableTo(Type type, TypeResolveStrategy strategy);
-
-        /// <summary>
-        /// Gets all types that are assignable to the provided <typeparamref name="TType"/>.
-        /// </summary>
-        /// <typeparam name="TType">The <see cref="Type"/> that returned types should be assignable to.</typeparam>
-        /// <param name="strategy">A <see cref="TypeResolveStrategy"/> that should be used then retrieving types.</param>
-        /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Type"/> instances.</returns>
-        IReadOnlyCollection<Type> GetTypesAssignableTo<TType>(TypeResolveStrategy strategy);
     }
 }

--- a/src/Nancy/ITypeCatalogExtensions.cs
+++ b/src/Nancy/ITypeCatalogExtensions.cs
@@ -1,0 +1,33 @@
+namespace Nancy
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Contains extension methods for <see cref="ITypeCatalog"/> implementations.
+    /// </summary>
+    public static class ITypeCatalogExtensions
+    {
+        /// <summary>
+        /// Gets all <see cref="Type"/> instances that are assigneable to <paramref name="type"/>, using <see cref="TypeResolveStrategies.All"/>.
+        /// </summary>
+        /// <param name="typeCatalog">The <see cref="ITypeCatalog"/> instance where the types should be retrieved from.</param>
+        /// <param name="type">The <see cref="Type"/> that all returned types should be assingable to.</param>
+        /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Type"/> instances.</returns>
+        public static IReadOnlyCollection<Type> GetTypesAssignableTo(this ITypeCatalog typeCatalog, Type type)
+        {
+            return typeCatalog.GetTypesAssignableTo(type, TypeResolveStrategies.All);
+        }
+
+        /// <summary>
+        /// Gets all <see cref="Type"/> instances that are assigneable to <typeparamref name="TType"/>, using <see cref="TypeResolveStrategies.All"/>.
+        /// </summary>
+        /// <param name="typeCatalog">The <see cref="ITypeCatalog"/> instance where the types should be retrieved from.</param>
+        /// <typeparam name="TType">The <see cref="Type"/> that all returned types should be assingable to.</typeparam>
+        /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Type"/> instances.</returns>
+        public static IReadOnlyCollection<Type> GetTypesAssignableTo<TType>(this ITypeCatalog typeCatalog)
+        {
+            return typeCatalog.GetTypesAssignableTo(typeof(TType), TypeResolveStrategies.All);
+        }
+    }
+}

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -109,6 +109,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AppDomainAssemblyCatalog.cs" />
     <Compile Include="AsyncNamedPipelineBase.cs" />
     <Compile Include="Bootstrapper\AppDomainAssemblyTypeScanner.cs" />
     <Compile Include="Bootstrapper\IRequestStartup.cs" />
@@ -160,6 +161,7 @@
     <Compile Include="DefaultSerializerFactory.cs" />
     <Compile Include="DefaultStaticContentProvider.cs" />
     <Compile Include="DefaultTraceConfigurationProvider.cs" />
+    <Compile Include="DefaultTypeCatalog.cs" />
     <Compile Include="DefaultViewConfigurationProvider.cs" />
     <Compile Include="Diagnostics\DefaultRequestTraceFactory.cs" />
     <Compile Include="Diagnostics\DefaultTraceLog.cs" />
@@ -193,10 +195,13 @@
     <Compile Include="Diagnostics\DiagnosticsViewRenderer.cs" />
     <Compile Include="Helpers\CacheHelpers.cs" />
     <Compile Include="Helpers\ExceptionExtensions.cs" />
+    <Compile Include="IAssemblyCatalog.cs" />
     <Compile Include="IncludeInNancyAssemblyScanningAttribute.cs" />
     <Compile Include="IRuntimeEnvironmentInformation.cs" />
     <Compile Include="ISerializerFactory.cs" />
     <Compile Include="IStaticContentProvider.cs" />
+    <Compile Include="ITypeCatalog.cs" />
+    <Compile Include="ITypeCatalogExtensions.cs" />
     <Compile Include="Json\Converters\TupleConverter.cs" />
     <Compile Include="Json\DefaultJsonConfigurationProvider.cs" />
     <Compile Include="Json\JavaScriptPrimitiveConverter.cs" />
@@ -314,6 +319,8 @@
     <Compile Include="Routing\Trie\RouteResolverTrie.cs" />
     <Compile Include="Routing\Trie\SegmentMatch.cs" />
     <Compile Include="Routing\Trie\TrieNodeFactory.cs" />
+    <Compile Include="TypeResolveStrategies.cs" />
+    <Compile Include="TypeResolveStrategy.cs" />
     <Compile Include="Security\SSLProxy.cs" />
     <Compile Include="Session\CookieBasedSessionsConfiguration.cs" />
     <Compile Include="StaticContent.cs" />

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -110,6 +110,8 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="AppDomainAssemblyCatalog.cs" />
+    <Compile Include="AssemblyResolveStrategies.cs" />
+    <Compile Include="AssemblyResolveStrategy.cs" />
     <Compile Include="AsyncNamedPipelineBase.cs" />
     <Compile Include="Bootstrapper\AppDomainAssemblyTypeScanner.cs" />
     <Compile Include="Bootstrapper\IRequestStartup.cs" />
@@ -201,7 +203,7 @@
     <Compile Include="ISerializerFactory.cs" />
     <Compile Include="IStaticContentProvider.cs" />
     <Compile Include="ITypeCatalog.cs" />
-    <Compile Include="ITypeCatalogExtensions.cs" />
+    <Compile Include="TypeCatalogExtensions.cs" />
     <Compile Include="Json\Converters\TupleConverter.cs" />
     <Compile Include="Json\DefaultJsonConfigurationProvider.cs" />
     <Compile Include="Json\JavaScriptPrimitiveConverter.cs" />

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -111,6 +111,7 @@
     </Compile>
     <Compile Include="AppDomainAssemblyCatalog.cs" />
     <Compile Include="AssemblyCatalogBase.cs" />
+    <Compile Include="AssemblyCatalogExtensions.cs" />
     <Compile Include="AssemblyResolveStrategies.cs" />
     <Compile Include="AssemblyResolveStrategy.cs" />
     <Compile Include="AsyncNamedPipelineBase.cs" />

--- a/src/Nancy/Nancy.csproj
+++ b/src/Nancy/Nancy.csproj
@@ -110,6 +110,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="AppDomainAssemblyCatalog.cs" />
+    <Compile Include="AssemblyCatalogBase.cs" />
     <Compile Include="AssemblyResolveStrategies.cs" />
     <Compile Include="AssemblyResolveStrategy.cs" />
     <Compile Include="AsyncNamedPipelineBase.cs" />

--- a/src/Nancy/TypeCatalogExtensions.cs
+++ b/src/Nancy/TypeCatalogExtensions.cs
@@ -9,7 +9,7 @@ namespace Nancy
     public static class TypeCatalogExtensions
     {
         /// <summary>
-        /// Gets all <see cref="Type"/> instances that are assigneable to <paramref name="type"/>, using <see cref="TypeResolveStrategies.All"/>.
+        /// Gets all <see cref="Type"/> instances that are assignable to <paramref name="type"/>, using <see cref="TypeResolveStrategies.All"/>.
         /// </summary>
         /// <param name="typeCatalog">The <see cref="ITypeCatalog"/> instance where the types should be retrieved from.</param>
         /// <param name="type">The <see cref="Type"/> that all returned types should be assingable to.</param>
@@ -20,7 +20,7 @@ namespace Nancy
         }
 
         /// <summary>
-        /// Gets all <see cref="Type"/> instances that are assigneable to <typeparamref name="TType"/>, using <see cref="TypeResolveStrategies.All"/>.
+        /// Gets all <see cref="Type"/> instances that are assignable to <typeparamref name="TType"/>, using <see cref="TypeResolveStrategies.All"/>.
         /// </summary>
         /// <param name="typeCatalog">The <see cref="ITypeCatalog"/> instance where the types should be retrieved from.</param>
         /// <typeparam name="TType">The <see cref="Type"/> that all returned types should be assingable to.</typeparam>

--- a/src/Nancy/TypeCatalogExtensions.cs
+++ b/src/Nancy/TypeCatalogExtensions.cs
@@ -6,7 +6,7 @@ namespace Nancy
     /// <summary>
     /// Contains extension methods for <see cref="ITypeCatalog"/> implementations.
     /// </summary>
-    public static class ITypeCatalogExtensions
+    public static class TypeCatalogExtensions
     {
         /// <summary>
         /// Gets all <see cref="Type"/> instances that are assigneable to <paramref name="type"/>, using <see cref="TypeResolveStrategies.All"/>.
@@ -28,6 +28,18 @@ namespace Nancy
         public static IReadOnlyCollection<Type> GetTypesAssignableTo<TType>(this ITypeCatalog typeCatalog)
         {
             return typeCatalog.GetTypesAssignableTo(typeof(TType), TypeResolveStrategies.All);
+        }
+
+        /// <summary>
+        /// Gets all types that are assignable to the provided <typeparamref name="TType"/>.
+        /// </summary>
+        /// <param name="typeCatalog">The <see cref="ITypeCatalog"/> instance where the types should be retrieved from.</param>
+        /// <param name="strategy">A <see cref="TypeResolveStrategy"/> that should be used then retrieving types.</param>
+        /// <typeparam name="TType">The <see cref="Type"/> that returned types should be assignable to.</typeparam>
+        /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Type"/> instances.</returns>
+        public static IReadOnlyCollection<Type> GetTypesAssignableTo<TType>(this ITypeCatalog typeCatalog, TypeResolveStrategy strategy)
+        {
+            return typeCatalog.GetTypesAssignableTo(typeof(TType), strategy);
         }
     }
 }

--- a/src/Nancy/TypeResolveStrategies.cs
+++ b/src/Nancy/TypeResolveStrategies.cs
@@ -1,0 +1,50 @@
+namespace Nancy
+{
+    using System;
+
+    /// <summary>
+    /// Default <see cref="TypeResolveStrategy"/> implementations.
+    /// </summary>
+    public class TypeResolveStrategies
+    {
+        /// <summary>
+        /// Resolve types from all available locations.
+        /// </summary>
+        public static readonly TypeResolveStrategy All = type =>
+        {
+            return true;
+        };
+
+        /// <summary>
+        /// Resolve types that are not located in the Nancy assembly.
+        /// </summary>
+        public static readonly TypeResolveStrategy ExcludeNancy = type =>
+        {
+            return !OnlyNancy.Invoke(type);
+        };
+
+        /// <summary>
+        /// Resolve types that are not located in the Nancy namespace.
+        /// </summary>
+        public static readonly TypeResolveStrategy ExcludeNancyNamespace = type =>
+        {
+            return !OnlyNancyNamespace.Invoke(type);
+        };
+
+        /// <summary>
+        /// Resolve types that are located in the Nancy assembly.
+        /// </summary>
+        public static readonly TypeResolveStrategy OnlyNancy = type =>
+        {
+            return type.Assembly.Equals(typeof(INancyEngine).Assembly);
+        };
+
+        /// <summary>
+        /// Resolve types that are located in the Nancy namespace.
+        /// </summary>
+        public static readonly TypeResolveStrategy OnlyNancyNamespace = type =>
+        {
+            return type.Assembly.GetName().Name.StartsWith("Nancy", StringComparison.OrdinalIgnoreCase);
+        };
+    }
+}

--- a/src/Nancy/TypeResolveStrategies.cs
+++ b/src/Nancy/TypeResolveStrategies.cs
@@ -44,7 +44,7 @@ namespace Nancy
         /// </summary>
         public static readonly TypeResolveStrategy OnlyNancyNamespace = type =>
         {
-            return type.Assembly.GetName().Name.StartsWith("Nancy", StringComparison.OrdinalIgnoreCase);
+            return (type.Namespace ?? string.Empty).StartsWith("Nancy", StringComparison.OrdinalIgnoreCase);
         };
     }
 }

--- a/src/Nancy/TypeResolveStrategy.cs
+++ b/src/Nancy/TypeResolveStrategy.cs
@@ -5,7 +5,7 @@
     /// <summary>
     /// Predicate used to decide if a <see cref="Type"/> should be included when resolving types.
     /// </summary>
-    /// <param name="type">The <see cref="Type"/> that are being inspected.</param>
+    /// <param name="type">The <see cref="Type"/> that is being inspected.</param>
     /// <value><see langword="true"/> if the type should be included in the result, otherwise <see langword="false"/>.</value>
     public delegate bool TypeResolveStrategy(Type type);
 }

--- a/src/Nancy/TypeResolveStrategy.cs
+++ b/src/Nancy/TypeResolveStrategy.cs
@@ -1,0 +1,11 @@
+﻿namespace Nancy
+{
+    using System;
+
+    /// <summary>
+    /// Predicate used to decide if a <see cref="Type"/> should be included when resolving types.
+    /// </summary>
+    /// <param name="type">The <see cref="Type"/> that are being inspected.</param>
+    /// <value><see langword="true"/> if the type should be included in the result, otherwise <see langword="false"/>.</value>
+    public delegate bool TypeResolveStrategy(Type type);
+}


### PR DESCRIPTION
This is meant to be a pre-requisite for the instance based scanning (#1846) change that we want to replace the `AppDomainAssemblyTypeScanner`

- Adds `ITypeCatalog` and the ´DefaultTypeCatalog`. This default implementation uses a cache internally because once Nancy is booted up, it should be treated as immutable anyway.
- Adds `IAssemblyCatalog` and the `AppDomainAssemblyCatalog`. This implementation mimics a lot of the assembly functionality in `AppDomainAssemblyTypeScanner` by means of ensuring that Nancy referencing assemblies are loaded and it looks the bin paths for it.
- Replaces `ScanMode` with a strategy based approach. The strategy is defined by the `TypeResolveStrategy` delegate and there are implementations, in `TypeResolveStrategies` that represent the `ScanMode` members. This is a better approach because you can add strategies if you need them in your Nancy application.
- Includes `ITypeCatalogExtension` which adds a couple of `ITypeCatalog.GetTypesAssignableTo` overloads which uses `TypeResolveStrategies.All`

## Discussion point

The `AppDomainAssemblyCatalog` only scans over 

- Nancy assembly,
- Any Nancy referencing assemblies
- Ignored `Nancy.Testing` assembly

But has no means of letting someone bring more assemblies to its attention. `AppDomainAssemblyTypeScanner` had a bunch of `AddAssembliesToScan` and `LoadAssemblies` method to allow you to do this. However I think this design is bad and needs a bit of rethinking. In my opinion, these should be no runtime modification of this catalog, because most parts of Nancy is unable to react to the changes and make use of the new types anyway.

So I thought about adding something like

```c#
public virtual IEnumerable<string> AddtionalAssembliesToScan()
{
   return Enumerable.Empty<string>();
}
```

To the `AppDomainAssemblyTypeScanner` implementation. So if you wanted to include more assemblies, you would simply derive a new class, override `AddtionalAssembliesToScan` (naming suggestions are welcome!) and tell Nancy to use this assembly catalog instead. 

I thought about adding it as a ctor overload instead, but it just gets ugly quick. Supporting both is not something I would like to do.

Thoughts?