### PR TITLE
Changed custom IResourceAssemblyProviders to use NancyReferencing strategy

### DIFF
--- a/samples/Nancy.Demo.Hosting.Aspnet/DemoBootstrapper.cs
+++ b/samples/Nancy.Demo.Hosting.Aspnet/DemoBootstrapper.cs
@@ -107,12 +107,12 @@
 
         public CustomResourceAssemblyProvider(IAssemblyCatalog assemblyCatalog)
         {
-            this.assemblyCatalog = assemblyCatalog;            
+            this.assemblyCatalog = assemblyCatalog;
         }
 
         public IEnumerable<Assembly> GetAssembliesToScan()
         {
-            return (this.filteredAssemblies ?? (this.filteredAssemblies = this.assemblyCatalog.GetAssemblies()));
+            return (this.filteredAssemblies ?? (this.filteredAssemblies = this.assemblyCatalog.GetAssemblies(AssemblyResolveStrategies.NancyReferencing)));
         }
     }
 }

--- a/samples/Nancy.Demo.Razor.Localization/CustomResourceAssemblyProvider.cs
+++ b/samples/Nancy.Demo.Razor.Localization/CustomResourceAssemblyProvider.cs
@@ -20,7 +20,7 @@
 
         public IEnumerable<Assembly> GetAssembliesToScan()
         {
-            return (this.filteredAssemblies ?? (this.filteredAssemblies = this.assemblyCatalog.GetAssemblies()));
+            return (this.filteredAssemblies ?? (this.filteredAssemblies = this.assemblyCatalog.GetAssemblies(AssemblyResolveStrategies.NancyReferencing)));
         }
     }
 }


### PR DESCRIPTION
Previously they were using `AppDomainAssemblyTypeScanner.Assemblies` which were limited to Nancy-referencing assemblies only. With the introduction of `IAssemblyCatalog` the `AppDomainAssemblyDomain` will resolve all assemblies, and let you use a `AssemblyResolveStragegy` to narrow them down. By using `AssemblyResolveStrategies.NancyReferencing` we get the same behaviour as before.

Without this change we run into duplicate key issues in the `ResourceBasedTextResources` class, that uses the resource name as a dictionary key. The reason is that we fetched all assemblies and some system assemblies have the same resource file name in them.