### PR TITLE
Updated DiagnosticsConfiguration with Enabled

### DIFF
--- a/samples/Nancy.Demo.CustomModule/DemoBootstrapper.cs
+++ b/samples/Nancy.Demo.CustomModule/DemoBootstrapper.cs
@@ -8,6 +8,7 @@
         public override void Configure(INancyEnvironment environment)
         {
             environment.Diagnostics(
+                enabled: true,
                 password: "password");
         }
     }

--- a/samples/Nancy.Demo.Hosting.Aspnet/DemoBootstrapper.cs
+++ b/samples/Nancy.Demo.Hosting.Aspnet/DemoBootstrapper.cs
@@ -30,6 +30,7 @@
         public override void Configure(INancyEnvironment environment)
         {
             environment.Diagnostics(
+                enabled: true,
                 password: "password",
                 path: "/_Nancy",
                 cookieName: "__custom_cookie",

--- a/samples/Nancy.Demo.Hosting.Self/DemoBootstrapper.cs
+++ b/samples/Nancy.Demo.Hosting.Self/DemoBootstrapper.cs
@@ -8,8 +8,8 @@
         public override void Configure(Nancy.Configuration.INancyEnvironment environment)
         {
             environment.Diagnostics(
+                enabled: true,
                 password: "password");
         }
     }
 }
-

--- a/src/Nancy/Diagnostics/DefaultDiagnostics.cs
+++ b/src/Nancy/Diagnostics/DefaultDiagnostics.cs
@@ -28,7 +28,6 @@
         private readonly IEnumerable<IRouteMetadataProvider> routeMetadataProviders;
         private readonly ITextResource textResource;
         private readonly INancyEnvironment environment;
-        private readonly IRuntimeEnvironmentInformation runtimeEnvironmentInformation;
         private readonly ITypeCatalog typeCatalog;
 
         /// <summary>
@@ -46,7 +45,6 @@
         /// <param name="routeMetadataProviders"></param>
         /// <param name="textResource"></param>
         /// <param name="environment"></param>
-        /// <param name="runtimeEnvironmentInformation"></param>
         /// <param name="typeCatalog"></param>
         public DefaultDiagnostics(
             IEnumerable<IDiagnosticsProvider> diagnosticProviders,
@@ -61,7 +59,6 @@
             IEnumerable<IRouteMetadataProvider> routeMetadataProviders,
             ITextResource textResource,
             INancyEnvironment environment,
-            IRuntimeEnvironmentInformation runtimeEnvironmentInformation,
             ITypeCatalog typeCatalog)
         {
             this.diagnosticProviders = diagnosticProviders;
@@ -76,7 +73,6 @@
             this.routeMetadataProviders = routeMetadataProviders;
             this.textResource = textResource;
             this.environment = environment;
-            this.runtimeEnvironmentInformation = runtimeEnvironmentInformation;
             this.typeCatalog = typeCatalog;
         }
 
@@ -100,7 +96,6 @@
                 this.routeMetadataProviders,
                 this.textResource,
                 this.environment,
-                this.runtimeEnvironmentInformation,
                 this.typeCatalog);
         }
     }

