### PR TITLE
Removed GetRawCertData error by passing X509Certificate2 

### DIFF
--- a/src/Nancy.Hosting.Aspnet/NancyHandler.cs
+++ b/src/Nancy.Hosting.Aspnet/NancyHandler.cs
@@ -4,6 +4,7 @@ namespace Nancy.Hosting.Aspnet
     using System.Configuration;
     using System.Globalization;
     using System.Linq;
+    using System.Security.Cryptography.X509Certificates;
     using System.Threading.Tasks;
     using System.Web;
 
@@ -84,7 +85,7 @@ namespace Nancy.Hosting.Aspnet
                 body, 
                 incomingHeaders, 
                 context.Request.UserHostAddress, 
-                certificate,
+                new X509Certificate2(certificate),
                 protocolVersion);
         }
 

--- a/src/Nancy.Hosting.Self/NancyHost.cs
+++ b/src/Nancy.Hosting.Self/NancyHost.cs
@@ -6,6 +6,7 @@
     using System.IO;
     using System.Linq;
     using System.Net;
+    using System.Security.Cryptography.X509Certificates;
     using System.Security.Principal;
     using System.Threading.Tasks;
     using Nancy.Bootstrapper;
@@ -264,7 +265,7 @@
                 Query = request.Url.Query,
             };
 
-            byte[] certificate = null;
+            X509Certificate2 certificate = null;
 
             if (this.configuration.EnableClientCertificates)
             {
@@ -272,7 +273,7 @@
 
                 if (x509Certificate != null)
                 {
-                    certificate = x509Certificate.RawData;
+                    certificate = x509Certificate;
                 }
             }
 

--- a/src/Nancy.Testing/Browser.cs
+++ b/src/Nancy.Testing/Browser.cs
@@ -326,9 +326,7 @@ namespace Nancy.Testing
             var requestStream =
                 RequestStream.FromStream(contextValues.Body, 0, true);
 
-            var certBytes = (contextValues.ClientCertificate == null)
-                ? new byte[] { }
-                : contextValues.ClientCertificate.GetRawCertData();
+            var certBytes = contextValues.ClientCertificate ?? null;
 
             var requestUrl = url;
             requestUrl.Scheme = string.IsNullOrWhiteSpace(contextValues.Protocol) ? requestUrl.Scheme : contextValues.Protocol;

--- a/src/Nancy/Owin/NancyMiddleware.cs
+++ b/src/Nancy/Owin/NancyMiddleware.cs
@@ -68,12 +68,12 @@
                         var owinRequestProtocol = Get<string>(environment, "owin.RequestProtocol");
                         var owinCallCancelled = Get<CancellationToken>(environment, "owin.CallCancelled");
                         var owinRequestHost = GetHeader(owinRequestHeaders, "Host") ?? Dns.GetHostName();
-                        var owinUser = GetUser(environment); 
+                        var owinUser = GetUser(environment);
 
                         X509Certificate2 certificate = null;
                         if (options.EnableClientCertificates)
                         {
-                            var clientCertificate = Get<X509Certificate2>(environment, "ssl.ClientCertificate");
+                            var clientCertificate = new X509Certificate2(Get<X509Certificate>(environment, "ssl.ClientCertificate").Export(X509ContentType.Cert));
                             certificate = clientCertificate ?? null;
                         }
 
@@ -133,12 +133,12 @@
 
                 foreach (var responseHeader in nancyResponse.Headers)
                 {
-                    owinResponseHeaders[responseHeader.Key] = new[] {responseHeader.Value};
+                    owinResponseHeaders[responseHeader.Key] = new[] { responseHeader.Value };
                 }
 
                 if (!string.IsNullOrWhiteSpace(nancyResponse.ContentType))
                 {
-                    owinResponseHeaders["Content-Type"] = new[] {nancyResponse.ContentType};
+                    owinResponseHeaders["Content-Type"] = new[] { nancyResponse.ContentType };
                 }
 
                 if (nancyResponse.Cookies != null && nancyResponse.Cookies.Count != 0)

--- a/src/Nancy/Owin/NancyMiddleware.cs
+++ b/src/Nancy/Owin/NancyMiddleware.cs
@@ -70,11 +70,11 @@
                         var owinRequestHost = GetHeader(owinRequestHeaders, "Host") ?? Dns.GetHostName();
                         var owinUser = GetUser(environment); 
 
-                        byte[] certificate = null;
+                        X509Certificate2 certificate = null;
                         if (options.EnableClientCertificates)
                         {
-                            var clientCertificate = Get<X509Certificate>(environment, "ssl.ClientCertificate");
-                            certificate = (clientCertificate == null) ? null : clientCertificate.GetRawCertData();
+                            var clientCertificate = Get<X509Certificate2>(environment, "ssl.ClientCertificate");
+                            certificate = clientCertificate ?? null;
                         }
 
                         var serverClientIp = Get<string>(environment, "server.RemoteIpAddress");

--- a/src/Nancy/Request.cs
+++ b/src/Nancy/Request.cs
@@ -50,7 +50,7 @@ namespace Nancy
             RequestStream body = null,
             IDictionary<string, IEnumerable<string>> headers = null,
             string ip = null,
