### PR TITLE
Specify v3.4.0.0 of FluentValidation in nuspec

### DIFF
--- a/src/Nancy.Validation.FluentValidation/nancy.validation.fluentvalidation.nuspec
+++ b/src/Nancy.Validation.FluentValidation/nancy.validation.fluentvalidation.nuspec
@@ -14,7 +14,7 @@
     <projectUrl>http://nancyfx.org</projectUrl>
     <dependencies>
       <dependency id="Nancy" />
-      <dependency id="FluentValidation" />
+      <dependency id="FluentValidation" version="3.4.0.0" />
     </dependencies> 
     <tags>Nancy Validation FluentValidation</tags>
   </metadata>

--- a/src/Nancy.Validation.FluentValidation/nancy.validation.fluentvalidation.nuspec
+++ b/src/Nancy.Validation.FluentValidation/nancy.validation.fluentvalidation.nuspec
@@ -14,7 +14,7 @@
     <projectUrl>http://nancyfx.org</projectUrl>
     <dependencies>
       <dependency id="Nancy" />
-      <dependency id="FluentValidation" version="3.4.0.0" />
+      <dependency id="FluentValidation" version="3.4.0" />
     </dependencies> 
     <tags>Nancy Validation FluentValidation</tags>
   </metadata>


### PR DESCRIPTION
Simple addition to add specific version of FluentValidation to Nancy.Validation.FluentValidation nuspec.

Fixes the issue raised at https://github.com/NancyFx/Nancy/issues/2302 - basically an incompatible version of the FluentValidation package is installed during package installation of Nancy.Validation.FluentValidation.