### PR TITLE
Removed use of Assembly.EscapedCodeBase

### DIFF
--- a/src/Nancy.ViewEngines.Razor/CSharp/CSharpRazorViewRenderer.cs
+++ b/src/Nancy.ViewEngines.Razor/CSharp/CSharpRazorViewRenderer.cs
@@ -4,10 +4,7 @@
     using System.CodeDom.Compiler;
     using System.Collections.Generic;
     using System.Web.Razor;
-    using Microsoft.CSharp;
     using Microsoft.CSharp.RuntimeBinder;
-
-    using Nancy.Extensions;
 
     /// <summary>
     /// Renderer for CSharp razor files.
@@ -50,7 +47,7 @@
         {
             this.Assemblies = new List<string>
             {
-                typeof(Binder).GetAssemblyPath()
+                typeof(Binder).Assembly.Location
             };
 
             this.ModelCodeGenerator = typeof(ModelCodeGenerator);
@@ -65,7 +62,6 @@
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
-        /// <filterpriority>2</filterpriority>
         public void Dispose()
         {
             if (this.Provider != null)

--- a/src/Nancy/Extensions/TypeExtensions.cs
+++ b/src/Nancy/Extensions/TypeExtensions.cs
@@ -10,19 +10,6 @@
     public static class TypeExtensions
     {
         /// <summary>
-        /// Gets the path of the assembly that contains the provided type.
-        /// </summary>
-        /// <param name="source">The <see cref="Type"/> to look up the assembly path for.</param>
-        /// <returns>A string containing the path of the assembly that contains the type.</returns>
-        public static string GetAssemblyPath(this Type source)
-        {
-            var assemblyUri =
-                new Uri(source.Assembly.EscapedCodeBase);
-
-            return assemblyUri.LocalPath;
-        }
-
-        /// <summary>
         /// Checks if a type is an array or not
         /// </summary>
         /// <param name="source">The type to check.</param>


### PR DESCRIPTION
This was used quite a lot, in the Razor engine, before we moved it over to Roslyn. The only assembly we now need to load into the `CSharpCodeProvider` is `Microsoft.CSharp` and since that is in the GAC we can just use `Asembly.Location`