-            byte[] certificate = null,
+            X509Certificate certificate = null,
             string protocolVersion = null)
         {
             if (String.IsNullOrEmpty(method))
@@ -87,9 +87,9 @@ namespace Nancy
 
             this.Session = new NullSessionProvider();
 
-            if (certificate != null && certificate.Length != 0)
+            if (certificate != null)
             {
-                this.ClientCertificate = new X509Certificate2(certificate);
+                this.ClientCertificate = certificate;
             }
 
             this.ProtocolVersion = protocolVersion ?? string.Empty;

--- a/test/Nancy.Owin.Tests/AppBuilderExtensionsFixture.cs
+++ b/test/Nancy.Owin.Tests/AppBuilderExtensionsFixture.cs
@@ -1,7 +1,11 @@
 ﻿namespace Nancy.Owin.Tests
 {
     using System;
-
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Reflection;
+    using System.Security.Cryptography.X509Certificates;
+    using System.Text;
     using global::Owin;
 
     using Microsoft.Owin.Testing;
@@ -21,7 +25,7 @@
             // Given
             var bootstrapper = new ConfigurableBootstrapper(config => config.Module<TestModule>());
 
-            using(var server = TestServer.Create(app => app.UseNancy(opts => opts.Bootstrapper = bootstrapper)))
+            using (var server = TestServer.Create(app => app.UseNancy(opts => opts.Bootstrapper = bootstrapper)))
             {
                 // When
                 var response = server.HttpClient.GetAsync(new Uri("http://localhost/")).Result;
@@ -30,13 +34,69 @@
                 Assert.Equal(response.StatusCode, System.Net.HttpStatusCode.OK);
             }
         }
+
+        [Fact]
+        public void When_host_Nancy_via_IAppBuilder_should_read_X509Certificate2()
+        {
+            // Given
+            var bootstrapper = new ConfigurableBootstrapper(config => config.Module<TestModule>());
+
+
+            using (var server = TestServer.Create(app => app.UseNancy(opts =>
+            {
+                opts.Bootstrapper = bootstrapper;
+                opts.EnableClientCertificates = true;
+            })))
+            {
+                // When
+                var cert = @"-----BEGIN CERTIFICATE-----
+                            MIICNTCCAZ4CCQC21XwOAYG32zANBgkqhkiG9w0BAQUFADBfMQswCQYDVQQGEwJH
+                            QjETMBEGA1UECBMKU29tZS1TdGF0ZTEOMAwGA1UEChMFTmFuY3kxDjAMBgNVBAsT
+                            BU5hbmN5MRswGQYDVQQDExJodHRwOi8vbmFuY3lmeC5vcmcwHhcNMTYwMjIyMTE1
+                            NzQ3WhcNMTcwMjIxMTE1NzQ3WjBfMQswCQYDVQQGEwJHQjETMBEGA1UECBMKU29t
+                            ZS1TdGF0ZTEOMAwGA1UEChMFTmFuY3kxDjAMBgNVBAsTBU5hbmN5MRswGQYDVQQD
+                            ExJodHRwOi8vbmFuY3lmeC5vcmcwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGB
+                            AMT4vOtIH9Fzad+8KCGjMPkkVpCtn+L5H97bnI3x+y3x5lY0WRsK8FyxVshY/7fv
+                            TDeeVKUWanmbMkQjgFRYffA3ep3/AIguswYdANiNVHrx0L7DXNDcgsjRwaa6JVgQ
+                            9iavlli0a80AF67FN1wfidlHCX53u3/fAjiSTwf7D+NBAgMBAAEwDQYJKoZIhvcN
+                            AQEFBQADgYEAh12A4NntHHdVMGaw+2umXkWqCOyAPuNhyBGUHK5vGON+VG0HPFaf
+                            8P8eMtdF4deBHkrfoWxRuGGn2tJzNpZLiEf23BAivEf36IqwfkVP7/zDwI+bjVXC
+                            k64Un2uN8ALR/wLwfJzHfOLPtsca7ySWhlv8oZo2nk0vR34asQiGJDQ=
+                            -----END CERTIFICATE-----
+                            ";
+
+                byte[] embeddedCert = Encoding.UTF8.GetBytes(cert);
+
+                var env = new Dictionary<string, object>()
+                {
+                    { "owin.RequestPath", "/ssl" },
+                    { "owin.RequestScheme", "http" },
+                    { "owin.RequestHeaders", new Dictionary<string, string[]>() { { "Host", new[] { "localhost" } } } },
+                    { "owin.RequestMethod", "GET" },
+                    {"ssl.ClientCertificate", new X509Certificate(embeddedCert) }
+                };
+                server.Invoke(env);
+
+
+                // Then
+                Assert.Equal(env["owin.ResponseStatusCode"], 200);
+            }
+        }
 #endif
 
         public class TestModule : LegacyNancyModule
         {
             public TestModule()
             {
-                Get["/"] = _ => HttpStatusCode.OK;
+                Get["/"] = _ =>
+                {
+                    return HttpStatusCode.OK;
+                };
+
+                Get["/ssl"] = _ =>
+                {
+                    return this.Request.ClientCertificate != null ? 200 : 500;
+                };
             }
         }
     }


### PR DESCRIPTION
Currently we pass a `byte[]` into `Request` to construct a `ClientCertificate`, in ASPNet Host and SelfHost the incoming request already gives us a `X509Certificate2` so we can pass that through.

The OWIN spec says that `ssl.ClientCertificate` is type `X509Certificate` however we can pull it out of the environment dictionary and cast that to a `X509Certificate2`. This is also how MS [does it](https://github.com/aspnet/HttpAbstractions/blob/5e7b30c04b89441df4b60c0bc49a3b05c3a642db/src/Microsoft.AspNetCore.Owin/OwinFeatureCollection.cs#L248) (their `Prop` method is the same as our `Get` method when retrieving items out the dictionary to a `Type`.