### PR TITLE
Replaced ADATS with ITypeCatalog in Registrations

### DIFF
--- a/src/Nancy.Metadata.Modules/MetadataModuleRegistrations.cs
+++ b/src/Nancy.Metadata.Modules/MetadataModuleRegistrations.cs
@@ -11,7 +11,8 @@
         /// Creates a new instance of the <see cref="MetadataModuleRegistrations"/> class, that performs
         /// the default registrations of the metadata modules types.
         /// </summary>
-        public MetadataModuleRegistrations()
+        /// <param name="typeCatalog">An <see cref="ITypeCatalog"/> instance.</param>
+        public MetadataModuleRegistrations(ITypeCatalog typeCatalog) : base(typeCatalog)
         {
             this.Register<DefaultMetadataModuleConventions>();
             this.RegisterAll<IMetadataModule>();

--- a/src/Nancy.Validation.DataAnnotations/DataAnnotationsRegistrations.cs
+++ b/src/Nancy.Validation.DataAnnotations/DataAnnotationsRegistrations.cs
@@ -11,7 +11,8 @@ namespace Nancy.Validation.DataAnnotations
         /// Creates a new instance of the <see cref="DataAnnotationsRegistrations"/> class, that performs
         /// the default registrations of the Data Annotations types.
         /// </summary>
-        public DataAnnotationsRegistrations()
+        /// <param name="typeCatalog">An <see cref="ITypeCatalog"/> instance.</param>
+        public DataAnnotationsRegistrations(ITypeCatalog typeCatalog) : base(typeCatalog)
         {
             this.RegisterAll<IDataAnnotationsValidatorAdapter>();
             this.RegisterWithDefault<IPropertyValidatorFactory>(typeof(DefaultPropertyValidatorFactory));

--- a/src/Nancy.Validation.FluentValidation/FluentValidationRegistrations.cs
+++ b/src/Nancy.Validation.FluentValidation/FluentValidationRegistrations.cs
@@ -13,7 +13,8 @@ namespace Nancy.Validation.FluentValidation
         /// Creates a new instance of the <see cref="FluentValidationRegistrations"/> class, that performs
         /// the default registrations of the Fluent Validation types.
         /// </summary>
-        public FluentValidationRegistrations()
+        /// <param name="typeCatalog">An <see cref="ITypeCatalog"/> instance.</param>
+        public FluentValidationRegistrations(ITypeCatalog typeCatalog) : base(typeCatalog)
         {
             this.Register<IFluentAdapterFactory>(typeof(DefaultFluentAdapterFactory));
             this.RegisterAll<IFluentAdapter>();

--- a/src/Nancy.ViewEngines.DotLiquid/DotLiquidRegistrations.cs
+++ b/src/Nancy.ViewEngines.DotLiquid/DotLiquidRegistrations.cs
@@ -15,7 +15,8 @@
         /// <summary>
         /// Register the <c>RubyNamingConvention</c> as the default.
         /// </summary>
-        public DotLiquidRegistrations()
+        /// <param name="typeCatalog">An <see cref="ITypeCatalog"/> instance.</param>
+        public DotLiquidRegistrations(ITypeCatalog typeCatalog) : base(typeCatalog)
         {
             this.RegisterWithDefault<INamingConvention>(typeof(RubyNamingConvention));
         }

--- a/src/Nancy.ViewEngines.Razor/RazorViewEngineApplicationStartupRegistrations.cs
+++ b/src/Nancy.ViewEngines.Razor/RazorViewEngineApplicationStartupRegistrations.cs
@@ -7,7 +7,11 @@ namespace Nancy.ViewEngines.Razor
     /// </summary>
     public class RazorViewEngineRegistrations : Registrations
     {
-        public RazorViewEngineRegistrations()
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RazorViewEngineRegistrations"/> class.
+        /// </summary>
+        /// <param name="typeCatalog">An <see cref="ITypeCatalog"/> instance.</param>
+        public RazorViewEngineRegistrations(ITypeCatalog typeCatalog) : base(typeCatalog)
         {
             this.RegisterWithDefault<IRazorConfiguration>(typeof(DefaultRazorConfiguration));
         }


### PR DESCRIPTION
Part of #2221

The way to get the `ITypeCatalog` into `Registrations` was to add a protected constructor. It is a *breaking change* but I think it's a fair one