--- a/src/Nancy/Diagnostics/DiagnosticsConfiguration.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsConfiguration.cs
@@ -12,6 +12,7 @@
         /// </summary>
         public static readonly DiagnosticsConfiguration Default = new DiagnosticsConfiguration
         {
+            Enabled = false,
             CookieName = "__ncd",
             CryptographyConfiguration = CryptographyConfiguration.Default,
             Password = null,
@@ -26,16 +27,18 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="DiagnosticsConfiguration"/> class
         /// </summary>
+        /// <param name="enabled"></param>
         /// <param name="password">Password used to secure the dashboard.</param>
         /// <param name="path">Relative path of the dashboard.</param>
         /// <param name="cookieName">Name of the cookie to store diagnostics information.</param>
         /// <param name="slidingTimeout">Number of minutes that expiry of the diagnostics dashboard.</param>
         /// <param name="cryptographyConfiguration">Cryptography config to use for securing the dashboard.</param>
-        public DiagnosticsConfiguration(string password, string path, string cookieName, int slidingTimeout, CryptographyConfiguration cryptographyConfiguration)
+        public DiagnosticsConfiguration(bool enabled, string password, string path, string cookieName, int slidingTimeout, CryptographyConfiguration cryptographyConfiguration)
         {
             this.Password = password ?? Default.Password;
             this.Path = GetNormalizedPath(path ?? Default.Path);
             this.CookieName = cookieName ?? Default.CookieName;
+            this.Enabled = enabled;
             this.SlidingTimeout = slidingTimeout;
             this.CryptographyConfiguration = cryptographyConfiguration ?? Default.CryptographyConfiguration;
         }
@@ -47,19 +50,24 @@
         public string CookieName { get; private set; }
 
         /// <summary>
-        /// Gets or sets the cryptography config to use for securing the diagnostics dashboard
+        /// Gets the cryptography config to use for securing the diagnostics dashboard
         /// </summary>
         /// <remarks>The default is <see cref="CryptographyConfiguration.Default"/></remarks>
         public CryptographyConfiguration CryptographyConfiguration { get; private set; }
 
         /// <summary>
-        /// Gets or sets password for accessing the diagnostics screen.
+        /// Gets a value indicating if diagnostics is enabled or not.
+        /// </summary>
+        public bool Enabled { get; private set; }
+
+        /// <summary>
+        /// Gets password for accessing the diagnostics screen.
         /// </summary>
         /// <remarks>The default value is <see langword="null" />.</remarks>
         public string Password { get; private set; }
 
         /// <summary>
-        /// Gets or sets the path that the diagnostics dashboard will be accessible on.
+        /// Gets the path that the diagnostics dashboard will be accessible on.
         /// </summary>
         /// <remarks>The default is /_Nancy.</remarks>
         public string Path { get; private set; }

--- a/src/Nancy/Diagnostics/DiagnosticsConfigurationExtensions.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsConfigurationExtensions.cs
@@ -12,6 +12,28 @@
         /// Configures diagnostics.
         /// </summary>
         /// <param name="environment"><see cref="INancyEnvironment"/> that should be configured.</param>
+        /// <param name="password">Password used to secure the dashboard.</param>
+        /// <param name="path">Relative path of the dashboard.</param>
+        /// <param name="cookieName">Name of the cookie to store diagnostics information.</param>
+        /// <param name="slidingTimeout">Number of minutes that expiry of the diagnostics dashboard.</param>
+        /// <param name="cryptographyConfiguration">Cryptography config to use for securing the dashboard.</param>
+        /// <remarks>This will implicitly enable diagnostics. If you need control, please explicitly set enabled to either <see langword="true"/> or <see langword="false"/>.</remarks>
+        public static void Diagnostics(this INancyEnvironment environment, string password, string path = null, string cookieName = null, int slidingTimeout = 15, CryptographyConfiguration cryptographyConfiguration = null)
+        {
+            Diagnostics(
+                environment,
+                enabled: true,
+                password: password,
+                path: path,
+                cookieName: cookieName,
+                slidingTimeout: slidingTimeout,
+                cryptographyConfiguration: cryptographyConfiguration);
+        }
+
+        /// <summary>
+        /// Configures diagnostics.
+        /// </summary>
+        /// <param name="environment"><see cref="INancyEnvironment"/> that should be configured.</param>
         /// <param name="enabled"><see langword="true"/> if diagnostics should be enabled, otherwise <see langword="false"/>.</param>
         /// <param name="password">Password used to secure the dashboard.</param>
         /// <param name="path">Relative path of the dashboard.</param>

--- a/src/Nancy/Diagnostics/DiagnosticsConfigurationExtensions.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsConfigurationExtensions.cs
@@ -12,19 +12,21 @@
         /// Configures diagnostics.
         /// </summary>
         /// <param name="environment"><see cref="INancyEnvironment"/> that should be configured.</param>
+        /// <param name="enabled"><see langword="true"/> if diagnostics should be enabled, otherwise <see langword="false"/>.</param>
         /// <param name="password">Password used to secure the dashboard.</param>
         /// <param name="path">Relative path of the dashboard.</param>
         /// <param name="cookieName">Name of the cookie to store diagnostics information.</param>
         /// <param name="slidingTimeout">Number of minutes that expiry of the diagnostics dashboard.</param>
         /// <param name="cryptographyConfiguration">Cryptography config to use for securing the dashboard.</param>
-        public static void Diagnostics(this INancyEnvironment environment, string password, string path = null, string cookieName = null, int slidingTimeout = 15, CryptographyConfiguration cryptographyConfiguration = null)
+        public static void Diagnostics(this INancyEnvironment environment, bool enabled, string password, string path = null, string cookieName = null, int slidingTimeout = 15, CryptographyConfiguration cryptographyConfiguration = null)
         {
             environment.AddValue(new DiagnosticsConfiguration(
-                password,
-                path,
-                cookieName,
-                slidingTimeout,
-                cryptographyConfiguration));
+                enabled: enabled,
+                password: password,
+                path: path,
+                cookieName: cookieName,
+                slidingTimeout: slidingTimeout,
+                cryptographyConfiguration: cryptographyConfiguration));
         }
     }
 }

--- a/src/Nancy/Diagnostics/Views/help.sshtml
+++ b/src/Nancy/Diagnostics/Views/help.sshtml
@@ -12,8 +12,7 @@
 @Section['Body']
 	<div class="grid_2">&nbsp;</div>
 	<div class="grid_8 help">
-		<p>Diagnostics is currently disabled. To enable it you need to supply a valid DiagnosticsConfiguration (with a strong password!) by overriding the relevent property in your bootstrapper.</p>
-		<p>Alternatively you can disable this message by calling DiagnosticsHook.Disable();</p>
+		<p>Diagnostics is currently not correctly configured for this website. Please review your diagnostic configuration and try again.</p>
 	</div>
 	<div class="grid_2">&nbsp;</div>
 @EndSection

