### PR TITLE
MemoryStream.GetBuffer -> MemoryStream.TryGetBuffer

### DIFF
--- a/src/Nancy.MSBuild/Nancy.csproj
+++ b/src/Nancy.MSBuild/Nancy.csproj
@@ -323,6 +323,9 @@
     <Compile Include="..\Nancy\ErrorHandling\RouteExecutionEarlyExitException.cs">
       <Link>ErrorHandling\RouteExecutionEarlyExitException.cs</Link>
     </Compile>
+    <Compile Include="..\Nancy\Extensions\MemoryStreamExtensions.cs">
+      <Link>Extensions\MemoryStreamExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\Nancy\Extensions\ModelValidationErrorExtensions.cs">
       <Link>Extensions\ModelValidationErrorExtensions.cs</Link>
     </Compile>

--- a/src/Nancy/DefaultObjectSerializer.cs
+++ b/src/Nancy/DefaultObjectSerializer.cs
@@ -1,5 +1,6 @@
 namespace Nancy
 {
+    using Extensions;
     using System;
     using System.IO;
     using System.Runtime.Serialization;
@@ -25,9 +26,8 @@ namespace Nancy
             {
                 formatter.Serialize(outputStream, sourceObject);
 
-                var outputBytes = outputStream.GetBuffer();
-
-                return Convert.ToBase64String(outputBytes, 0, (int)outputStream.Length);
+                var buffer = outputStream.GetBufferSegment();
+                return Convert.ToBase64String(buffer.Array, buffer.Offset, buffer.Count);
             }
         }
 

--- a/src/Nancy/Extensions/MemoryStreamExtensions.cs
+++ b/src/Nancy/Extensions/MemoryStreamExtensions.cs
@@ -1,0 +1,31 @@
+﻿namespace Nancy.Extensions
+{
+    using System;
+    using System.IO;
+
+    internal static class MemoryStreamExtensions
+    {
+        public static ArraySegment<byte> GetBufferSegment(this MemoryStream stream)
+        {
+#if DOTNET5_4
+            ArraySegment<byte> buffer;
+            if (stream.TryGetBuffer(out buffer))
+            {
+                return buffer;
+            }
+#endif
+            var bytes = stream.GetBytes();
+
+            return new ArraySegment<byte>(bytes, 0, bytes.Length);
+        }
+
+        private static byte[] GetBytes(this MemoryStream stream)
+        {
+#if DOTNET5_4
+            return stream.ToArray(); // This is all we have if TryGetBuffer fails in GetBufferSegment
+#else
+            return stream.GetBuffer();
+#endif
+        }
+    }
+}

--- a/src/Nancy/Helpers/HttpUtility.cs
+++ b/src/Nancy/Helpers/HttpUtility.cs
@@ -31,6 +31,7 @@
 
 namespace Nancy.Helpers
 {
+    using Extensions;
     using System;
     using System.Collections;
     using System.Collections.Generic;
@@ -118,7 +119,8 @@ namespace Nancy.Helpers
 
         static char[] GetChars(MemoryStream b, Encoding e)
         {
-            return e.GetChars(b.GetBuffer(), 0, (int)b.Length);
+            var buffer = b.GetBufferSegment();
+            return e.GetChars(buffer.Array, buffer.Offset, buffer.Count);
         }
 
         static void WriteCharBytes(IList buf, char ch, Encoding e)
@@ -750,6 +752,6 @@ namespace Nancy.Helpers
             return new KeyValuePair<string, string>(key, value);
         }
 
-        #endregion // Methods
+#endregion // Methods
     }
 }

--- a/src/Nancy/project.json
+++ b/src/Nancy/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "version": "2.0.0-*",
 
     "description": "Nancy is a lightweight web framework for the .Net platform, inspired by Sinatra. Nancy aim at delivering a low ceremony approach to building light, fast web applications.",
@@ -7,12 +7,10 @@
     "projectUrl": "http://nancyfx.org",
     "licenseUrl": "https://github.com/NancyFx/Nancy/blob/master/license.txt",
     "iconUrl": "http://nancyfx.org/nancy-nuget.png",
-
     "resource": [
         "Diagnostics/Resources/**/*.*",
         "Diagnostics/Views/**/*.*"
     ],
-
     "frameworks": {
         "dotnet5.4": {
           "dependencies": {
@@ -30,7 +28,7 @@
             "System.Net.NameResolution": "4.0.0-beta-23516",
             "System.Net.Primitives": "4.0.11-beta-23516",
             "System.Reflection.TypeExtensions": "4.1.0-beta-23516",
-            "System.Reflection.Extensions" : "4.0.1-beta-23516",
+            "System.Reflection.Extensions": "4.0.1-beta-23516",
             "System.Runtime": "4.0.21-beta-23516",
             "System.Runtime.Serialization.Primitives": "4.1.0-beta-23516",
             "System.Security.Claims": "4.0.1-beta-23516",


### PR DESCRIPTION
Part of #2220 

Replaced Usage of MemoryStream.GetBuffer to MemoryStream.TryGetBuffer

For now, I couldn't find a suitable exception to throw if TryGetBuffer fails, what would be the best approach for this? for now I have just returned an empty object however I think this could be a bit of an issue.