### PR TITLE
Replaced SchemeDelimiter, UriSchemeHttp, UriSchemeHttps

### DIFF
--- a/src/Nancy/Url.cs
+++ b/src/Nancy/Url.cs
@@ -20,7 +20,7 @@ namespace Nancy
         /// </summary>
         public Url()
         {
-            this.Scheme = Uri.UriSchemeHttp;
+            this.Scheme = "http://";
             this.HostName = string.Empty;
             this.Port = null;
             this.BasePath = string.Empty;
@@ -91,7 +91,7 @@ namespace Nancy
             {
                 return new StringBuilder()
                     .Append(this.Scheme)
-                    .Append(Uri.SchemeDelimiter)
+                    .Append("://")
                     .Append(GetHostName(this.HostName))
                     .Append(GetPort(this.Port))
                     .ToString();
@@ -105,7 +105,7 @@ namespace Nancy
         {
             get
             {
-                return Uri.UriSchemeHttps.Equals(this.Scheme, StringComparison.OrdinalIgnoreCase);
+                return "https://".Equals(this.Scheme, StringComparison.OrdinalIgnoreCase);
             }
         }
 
@@ -113,7 +113,7 @@ namespace Nancy
         {
             return new StringBuilder()
                 .Append(this.Scheme)
-                .Append(Uri.SchemeDelimiter)
+                .Append("://")
                 .Append(GetHostName(this.HostName))
                 .Append(GetPort(this.Port))
                 .Append(GetCorrectPath(this.BasePath))

--- a/src/Nancy/Url.cs
+++ b/src/Nancy/Url.cs
@@ -20,7 +20,7 @@ namespace Nancy
         /// </summary>
         public Url()
         {
-            this.Scheme = "http://";
+            this.Scheme = "http";
             this.HostName = string.Empty;
             this.Port = null;
             this.BasePath = string.Empty;
@@ -105,7 +105,7 @@ namespace Nancy
         {
             get
             {
-                return "https://".Equals(this.Scheme, StringComparison.OrdinalIgnoreCase);
+                return "https".Equals(this.Scheme, StringComparison.OrdinalIgnoreCase);
             }
         }
 


### PR DESCRIPTION
Replaced SchemeDelimiter, UriSchemeHttp, UriSchemeHttps with string literals as suggested by portability analyser 