### PR TITLE
Added a ILibraryManager based IAssemblyCatalog for DNX

### DIFF
--- a/src/Nancy/AppDomainAssemblyCatalog.cs
+++ b/src/Nancy/AppDomainAssemblyCatalog.cs
@@ -1,3 +1,4 @@
+#if !DNX
 namespace Nancy
 {
     using System;
@@ -147,3 +148,4 @@ namespace Nancy
         }
     }
 }
+#endif

--- a/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
+++ b/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
@@ -89,7 +89,15 @@
         /// <value>An <see cref="IAssemblyCatalog"/> instance.</value>
         protected virtual IAssemblyCatalog AssemblyCatalog
         {
-            get { return this.assemblyCatalog ?? (this.assemblyCatalog = new AppDomainAssemblyCatalog()); }
+            get {
+                return this.assemblyCatalog ?? (
+#if !DNX
+                    this.assemblyCatalog = new AppDomainAssemblyCatalog()
+#else
+                    this.assemblyCatalog = new LibraryManagerAssemblyCatalog()
+#endif
+                );
+            }
         }
 
         /// <summary>

--- a/src/Nancy/LibraryManagerAssemblyCatalog.cs
+++ b/src/Nancy/LibraryManagerAssemblyCatalog.cs
@@ -19,7 +19,7 @@ namespace Nancy
             this.assemblies = new Lazy<IReadOnlyCollection<Assembly>>(this.LoadAllNancyReferencingAssemblies);
         }
 
-        public IReadOnlyCollection<Assembly> GetAssemblies(AssemblyResolveStrategy strategy)
+        public IReadOnlyCollection<Assembly> GetAssemblies()
         {
             return this.assemblies.Value;
         }

--- a/src/Nancy/LibraryManagerAssemblyCatalog.cs
+++ b/src/Nancy/LibraryManagerAssemblyCatalog.cs
@@ -35,7 +35,7 @@ namespace Nancy
             return this.assemblies.Value;
         }
 