--- a/test/Nancy.Tests/Unit/Diagnostics/CustomInteractiveDiagnosticsFixture.cs
+++ b/test/Nancy.Tests/Unit/Diagnostics/CustomInteractiveDiagnosticsFixture.cs
@@ -43,7 +43,6 @@
             private readonly IEnumerable<IRouteMetadataProvider> routeMetadataProviders;
             private readonly ITextResource textResource;
             private readonly INancyEnvironment environment;
-            private readonly IRuntimeEnvironmentInformation runtimeEnvironmentInformation;
             private readonly ITypeCatalog typeCatalog;
 
             public FakeDiagnostics(
@@ -58,7 +57,6 @@
                 IEnumerable<IRouteMetadataProvider> routeMetadataProviders,
                 ITextResource textResource,
                 INancyEnvironment environment,
-                IRuntimeEnvironmentInformation runtimeEnvironmentInformation,
                 ITypeCatalog typeCatalog)
             {
                 this.diagnosticProviders = (new IDiagnosticsProvider[] { new FakeDiagnosticsProvider() }).ToArray();
@@ -73,7 +71,6 @@
                 this.routeMetadataProviders = routeMetadataProviders;
                 this.textResource = textResource;
                 this.environment = environment;
-                this.runtimeEnvironmentInformation = runtimeEnvironmentInformation;
                 this.typeCatalog = typeCatalog;
             }
 
@@ -93,7 +90,6 @@
                     this.routeMetadataProviders,
                     this.textResource,
                     this.environment,
-                    this.runtimeEnvironmentInformation,
                     this.typeCatalog);
             }
         }
@@ -125,6 +121,7 @@
                 with.Configure(env =>
                 {
                     env.Diagnostics(
+                        enabled: true,
                         password: "password",
                         cryptographyConfiguration: this.cryptoConfig);
                 });

--- a/test/Nancy.Tests/Unit/Diagnostics/DiagnosticsHookFixture.cs
+++ b/test/Nancy.Tests/Unit/Diagnostics/DiagnosticsHookFixture.cs
@@ -34,6 +34,7 @@
                 with.Configure(env =>
                 {
                     env.Diagnostics(
+                        enabled: true,
                         password: null,
                         cryptographyConfiguration: this.cryptoConfig);
                 });
@@ -60,6 +61,7 @@
                 with.Configure(env =>
                 {
                     env.Diagnostics(
+                        enabled: true,
                         password: string.Empty,
                         cryptographyConfiguration: this.cryptoConfig);
                 });
@@ -87,6 +89,7 @@
                 with.Configure(env =>
                 {
                     env.Diagnostics(
+                        enabled: true,
                         password: "password",
                         cryptographyConfiguration: this.cryptoConfig);
                 });
@@ -113,6 +116,7 @@
                 with.Configure(env =>
                 {
                     env.Diagnostics(
+                        enabled: true,
                         password: "password",
                         cryptographyConfiguration: this.cryptoConfig);
                 });
@@ -142,6 +146,7 @@
                 with.Configure(env =>
                 {
                     env.Diagnostics(
+                        enabled: true,
                         password: "password",
                         cryptographyConfiguration: this.cryptoConfig);
                 });
@@ -171,6 +176,7 @@
                 with.Configure(env =>
                 {
                     env.Diagnostics(
+                        enabled: true,
                         password: "password",
                         cryptographyConfiguration: this.cryptoConfig);
                 });
@@ -200,6 +206,7 @@
                 with.Configure(env =>
                 {
                     env.Diagnostics(
+                        enabled: true,
                         password: "password",
                         cryptographyConfiguration: this.cryptoConfig);
                 });
@@ -230,6 +237,7 @@
                 with.Configure(env =>
                 {
                     env.Diagnostics(
+                        enabled: true,
                         password: "password",
                         cryptographyConfiguration: this.cryptoConfig);
                 });
@@ -260,6 +268,7 @@
                 with.Configure(env =>
                 {
                     env.Diagnostics(
+                        enabled: true,
                         password: "password",
                         cryptographyConfiguration: this.cryptoConfig);
                 });
@@ -292,6 +301,7 @@
                 with.Configure(env =>
                 {
                     env.Diagnostics(
+                        enabled: true,
                         password: "password",
                         cryptographyConfiguration: this.cryptoConfig);
                 });


### PR DESCRIPTION
The following modifications where made

- new member to control if diagnostics should be enabled or not (will defaults to false)
- updated the diagnostics hook to not use `IRuntimeEnvironmentInformation.IsDebug` to determine if it should display a help page or not
- updated help page text as it was no longer relevant since we migrated to the configuration API

It makes sense to have the `Enabled` property on it, because then the user application can set this value depending on things like an environment variable etc.

Most of the changed files are either test fixtures or boostrappers in sample projects. The main file is the `DiagnosticsHook` class