### PR TITLE
Fixed NullReferenceException if Start is not called before Dispose.

### DIFF
--- a/src/Nancy.Hosting.Self/NancyHost.cs
+++ b/src/Nancy.Hosting.Self/NancyHost.cs
@@ -218,10 +218,10 @@
         /// </summary>
         public void Stop()
         {
-            if (this.listener.IsListening)
+            if (this.listener != null && this.listener.IsListening)
             {
                 this.stop = true;
-                listener.Stop();
+                this.listener.Stop();
             }
         }
 

--- a/test/Nancy.Hosting.Self.Tests/NancySelfHostFixture.cs
+++ b/test/Nancy.Hosting.Self.Tests/NancySelfHostFixture.cs
@@ -248,6 +248,20 @@ namespace Nancy.Hosting.Self.Tests
             prefix.ShouldEqual("http://+:80/");
         }
 
+        [Fact]
+        public void Should_not_throw_when_disposed_without_starting()
+        {
+            // Given
+            var bootstrapperMock = A.Fake<INancyBootstrapper>();
+            var host = new NancyHost(new Uri("http://localhost/"), bootstrapperMock);
+
+            // When
+            host.Dispose();
+
+            // Then
+            A.CallTo(() => bootstrapperMock.Dispose()).MustHaveHappened();
+        }
+
         private class NancyHostWrapper : IDisposable
         {
             private readonly NancyHost host;


### PR DESCRIPTION
Fixed an issue where NancyHost.Dispose() would throw an exception if Start() was not previously called.