-        public IReadOnlyCollection<Assembly> LoadAllNancyReferencingAssemblies()
+        private IReadOnlyCollection<Assembly> LoadAllNancyReferencingAssemblies()
         {
             var results = new HashSet<Assembly>
             {

--- a/src/Nancy/LibraryManagerAssemblyCatalog.cs
+++ b/src/Nancy/LibraryManagerAssemblyCatalog.cs
@@ -7,18 +7,29 @@ namespace Nancy
     using System.Reflection;
     using Microsoft.Extensions.PlatformAbstractions;
 
+    /// <summary>
+    /// Default implementation of the <see cref="IAssemblyCatalog"/> interface, based on
+    /// retrieving <see cref="Assembly"/> information from an <see cref="ILibraryManager"/>.
+    /// </summary>
     public class LibraryManagerAssemblyCatalog : IAssemblyCatalog
     {
         private readonly ILibraryManager libraryManager;
         private readonly AssemblyName nancyAssemblyName = typeof(LibraryManagerAssemblyCatalog).GetTypeInfo().Assembly.GetName();
         private readonly Lazy<IReadOnlyCollection<Assembly>> assemblies;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LibraryManagerAssemblyCatalog"/> class.
+        /// </summary>
         public LibraryManagerAssemblyCatalog()
         {
             this.libraryManager = PlatformServices.Default.LibraryManager;
             this.assemblies = new Lazy<IReadOnlyCollection<Assembly>>(this.LoadAllNancyReferencingAssemblies);
         }
 
+        /// <summary>
+        /// Gets all <see cref="Assembly"/> instances in the catalog.
+        /// </summary>
+        /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Assembly"/> instances.</returns>
         public IReadOnlyCollection<Assembly> GetAssemblies()
         {
             return this.assemblies.Value;

--- a/src/Nancy/LibraryManagerAssemblyCatalog.cs
+++ b/src/Nancy/LibraryManagerAssemblyCatalog.cs
@@ -1,0 +1,57 @@
+#if DNX
+namespace Nancy
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Microsoft.Extensions.PlatformAbstractions;
+
+    public class LibraryManagerAssemblyCatalog : IAssemblyCatalog
+    {
+        private readonly ILibraryManager libraryManager;
+        private readonly AssemblyName nancyAssemblyName = typeof(LibraryManagerAssemblyCatalog).GetTypeInfo().Assembly.GetName();
+        private readonly Lazy<IReadOnlyCollection<Assembly>> assemblies;
+
+        public LibraryManagerAssemblyCatalog()
+        {
+            this.libraryManager = PlatformServices.Default.LibraryManager;
+            this.assemblies = new Lazy<IReadOnlyCollection<Assembly>>(this.LoadAllNancyReferencingAssemblies);
+        }
+
+        public IReadOnlyCollection<Assembly> GetAssemblies(AssemblyResolveStrategy strategy)
+        {
+            return this.assemblies.Value;
+        }
+
+        public IReadOnlyCollection<Assembly> LoadAllNancyReferencingAssemblies()
+        {
+            var results = new HashSet<Assembly>
+            {
+                typeof (INancyEngine).GetTypeInfo().Assembly
+            };
+
+            var referencingLibraries = this.libraryManager.GetReferencingLibraries(this.nancyAssemblyName.Name);
+
+            foreach (var assemblyName in referencingLibraries.SelectMany(referencingLibrary => referencingLibrary.Assemblies))
+            {
+                results.Add(SafeLoadAssembly(assemblyName));
+            }
+
+            return results.ToArray();
+        }
+
+        private static Assembly SafeLoadAssembly(AssemblyName assemblyName)
+        {
+            try
+            {
+                return Assembly.Load(assemblyName);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+    }
+}
+#endif

--- a/test/Nancy.Tests/Unit/Bootstrapper/NancyInternalConfigurationFixture.cs
+++ b/test/Nancy.Tests/Unit/Bootstrapper/NancyInternalConfigurationFixture.cs
@@ -12,7 +12,15 @@ namespace Nancy.Tests.Unit.Bootstrapper
 
         public NancyInternalConfigurationFixture()
         {
-            this.typeCatalog = new DefaultTypeCatalog(new AppDomainAssemblyCatalog());
+            IAssemblyCatalog assemblyCatalog;
+
+#if !DNX
+            assemblyCatalog = new AppDomainAssemblyCatalog();
+#else
+            assemblyCatalog = new LibraryManagerAssemblyCatalog();
+#endif
+
+            this.typeCatalog = new DefaultTypeCatalog(assemblyCatalog);
         }
 
         [Fact]

--- a/test/Nancy.ViewEngines.Razor.Tests/RazorViewEngineFixture.cs
+++ b/test/Nancy.ViewEngines.Razor.Tests/RazorViewEngineFixture.cs
@@ -24,15 +24,22 @@
 
         public RazorViewEngineFixture()
         {
+            IAssemblyCatalog assemblyCatalog;
+
+#if !DNX
+            assemblyCatalog = new AppDomainAssemblyCatalog();
+#else
+            assemblyCatalog = new LibraryManagerAssemblyCatalog();
+#endif
+
             var environment = new DefaultNancyEnvironment();
             environment.Tracing(
                 enabled: true,
                 displayErrorTraces: true);
 
             this.configuration = A.Fake<IRazorConfiguration>();
+            this.engine = new RazorViewEngine(this.configuration, environment, assemblyCatalog);
             A.CallTo(() => this.configuration.GetAssemblyNames()).Returns(new[] { "Nancy.ViewEngines.Razor.Tests.Models" });
-
-            this.engine = new RazorViewEngine(this.configuration, environment, new AppDomainAssemblyCatalog());
 
             var cache = A.Fake<IViewCache>();
             A.CallTo(() => cache.GetOrAdd(A<ViewLocationResult>.Ignored, A<Func<ViewLocationResult, Func<INancyRazorView>>>.Ignored))


### PR DESCRIPTION
As principal as the `AppDomainAssemblyCatalog` but based around `ILibraryManager`

Will return the following assemblies

- The Nancy assembly
- Anything that has a reference on the Nancy assembly