### PR TITLE
Removed use of IAssemblyCatalog in DefaultObjectSerializer

### DIFF
--- a/samples/Nancy.Demo.Hosting.Aspnet/DemoBootstrapper.cs
+++ b/samples/Nancy.Demo.Hosting.Aspnet/DemoBootstrapper.cs
@@ -67,7 +67,7 @@
 
             this.Conventions.StaticContentsConventions.Add(StaticContentConventionBuilder.AddDirectory("moo", "Content"));
 
-            CookieBasedSessions.Enable(pipelines, this.AssemblyCatalog);
+            CookieBasedSessions.Enable(pipelines);
 
             pipelines.AfterRequest += (ctx) =>
             {

--- a/src/Nancy/Diagnostics/DiagnosticsHook.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsHook.cs
@@ -58,7 +58,7 @@ namespace Nancy.Diagnostics
                 new RouteResolverTrie(new TrieNodeFactory(routeSegmentConstraints)),
                 environment);
 
-            var serializer = new DefaultObjectSerializer(assemblyCatalog);
+            var serializer = new DefaultObjectSerializer();
 
             pipelines.BeforeRequest.AddItemToStartOfPipeline(
                 new PipelineItem<Func<NancyContext, Response>>(

--- a/src/Nancy/Session/CookieBasedSessions.cs
+++ b/src/Nancy/Session/CookieBasedSessions.cs
@@ -23,10 +23,7 @@ namespace Nancy.Session
         /// <value>Cookie name</value>
         public string CookieName
         {
-            get
-            {
-                return this.currentConfiguration.CookieName;
-            }
+            get { return this.currentConfiguration.CookieName; }
         }
 
         /// <summary>
@@ -62,8 +59,6 @@ namespace Nancy.Session
             this.currentConfiguration = configuration;
         }
 
-
-
         /// <summary>
         /// Initialise and add cookie based session hooks to the application pipeline
         /// </summary>
@@ -90,13 +85,12 @@ namespace Nancy.Session
         /// </summary>
         /// <param name="pipelines">Application pipelines</param>
         /// <param name="cryptographyConfiguration">Cryptography configuration</param>
-        /// <param name="assemblyCatalog">Assembly catalog</param>
         /// <returns>Formatter selector for choosing a non-default serializer</returns>
-        public static IObjectSerializerSelector Enable(IPipelines pipelines, CryptographyConfiguration cryptographyConfiguration, IAssemblyCatalog assemblyCatalog)
+        public static IObjectSerializerSelector Enable(IPipelines pipelines, CryptographyConfiguration cryptographyConfiguration)
         {
             var cookieBasedSessionsConfiguration = new CookieBasedSessionsConfiguration(cryptographyConfiguration)
             {
-                Serializer = new DefaultObjectSerializer(assemblyCatalog)
+                Serializer = new DefaultObjectSerializer()
             };
             return Enable(pipelines, cookieBasedSessionsConfiguration);
         }
@@ -105,13 +99,12 @@ namespace Nancy.Session
         /// Initialise and add cookie based session hooks to the application pipeline with the default encryption provider.
         /// </summary>
         /// <param name="pipelines">Application pipelines</param>
-        /// <param name="assemblyCatalog">Assembly catalog</param>
         /// <returns>Formatter selector for choosing a non-default serializer</returns>
-        public static IObjectSerializerSelector Enable(IPipelines pipelines, IAssemblyCatalog assemblyCatalog)
+        public static IObjectSerializerSelector Enable(IPipelines pipelines)
         {
             return Enable(pipelines, new CookieBasedSessionsConfiguration
             {
-                Serializer = new DefaultObjectSerializer(assemblyCatalog)
+                Serializer = new DefaultObjectSerializer()
             });
         }
 

--- a/test/Nancy.Testing.Tests/BrowserFixture.cs
+++ b/test/Nancy.Testing.Tests/BrowserFixture.cs
@@ -6,18 +6,17 @@ namespace Nancy.Testing.Tests
     using System.Linq;
     using System.Security.Cryptography.X509Certificates;
     using System.Text;
+    using System.Collections.ObjectModel;
+    using System.Threading.Tasks;
     using Nancy.Extensions;
     using Nancy.Helpers;
     using Nancy.Session;
     using Nancy.Tests;
-    using Xunit;
-    using FakeItEasy;
     using Nancy.Authentication.Forms;
-    using System.Collections.ObjectModel;
-    using System.Threading.Tasks;
-    using Nancy.Bootstrapper;
     using Nancy.Configuration;
     using Nancy.Tests.xUnitExtensions;
+    using Xunit;
+    using FakeItEasy;
 
     public class BrowserFixture
     {
@@ -28,7 +27,7 @@ namespace Nancy.Testing.Tests
             var bootstrapper =
                 new ConfigurableBootstrapper(config => config.Modules(typeof(EchoModule)));
 
-            CookieBasedSessions.Enable(bootstrapper, A.Fake<IAssemblyCatalog>());
+            CookieBasedSessions.Enable(bootstrapper);
 
             this.browser = new Browser(bootstrapper);
         }

--- a/test/Nancy.Tests/Unit/Diagnostics/CustomInteractiveDiagnosticsFixture.cs
+++ b/test/Nancy.Tests/Unit/Diagnostics/CustomInteractiveDiagnosticsFixture.cs
@@ -3,9 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Reflection;
     using System.Threading.Tasks;
-    using FakeItEasy;
     using Nancy.Bootstrapper;
     using Nancy.Configuration;
     using Nancy.Cryptography;
@@ -28,14 +26,7 @@
         public CustomInteractiveDiagnosticsHookFixture()
         {
             this.cryptoConfig = CryptographyConfiguration.Default;
-            var fakeAssemblyCatalog = A.Fake<IAssemblyCatalog>();
-            A.CallTo(() => fakeAssemblyCatalog.GetAssemblies(AssemblyResolveStrategies.All))
-                .Returns(new[]
-                {
-                    typeof(CustomInteractiveDiagnosticsHookFixture).GetTypeInfo().Assembly,
-                    typeof(DiagnosticsSession).GetTypeInfo().Assembly
-                });
-            this.objectSerializer = new DefaultObjectSerializer(fakeAssemblyCatalog);
+            this.objectSerializer = new DefaultObjectSerializer();
         }
 
         private class FakeDiagnostics : IDiagnostics

--- a/test/Nancy.Tests/Unit/Diagnostics/DiagnosticsHookFixture.cs
+++ b/test/Nancy.Tests/Unit/Diagnostics/DiagnosticsHookFixture.cs
@@ -15,22 +15,13 @@
     public class DiagnosticsHookFixture
     {
         private const string DiagsCookieName = "__ncd";
-
         private readonly CryptographyConfiguration cryptoConfig;
-
         private readonly IObjectSerializer objectSerializer;
 
         public DiagnosticsHookFixture()
         {
             this.cryptoConfig = CryptographyConfiguration.Default;
-            var fakeAssemblyCatalog = A.Fake<IAssemblyCatalog>();
-            A.CallTo(() => fakeAssemblyCatalog.GetAssemblies(AssemblyResolveStrategies.All))
-                .Returns(new[]
-                {
-                    typeof(DiagnosticsHookFixture).GetTypeInfo().Assembly,
-                    typeof(DiagnosticsSession).GetTypeInfo().Assembly
-                });
-            this.objectSerializer = new DefaultObjectSerializer(fakeAssemblyCatalog);
+            this.objectSerializer = new DefaultObjectSerializer();
         }
 
 #if DEBUG

--- a/test/Nancy.Tests/Unit/Security/CsrfFixture.cs
+++ b/test/Nancy.Tests/Unit/Security/CsrfFixture.cs
@@ -2,14 +2,10 @@
 {
     using System.Collections.Generic;
     using System.Linq;
-    using System.Reflection;
     using System.Threading;
-
     using FakeItEasy;
-
     using Nancy.Bootstrapper;
     using Nancy.Cryptography;
-    using Nancy.Helpers;
     using Nancy.Security;
     using Nancy.Tests.Fakes;
 
@@ -18,27 +14,18 @@
     public class CsrfFixture
     {
         private readonly IPipelines pipelines;
-
         private readonly Request request;
-
         private readonly FakeRequest optionsRequest;
-
         private readonly Response response;
-
         private readonly CryptographyConfiguration cryptographyConfiguration;
-
         private readonly DefaultObjectSerializer objectSerializer;
-
 
         public CsrfFixture()
         {
             this.pipelines = new MockPipelines();
 
             this.cryptographyConfiguration = CryptographyConfiguration.Default;
-            var fakeAssemblyCatalog = A.Fake<IAssemblyCatalog>();
-            A.CallTo(() => fakeAssemblyCatalog.GetAssemblies(AssemblyResolveStrategies.All))
-                .Returns(new[] { typeof(CsrfFixture).GetTypeInfo().Assembly, typeof(CsrfToken).GetTypeInfo().Assembly });
-            this.objectSerializer = new DefaultObjectSerializer(fakeAssemblyCatalog);
+            this.objectSerializer = new DefaultObjectSerializer();
             var csrfStartup = new CsrfApplicationStartup(
                 this.cryptographyConfiguration,
                 this.objectSerializer,

--- a/test/Nancy.Tests/Unit/Sessions/DefaultSessionObjectFormatterFixture.cs
+++ b/test/Nancy.Tests/Unit/Sessions/DefaultSessionObjectFormatterFixture.cs
@@ -1,20 +1,15 @@
 namespace Nancy.Tests.Unit.Sessions
 {
     using System;
-    using System.Reflection;
-    using FakeItEasy;
     using Xunit;
 
     public class DefaultSessionObjectFormatterFixture
     {
-        private DefaultObjectSerializer serializer;
+        private readonly DefaultObjectSerializer serializer;
 
         public DefaultSessionObjectFormatterFixture()
         {
-            var fakeAssemblyCatalog = A.Fake<IAssemblyCatalog>();
-            A.CallTo(() => fakeAssemblyCatalog.GetAssemblies(AssemblyResolveStrategies.All))
-                .Returns(new[] { typeof(DefaultSessionObjectFormatterFixture).GetTypeInfo().Assembly });
-            this.serializer = new DefaultObjectSerializer(fakeAssemblyCatalog);
+            this.serializer = new DefaultObjectSerializer();
         }
 
         [Fact]
@@ -43,7 +38,7 @@ namespace Nancy.Tests.Unit.Sessions
         public void Should_return_empty_string_when_serializing_null()
         {
             object input = null;
-            
+
             var output = this.serializer.Serialize(input);
 
             output.ShouldEqual(string.Empty);
@@ -80,7 +75,7 @@ namespace Nancy.Tests.Unit.Sessions
 
             public Payload()
             {
-                
+
             }
 
             /// <summary>


### PR DESCRIPTION
I removed the use of `IAssemblyCatalog` to resolve the `AssemblyQualifiedName` of a `Type`. All tests passed after the change. I also tidied up the code a bit after it was removed.