### PR TITLE
Relaced use of ADATS with IAssemblyCatalog

### DIFF
--- a/src/Nancy/ResourceAssemblyProvider.cs
+++ b/src/Nancy/ResourceAssemblyProvider.cs
@@ -2,10 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Reflection;
-
-    using Nancy.Bootstrapper;
 
     /// <summary>
     /// Default set of assemblies that should be scanned for items (views, text, content etc)
@@ -14,7 +11,17 @@
     /// <remarks>The default convention will scan all assemblies that references another assemblies that has a name that starts with Nancy*</remarks>
     public class ResourceAssemblyProvider : IResourceAssemblyProvider
     {
+        private readonly IAssemblyCatalog assemblyCatalog;
         private IEnumerable<Assembly> filteredAssemblies;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResourceAssemblyProvider"/>
+        /// </summary>
+        /// <param name="assemblyCatalog">An <see cref="IAssemblyCatalog"/> instance.</param>
+        public ResourceAssemblyProvider(IAssemblyCatalog assemblyCatalog)
+        {
+            this.assemblyCatalog = assemblyCatalog;
+        }
 
         /// <summary>
         /// Gets a list of assemblies that should be scanned for views.
@@ -22,14 +29,12 @@
         /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="Assembly"/> instances.</returns>
         public IEnumerable<Assembly> GetAssembliesToScan()
         {
-            return (this.filteredAssemblies ?? (this.filteredAssemblies = GetFilteredAssemblies()));
+            return (this.filteredAssemblies ?? (this.filteredAssemblies = this.GetFilteredAssemblies()));
         }
 
-        private static IEnumerable<Assembly> GetFilteredAssemblies()
+        private IEnumerable<Assembly> GetFilteredAssemblies()
         {
-            return AppDomainAssemblyTypeScanner.Assemblies
-                .Where(x => !x.IsDynamic)
-                .Where(x => !x.GetName().Name.StartsWith("Nancy", StringComparison.OrdinalIgnoreCase));
+            return this.assemblyCatalog.GetAssemblies(x => !x.GetName().Name.StartsWith("Nancy", StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/Nancy/ViewEngines/ResourceViewLocationProvider.cs
+++ b/src/Nancy/ViewEngines/ResourceViewLocationProvider.cs
@@ -17,18 +17,19 @@
         /// <summary>
         /// User-configured root namespaces for assemblies.
         /// </summary>
-        public readonly static IDictionary<Assembly, string> RootNamespaces = new Dictionary<Assembly, string>();
+        public static readonly IDictionary<Assembly, string> RootNamespaces = new Dictionary<Assembly, string>();
 
         /// <summary>
         /// A list of assemblies to ignore when scanning for embedded views.
         /// </summary>
-        public readonly static IList<Assembly> Ignore = new List<Assembly>();
+        public static readonly IList<Assembly> Ignore = new List<Assembly>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ResourceViewLocationProvider"/> class.
         /// </summary>
-        public ResourceViewLocationProvider()
-            : this(new DefaultResourceReader(), new ResourceAssemblyProvider())
+        /// <param name="assemblyCatalog">An <see cref="IAssemblyCatalog"/> instance.</param>
+        public ResourceViewLocationProvider(IAssemblyCatalog assemblyCatalog)
+            : this(new DefaultResourceReader(), new ResourceAssemblyProvider(assemblyCatalog))
         {
         }
 


### PR DESCRIPTION
Part of #2221 a simple replace of a direct `AppDomainAssemblyTypeScanner` use