### PR TITLE
Removed ADATS dependency in NancyInternalConfiguration

### DIFF
--- a/samples/Nancy.Demo.Hosting.Aspnet/DemoBootstrapper.cs
+++ b/samples/Nancy.Demo.Hosting.Aspnet/DemoBootstrapper.cs
@@ -1,5 +1,6 @@
 ﻿namespace Nancy.Demo.Hosting.Aspnet
 {
+    using System;
     using System.Collections.Generic;
     using System.Reflection;
 
@@ -42,7 +43,7 @@
             environment.MyConfig("Hello World");
         }
 
-        protected override NancyInternalConfiguration InternalConfiguration
+        protected override Func<ITypeCatalog, NancyInternalConfiguration> InternalConfiguration
         {
             get
             {

--- a/samples/Nancy.Demo.Razor.Localization/DemoBootstrapper.cs
+++ b/samples/Nancy.Demo.Razor.Localization/DemoBootstrapper.cs
@@ -1,10 +1,11 @@
 ﻿namespace Nancy.Demo.Razor.Localization
 {
+    using System;
     using Nancy.Bootstrapper;
 
     public class DemoBootstrapper : DefaultNancyBootstrapper
     {
-        protected override NancyInternalConfiguration InternalConfiguration
+        protected override Func<ITypeCatalog, NancyInternalConfiguration> InternalConfiguration
         {
             get
             {

--- a/src/Nancy/Bootstrapper/NancyInternalConfiguration.cs
+++ b/src/Nancy/Bootstrapper/NancyInternalConfiguration.cs
@@ -3,7 +3,6 @@ namespace Nancy.Bootstrapper
     using System;
     using System.Collections.Generic;
     using System.Linq;
-
     using Nancy.Configuration;
     using Nancy.Culture;
     using Nancy.Diagnostics;
@@ -29,59 +28,59 @@ namespace Nancy.Bootstrapper
         /// <summary>
         /// Gets the Nancy default configuration
         /// </summary>
-        public static NancyInternalConfiguration Default
+        public static Func<ITypeCatalog, NancyInternalConfiguration> Default
         {
             get
             {
-                return new NancyInternalConfiguration
+                return typeCatalog => new NancyInternalConfiguration
                 {
-                    RouteResolver = typeof(DefaultRouteResolver),
-                    RoutePatternMatcher = typeof(DefaultRoutePatternMatcher),
-                    ContextFactory = typeof(DefaultNancyContextFactory),
-                    NancyEngine = typeof(NancyEngine),
-                    RouteCache = typeof(RouteCache),
-                    RouteCacheProvider = typeof(DefaultRouteCacheProvider),
-                    ViewLocator = typeof(DefaultViewLocator),
-                    ViewFactory = typeof(DefaultViewFactory),
-                    NancyModuleBuilder = typeof(DefaultNancyModuleBuilder),
-                    ResponseFormatterFactory = typeof(DefaultResponseFormatterFactory),
-                    ModelBinderLocator = typeof(DefaultModelBinderLocator),
                     Binder = typeof(DefaultBinder),
                     BindingDefaults = typeof(BindingDefaults),
-                    FieldNameConverter = typeof(DefaultFieldNameConverter),
-                    ViewResolver = typeof(DefaultViewResolver),
-                    ViewCache = typeof(DefaultViewCache),
-                    RenderContextFactory = typeof(DefaultRenderContextFactory),
-                    ModelValidatorLocator = typeof(DefaultValidatorLocator),
-                    ViewLocationProvider = typeof(FileSystemViewLocationProvider),
-                    StatusCodeHandlers = new List<Type>(AppDomainAssemblyTypeScanner.TypesOf<IStatusCodeHandler>(ScanMode.ExcludeNancy).Concat(new[] { typeof(DefaultStatusCodeHandler) })),
+                    ContextFactory = typeof(DefaultNancyContextFactory),
                     CsrfTokenValidator = typeof(DefaultCsrfTokenValidator),
-                    ObjectSerializer = typeof(DefaultObjectSerializer),
-                    Serializers = AppDomainAssemblyTypeScanner.TypesOf<ISerializer>(ScanMode.ExcludeNancy).Union(new List<Type>(new[] { typeof(DefaultJsonSerializer), typeof(DefaultXmlSerializer) })).ToList(),
-                    InteractiveDiagnosticProviders = new List<Type>(AppDomainAssemblyTypeScanner.TypesOf<IDiagnosticsProvider>()),
-                    RequestTracing = typeof(DefaultRequestTracing),
-                    RouteInvoker = typeof(DefaultRouteInvoker),
-                    ResponseProcessors = AppDomainAssemblyTypeScanner.TypesOf<IResponseProcessor>().ToList(),
-                    RequestDispatcher = typeof(DefaultRequestDispatcher),
-                    Diagnostics = typeof(DefaultDiagnostics),
-                    RouteSegmentExtractor = typeof(DefaultRouteSegmentExtractor),
-                    RouteDescriptionProvider = typeof(DefaultRouteDescriptionProvider),
                     CultureService = typeof(DefaultCultureService),
-                    TextResource = typeof(ResourceBasedTextResource),
-                    ResourceAssemblyProvider = typeof(ResourceAssemblyProvider),
-                    ResourceReader = typeof(DefaultResourceReader),
-                    StaticContentProvider = typeof(DefaultStaticContentProvider),
-                    RouteResolverTrie = typeof(RouteResolverTrie),
-                    TrieNodeFactory = typeof(TrieNodeFactory),
-                    RouteSegmentConstraints = AppDomainAssemblyTypeScanner.TypesOf<IRouteSegmentConstraint>().ToList(),
-                    RequestTraceFactory = typeof(DefaultRequestTraceFactory),
-                    ResponseNegotiator = typeof(DefaultResponseNegotiator),
-                    RouteMetadataProviders = AppDomainAssemblyTypeScanner.TypesOf<IRouteMetadataProvider>().ToList(),
+                    DefaultConfigurationProviders = typeCatalog.GetTypesAssignableTo<INancyDefaultConfigurationProvider>().ToList(),
+                    Diagnostics = typeof(DefaultDiagnostics),
                     EnvironmentFactory = typeof(DefaultNancyEnvironmentFactory),
                     EnvironmentConfigurator = typeof(DefaultNancyEnvironmentConfigurator),
-                    DefaultConfigurationProviders = AppDomainAssemblyTypeScanner.TypesOf<INancyDefaultConfigurationProvider>().ToList(),
-                    SerializerFactory = typeof(DefaultSerializerFactory),
+                    FieldNameConverter = typeof(DefaultFieldNameConverter),
+                    InteractiveDiagnosticProviders = new List<Type>(typeCatalog.GetTypesAssignableTo<IDiagnosticsProvider>()),
+                    ModelBinderLocator = typeof(DefaultModelBinderLocator),
+                    ModelValidatorLocator = typeof(DefaultValidatorLocator),
+                    NancyEngine = typeof(NancyEngine),
+                    NancyModuleBuilder = typeof(DefaultNancyModuleBuilder),
+                    ObjectSerializer = typeof(DefaultObjectSerializer),
+                    RenderContextFactory = typeof(DefaultRenderContextFactory),
+                    RequestDispatcher = typeof(DefaultRequestDispatcher),
+                    RequestTraceFactory = typeof(DefaultRequestTraceFactory),
+                    RequestTracing = typeof(DefaultRequestTracing),
+                    ResourceAssemblyProvider = typeof(ResourceAssemblyProvider),
+                    ResourceReader = typeof(DefaultResourceReader),
+                    ResponseFormatterFactory = typeof(DefaultResponseFormatterFactory),
+                    ResponseNegotiator = typeof(DefaultResponseNegotiator),
+                    ResponseProcessors = typeCatalog.GetTypesAssignableTo<IResponseProcessor>().ToList(),
+                    RouteCache = typeof(RouteCache),
+                    RouteCacheProvider = typeof(DefaultRouteCacheProvider),
+                    RouteInvoker = typeof(DefaultRouteInvoker),
+                    RoutePatternMatcher = typeof(DefaultRoutePatternMatcher),
+                    RouteResolver = typeof(DefaultRouteResolver),
+                    RouteResolverTrie = typeof(RouteResolverTrie),
+                    RouteSegmentConstraints = typeCatalog.GetTypesAssignableTo<IRouteSegmentConstraint>().ToList(),
+                    RouteSegmentExtractor = typeof(DefaultRouteSegmentExtractor),
+                    RouteMetadataProviders = typeCatalog.GetTypesAssignableTo<IRouteMetadataProvider>().ToList(),
+                    RouteDescriptionProvider = typeof(DefaultRouteDescriptionProvider),
                     RuntimeEnvironmentInformation = typeof(DefaultRuntimeEnvironmentInformation),
+                    SerializerFactory = typeof(DefaultSerializerFactory),
+                    Serializers = typeCatalog.GetTypesAssignableTo<ISerializer>(TypeResolveStrategies.ExcludeNancy).Union(new List<Type>(new[] { typeof(DefaultJsonSerializer), typeof(DefaultXmlSerializer) })).ToList(),
+                    StaticContentProvider = typeof(DefaultStaticContentProvider),
+                    StatusCodeHandlers = new List<Type>(typeCatalog.GetTypesAssignableTo<IStatusCodeHandler>(TypeResolveStrategies.ExcludeNancy).Concat(new[] { typeof(DefaultStatusCodeHandler) })),
+                    TextResource = typeof(ResourceBasedTextResource),
+                    TrieNodeFactory = typeof(TrieNodeFactory),
+                    ViewLocator = typeof(DefaultViewLocator),
+                    ViewFactory = typeof(DefaultViewFactory),
+                    ViewResolver = typeof(DefaultViewResolver),
+                    ViewCache = typeof(DefaultViewCache),
+                    ViewLocationProvider = typeof(FileSystemViewLocationProvider),
                 };
             }
         }
@@ -198,18 +197,17 @@ namespace Nancy.Bootstrapper
             }
         }
 
-        /// <summary>
-        /// Default Nancy configuration with specific overloads
-        /// </summary>
-        /// <param name="configurationBuilder">Configuration builder for overriding the default configuration properties.</param>
-        /// <returns>Nancy configuration instance</returns>
-        public static NancyInternalConfiguration WithOverrides(Action<NancyInternalConfiguration> configurationBuilder)
+        public static Func<ITypeCatalog, NancyInternalConfiguration> WithOverrides(Action<NancyInternalConfiguration> builder)
         {
-            var configuration = Default;
+            return catalog =>
+            {
+                var configuration =
+                    Default.Invoke(catalog);
 
-            configurationBuilder.Invoke(configuration);
+                builder.Invoke(configuration);
 
-            return configuration;
+                return configuration;
+            };
         }
 
         /// <summary>

--- a/test/Nancy.Tests/Fakes/FakeDefaultNancyBootstrapper.cs
+++ b/test/Nancy.Tests/Fakes/FakeDefaultNancyBootstrapper.cs
@@ -13,7 +13,7 @@
     {
         public IEnumerable<Type> OverriddenRegistrationTasks { get; set; }
 
-        private NancyInternalConfiguration configuration;
+        private Func<ITypeCatalog, NancyInternalConfiguration> configuration;
 
         protected override IEnumerable<ModuleRegistration> Modules
         {
@@ -25,7 +25,7 @@
         public FakeDefaultNancyBootstrapper()
             : this(NancyInternalConfiguration.WithOverrides(b => b.StatusCodeHandlers = new List<Type>(new[] { typeof(DefaultStatusCodeHandler) })))
         {
-            
+
         }
 
         protected override IEnumerable<Type> RegistrationTasks
@@ -43,13 +43,13 @@
                 return base.AutoRegisterIgnoredAssemblies.Union(new Func<Assembly, bool>[] { asm => asm.FullName.StartsWith("TestAssembly") });
             }
         }
-        public FakeDefaultNancyBootstrapper(NancyInternalConfiguration configuration)
+        public FakeDefaultNancyBootstrapper(Func<ITypeCatalog, NancyInternalConfiguration> configuration)
         {
             this.configuration = configuration;
             this.RequestContainerInitialisations = new Dictionary<NancyContext, int>();
         }
 
-        protected override NancyInternalConfiguration InternalConfiguration
+        protected override Func<ITypeCatalog, NancyInternalConfiguration> InternalConfiguration
         {
             get { return configuration; }
         }

--- a/test/Nancy.Tests/Unit/Bootstrapper/Base/BootstrapperBaseFixtureBase.cs
+++ b/test/Nancy.Tests/Unit/Bootstrapper/Base/BootstrapperBaseFixtureBase.cs
@@ -21,11 +21,11 @@ namespace Nancy.Tests.Unit.Bootstrapper.Base
     public abstract class BootstrapperBaseFixtureBase<TContainer>
         where TContainer : class
     {
-        private readonly NancyInternalConfiguration configuration;
+        private readonly Func<ITypeCatalog, NancyInternalConfiguration> configuration;
 
         protected abstract NancyBootstrapperBase<TContainer> Bootstrapper { get; }
 
-        protected NancyInternalConfiguration Configuration
+        protected Func<ITypeCatalog, NancyInternalConfiguration> Configuration
         {
             get { return this.configuration; }
         }
@@ -84,7 +84,7 @@ namespace Nancy.Tests.Unit.Bootstrapper.Base
             // When
             var result1 = this.Bootstrapper.GetEngine();
             var result2 = this.Bootstrapper.GetEngine();
-            
+
             // Then
             result1.ShouldBeSameAs(result2);
         }
@@ -94,7 +94,7 @@ namespace Nancy.Tests.Unit.Bootstrapper.Base
         {
             // Given
             this.Bootstrapper.Initialise();
-            
+
             // When
             var result1 = ((TestDependencyModule)this.Bootstrapper.GetModule(typeof(TestDependencyModule), new NancyContext()));
             var result2 = ((TestDependencyModule)this.Bootstrapper.GetModule(typeof(TestDependencyModule), new NancyContext()));

--- a/test/Nancy.Tests/Unit/Bootstrapper/NancyInternalConfigurationFixture.cs
+++ b/test/Nancy.Tests/Unit/Bootstrapper/NancyInternalConfigurationFixture.cs
@@ -1,21 +1,27 @@
 namespace Nancy.Tests.Unit.Bootstrapper
 {
     using System.Linq;
-
     using FakeItEasy;
-
     using Nancy.Bootstrapper;
     using Nancy.ModelBinding;
-
     using Xunit;
 
     public class NancyInternalConfigurationFixture
     {
+        private readonly ITypeCatalog typeCatalog;
+
+        public NancyInternalConfigurationFixture()
+        {
+            this.typeCatalog = new DefaultTypeCatalog(new AppDomainAssemblyCatalog());
+        }
+
         [Fact]
         public void Should_return_default_instance()
         {
-            var result = NancyInternalConfiguration.Default;
+            // Given, When
+            var result = NancyInternalConfiguration.Default.Invoke(this.typeCatalog);
 
+            // Then
             result.ShouldNotBeNull();
             result.ShouldBeOfType(typeof(NancyInternalConfiguration));
         }
@@ -23,20 +29,26 @@ namespace Nancy.Tests.Unit.Bootstrapper
         [Fact]
         public void Should_be_valid_default()
         {
-            var config = NancyInternalConfiguration.Default;
+            // Given
+            var config = NancyInternalConfiguration.Default.Invoke(this.typeCatalog);
 
+            // When
             var result = config.IsValid;
 
+            // Then
             result.ShouldBeTrue();
         }
 
         [Fact]
         public void Should_have_type_registrations_in_default()
         {
-            var config = NancyInternalConfiguration.Default;
+            // Given
+            var config = NancyInternalConfiguration.Default.Invoke(this.typeCatalog);
 
+            // When
             var result = config.GetTypeRegistrations();
 
+            // Then
             result.ShouldNotBeNull();
             result.Count().ShouldBeGreaterThan(0);
         }
@@ -44,22 +56,27 @@ namespace Nancy.Tests.Unit.Bootstrapper
         [Fact]
         public void Should_allow_overrides()
         {
+            // Given
             var fakeModelBinderLocator = A.Fake<IModelBinderLocator>();
             var config = NancyInternalConfiguration.WithOverrides((c) => c.ModelBinderLocator = fakeModelBinderLocator.GetType());
 
-            var result = config.GetTypeRegistrations();
+            // When
+            var result = config.Invoke(this.typeCatalog).GetTypeRegistrations();
 
-            result.Where(tr => tr.ImplementationType == fakeModelBinderLocator.GetType()).Any()
-                .ShouldBeTrue();
+            // Then
+            result.Where(tr => tr.ImplementationType == fakeModelBinderLocator.GetType()).Any().ShouldBeTrue();
         }
 
         [Fact]
         public void Should_not_be_valid_if_any_types_null()
         {
+            // Given
             var config = NancyInternalConfiguration.WithOverrides((c) => c.ModelBinderLocator = null);
 
-            var result = config.IsValid;
+            // When
+            var result = config.Invoke(this.typeCatalog).IsValid;
 
+             // Then
             result.ShouldBeFalse();
         }
     }

--- a/test/Nancy.Tests/Unit/DefaultNancyBootstrapperBootstrapperBaseFixture.cs
+++ b/test/Nancy.Tests/Unit/DefaultNancyBootstrapperBootstrapperBaseFixture.cs
@@ -1,4 +1,4 @@
-﻿#if !__MonoCS__ 
+﻿#if !__MonoCS__
 namespace Nancy.Tests.Unit
 {
     using System;
@@ -24,9 +24,9 @@ namespace Nancy.Tests.Unit
 
         public class FakeBootstrapper : DefaultNancyBootstrapper
         {
-            private readonly NancyInternalConfiguration configuration;
+            private readonly Func<ITypeCatalog, NancyInternalConfiguration> configuration;
 
-            protected override NancyInternalConfiguration InternalConfiguration
+            protected override Func<ITypeCatalog, NancyInternalConfiguration> InternalConfiguration
             {
                 get { return configuration; }
             }
@@ -39,7 +39,7 @@ namespace Nancy.Tests.Unit
                 }
             }
 
-            public FakeBootstrapper(NancyInternalConfiguration configuration)
+            public FakeBootstrapper(Func<ITypeCatalog, NancyInternalConfiguration> configuration)
             {
                 this.configuration = configuration;
             }


### PR DESCRIPTION
As part of #2221 

This one was a bit tricky as we could simply not just take a constructor dependency on `ITypeCatalog` in `NancyInternalConfiguration` because of the `Default` member and `WithOverrides`-method. I used the same approach that was taken in the #1846 spike. The `InternalConfiguration` property, on `NancyBoostrapperBase<T>` changed from plain `NancyInternalConfiguration` return type into `Func<ITypeCatalog, NancyInternalConfiguration>` so that we can inject the correct `ITypeCatalog` into it

This also meant that I had to update how the `WithOverrides` method was designed internally. It also meant that I had to rework `ConfigurableBootstrapper` worked. Previously I did modify a `NancyInternalConfiguration` instance, but it can not do that anymore because of the signature change on the bootstrapper. So instead the configurator build up a list of `Action<NancyInternalConfiguration>` which is then applied, one-by-one, on top of the `NancyInternalConfiguration` instance that the `ConfigurableBootstrapper` will end up using.