### PR TITLE
Ifdefed out usage of ICloneable interface in Url class

### DIFF
--- a/src/Nancy/Url.cs
+++ b/src/Nancy/Url.cs
@@ -122,17 +122,6 @@ namespace Nancy
                 .ToString();
         }
 
-#if !DOTNET5_4
-        /// <summary>
-        /// Clones the url.
-        /// </summary>
-        /// <returns>Returns a new cloned instance of the url.</returns>
-        object ICloneable.Clone()
-        {
-            return this.Clone();
-        }
-#endif
-
         /// <summary>
         /// Clones the url.
         /// </summary>

--- a/src/Nancy/Url.cs
+++ b/src/Nancy/Url.cs
@@ -9,11 +9,7 @@ namespace Nancy
     /// Represents a full Url of the form scheme://hostname:port/basepath/path?query
     /// </summary>
     /// <remarks>Since this is for  internal use, and fragments are not passed to the server, fragments are not supported.</remarks>
-#if DOTNET5_4
     public sealed class Url
-#else
-    public sealed class Url : ICloneable
-#endif
     {
         private string basePath;
 

--- a/src/Nancy/Url.cs
+++ b/src/Nancy/Url.cs
@@ -9,7 +9,11 @@ namespace Nancy
     /// Represents a full Url of the form scheme://hostname:port/basepath/path?query
     /// </summary>
     /// <remarks>Since this is for  internal use, and fragments are not passed to the server, fragments are not supported.</remarks>
+#if DOTNET5_4
+    public sealed class Url
+#else
     public sealed class Url : ICloneable
+#endif
     {
         private string basePath;
 
@@ -122,6 +126,7 @@ namespace Nancy
                 .ToString();
         }
 
+#if !DOTNET5_4
         /// <summary>
         /// Clones the url.
         /// </summary>
@@ -130,6 +135,7 @@ namespace Nancy
         {
             return this.Clone();
         }
+#endif
 
         /// <summary>
         /// Clones the url.


### PR DESCRIPTION
Part of #2220

We don't seem to be using the ICloneable method Clone() too often, but i've ifdefed it instead of replacement for now, if people want, we can remove it completely.