### PR TITLE
Removed ADATS dependency in NancyConventions

### DIFF
--- a/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
+++ b/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
@@ -41,7 +41,7 @@
         /// <summary>
         /// Default Nancy conventions
         /// </summary>
-        private readonly NancyConventions conventions;
+        private NancyConventions conventions;
 
         /// <summary>
         /// Internal configuration
@@ -74,7 +74,6 @@
         protected NancyBootstrapperBase()
         {
             this.ApplicationPipelines = new Pipelines();
-            this.conventions = new NancyConventions();
         }
 
         /// <summary>
@@ -118,7 +117,7 @@
         {
             get
             {
-                return this.conventions;
+                return this.conventions ?? (this.conventions = new NancyConventions(this.TypeCatalog));
             }
         }
 

--- a/src/Nancy/Conventions/NancyConventions.cs
+++ b/src/Nancy/Conventions/NancyConventions.cs
@@ -14,16 +14,15 @@
     /// </summary>
     public class NancyConventions
     {
-        /// <summary>
-        /// Discovered conventions
-        /// </summary>
+        private readonly ITypeCatalog typeCatalog;
         private IEnumerable<IConvention> conventions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NancyConventions"/> class.
         /// </summary>
-        public NancyConventions()
+        public NancyConventions(ITypeCatalog typeCatalog)
         {
+            this.typeCatalog = typeCatalog;
             this.BuildDefaultConventions();
         }
 
@@ -77,7 +76,7 @@
             {
                 new InstanceRegistration(typeof(ViewLocationConventions), new ViewLocationConventions(this.ViewLocationConventions)),
                 new InstanceRegistration(typeof(StaticContentsConventions), new StaticContentsConventions(this.StaticContentsConventions)),
-                new InstanceRegistration(typeof(AcceptHeaderCoercionConventions), new AcceptHeaderCoercionConventions(this.AcceptHeaderCoercionConventions)), 
+                new InstanceRegistration(typeof(AcceptHeaderCoercionConventions), new AcceptHeaderCoercionConventions(this.AcceptHeaderCoercionConventions)),
                 new InstanceRegistration(typeof(CultureConventions), new CultureConventions(this.CultureConventions))
             };
         }
@@ -89,10 +88,10 @@
         private void BuildDefaultConventions()
         {
             var defaultConventions =
-                AppDomainAssemblyTypeScanner.TypesOf<IConvention>(ScanMode.OnlyNancy);
+                this.typeCatalog.GetTypesAssignableTo<IConvention>(TypeResolveStrategies.OnlyNancy);
 
             this.conventions = defaultConventions
-                .Union(AppDomainAssemblyTypeScanner.TypesOf<IConvention>(ScanMode.ExcludeNancy))
+                .Union(this.typeCatalog.GetTypesAssignableTo<IConvention>(TypeResolveStrategies.ExcludeNancy))
                 .Select(t => (IConvention)Activator.CreateInstance(t));
 
             foreach (var convention in this.conventions)

--- a/test/Nancy.Tests/Unit/Conventions/DefaultAcceptHeaderCoercionConventionsFixture.cs
+++ b/test/Nancy.Tests/Unit/Conventions/DefaultAcceptHeaderCoercionConventionsFixture.cs
@@ -1,18 +1,24 @@
 ﻿namespace Nancy.Tests.Unit.Conventions
 {
+    using System;
+    using System.Linq;
+    using FakeItEasy;
     using Nancy.Conventions;
 
     using Xunit;
 
     public class DefaultAcceptHeaderCoercionConventionsFixture
     {
-         
+
         private readonly NancyConventions conventions;
         private readonly DefaultAcceptHeaderCoercionConventions acceptHeaderConventions;
 
         public DefaultAcceptHeaderCoercionConventionsFixture()
         {
-            this.conventions = new NancyConventions();
+            var typeCatalog = A.Fake<ITypeCatalog>();
+            A.CallTo(() => typeCatalog.GetTypesAssignableTo(A<Type>._, A<TypeResolveStrategy>._)).Returns(new Type[] { });
+
+            this.conventions = new NancyConventions(typeCatalog);
             this.acceptHeaderConventions = new DefaultAcceptHeaderCoercionConventions();
         }
 
@@ -48,7 +54,7 @@
             this.acceptHeaderConventions.Initialise(this.conventions);
 
             // Then
-            this.conventions.CultureConventions.Count.ShouldBeGreaterThan(0);
+            this.conventions.AcceptHeaderCoercionConventions.Count.ShouldBeGreaterThan(0);
         }
     }
 }

--- a/test/Nancy.Tests/Unit/Conventions/DefaultCultureConventionsFixture.cs
+++ b/test/Nancy.Tests/Unit/Conventions/DefaultCultureConventionsFixture.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Globalization;
-
+    using FakeItEasy;
     using Nancy.Conventions;
 
     using Xunit;
@@ -15,7 +15,10 @@
 
         public DefaultCultureConventionsFixture()
         {
-            this.conventions = new NancyConventions();
+            var typeCatalog = A.Fake<ITypeCatalog>();
+            A.CallTo(() => typeCatalog.GetTypesAssignableTo(A<Type>._, A<TypeResolveStrategy>._)).Returns(new Type[] { });
+
+            this.conventions = new NancyConventions(typeCatalog);
             this.cultureConventions = new DefaultCultureConventions();
         }
 

--- a/test/Nancy.Tests/Unit/Conventions/DefaultStaticContentsConventionsFixture.cs
+++ b/test/Nancy.Tests/Unit/Conventions/DefaultStaticContentsConventionsFixture.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
-
+    using FakeItEasy;
     using Nancy.Conventions;
 
     using Xunit;
@@ -14,7 +14,10 @@
 
         public DefaultStaticContentsConventionsFixture()
         {
-            this.conventions = new NancyConventions();
+            var typeCatalog = A.Fake<ITypeCatalog>();
+            A.CallTo(() => typeCatalog.GetTypesAssignableTo(A<Type>._, A<TypeResolveStrategy>._)).Returns(new Type[] { });
+
+            this.conventions = new NancyConventions(typeCatalog);
             this.staticContentsConventions = new DefaultStaticContentsConventions();
         }
 

--- a/test/Nancy.Tests/Unit/Conventions/DefaultViewLocationConventionsFixture.cs
+++ b/test/Nancy.Tests/Unit/Conventions/DefaultViewLocationConventionsFixture.cs
@@ -3,7 +3,7 @@ namespace Nancy.Tests.Unit.Conventions
     using System;
     using System.Collections.Generic;
     using System.Globalization;
-
+    using FakeItEasy;
     using Nancy.Conventions;
     using Nancy.ViewEngines;
 
@@ -17,7 +17,10 @@ namespace Nancy.Tests.Unit.Conventions
 
         public DefaultViewLocationConventionsFixture()
         {
-            this.conventions = new NancyConventions();
+            var typeCatalog = A.Fake<ITypeCatalog>();
+            A.CallTo(() => typeCatalog.GetTypesAssignableTo(A<Type>._, A<TypeResolveStrategy>._)).Returns(new Type[] { });
+
+            this.conventions = new NancyConventions(typeCatalog);
             this.viewLocationConventions = new DefaultViewLocationConventions();
         }
 


### PR DESCRIPTION
Part of #2221 this time is is `NancyConventions` that gets a cleansing 