### PR TITLE
Changed loading approach in AppDomainAssemblyCatalog

### DIFF
--- a/src/Nancy/ResourceAssemblyProvider.cs
+++ b/src/Nancy/ResourceAssemblyProvider.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Reflection;
 
     /// <summary>
@@ -34,7 +35,9 @@
 
         private IEnumerable<Assembly> GetFilteredAssemblies()
         {
-            return this.assemblyCatalog.GetAssemblies(x => !x.GetName().Name.StartsWith("Nancy", StringComparison.OrdinalIgnoreCase));
+            return this.assemblyCatalog
+                .GetAssemblies(AssemblyResolveStrategies.NancyReferencing)
+                .Where(x => !x.GetName().Name.StartsWith("Nancy", StringComparison.OrdinalIgnoreCase));
         }
     }
 }


### PR DESCRIPTION
## Background

We have always been having some intermittent problem with our assembly scanning strategy because of how the CLR sometimes tries to be a bit smart. Now that we have moved over to `IAssemblyCatalog` there is no explicit `AddAssemblyToScan` method that you can use to give the scanner some more hints on what assemblies it should forcefully load into the application domain and include in the scanning. This was causing some problems so I spent some time looking even deeper (than before) into this.

It turns out that the CLR attempts to be smart when it comes to not loading indirectly referenced assemblies, into the application domain, at startup. Instead it will defer the loading until it figures out that it is about to execute code that relies on code in one of these assemblies. Once that code has executed the assembly is in the application domain for the entire lifetime of the application. 

To put it short: The `AppDomain.CurrentDomain.Assemblies` can mutate at runtime and we've not been able to react

We could probably hook into something to know when a new assembly is loaded into the application domain, but by then it could already been too late, i.e imagine we ask for `IFoo` at one point in time and get 2 types back. Later in the life of the application, the same question could give us 3 types back instead because the CLR loaded in one of these assemblies.

## Workaround in AppDomainAssemblyTypeScanner

We have been exposing methods to load assemblies into ADATS and update the internal collection of discovered types. This does not directly solve the problem, unless you explicitly load everything in yourself - there could still be assemblies in your bin-folder that ends up being loaded by the CLR on a need-to-use basis and depending on the timing and order of your ADATS operation you could end up with these types discovered as well (a bit of coin flip).

We have mitigated this a bit by forcefully trying to load any assembly that references one of the Nancy assemblies. This is not perfect though, like when you have view models in a satellite assembly and our Razor engine model type resolver, which uses ADATS, can't find the model types because that model assembly ended up being one of those assemblies that weren't loaded into the application domain at startup so it was not present in ADATS

## Workaround in AppDomainAssemblyTypeScanner

This implementation still has the Nancy-referencing loading approach, but I've added a second loading approach as well.

It does the following

- Find all assemblies that are loaded into the application domain at startup
- Iterate over their references (from `Assembly.GetAssemblyReferences()`) and forcefully load them into the domain

It won't recurse, so it will only go one level deep. That _should_ solve most problem that we have been experiencing with this.

The code is very simple

```c#
foreach (var assembly in assemblies)
{
    var references = assembly.GetReferencedAssemblies();
    foreach (var reference in references)
    {
        Assembly.Load(reference);
    }
}
```

I found that there were not even a need to check that the assembly wasn't already loaded into the domain. The CLR assembly loader is clever enough to do all the pre-checks for you, and will ignore loading something if it figured out it's already available in the application domain.

Using this code I managed to fix some problems we had with type discovery during runtime that was caused by this. I will send a separate PR with those changes if/when this PR goes in