### PR TITLE
Created new culture convention for default culture

### DIFF
--- a/src/Nancy.MSBuild/Nancy.csproj
+++ b/src/Nancy.MSBuild/Nancy.csproj
@@ -1361,6 +1361,9 @@
     <Compile Include="..\Nancy\GlobalizationConfiguration.cs" />
     <Compile Include="..\Nancy\GlobalizationConfigurationExtensions.cs" />
     <Compile Include="..\Nancy\DefaultGlobalizationConfigurationProvider.cs" />
+    <Compile Include="..\Nancy\Configuration\ConfigurationException.cs">
+      <Link>Configuration\ConfigurationException.cs</Link>
+    </Compile>  
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\Nancy\Diagnostics\Views\Dashboard.sshtml">

--- a/src/Nancy/Configuration/ConfigurationException.cs
+++ b/src/Nancy/Configuration/ConfigurationException.cs
@@ -1,0 +1,20 @@
+namespace Nancy
+{
+    using System;
+    using Nancy.Configuration;
+
+    /// <summary>
+    /// An exception related to an invalid configuration created within <see cref="INancyEnvironment"/>
+    /// </summary>
+    public class ConfigurationException : Exception
+    {
+        /// <summary>
+        /// Create an instance of <see cref="ConfigurationException"/>
+        /// </summary>
+        /// <param name="message">A message to be passed into the exception</param>
+        public ConfigurationException(string message) : base(message)
+        {
+            
+        }
+    }
+}

--- a/src/Nancy/Conventions/BuiltInCultureConventions.cs
+++ b/src/Nancy/Conventions/BuiltInCultureConventions.cs
@@ -133,7 +133,12 @@
         /// <returns>CultureInfo from CurrentThread</returns>
         public static CultureInfo ThreadCulture(NancyContext context, GlobalizationConfiguration configuration)
         {
+#if DOTNET5_4
+            CultureInfo.CurrentCulture = new CultureInfo(configuration.SupportedCultureNames.First());
+            return CultureInfo.CurrentCulture;
+#else
             return Thread.CurrentThread.CurrentCulture;
+#endif
         }
 
         /// <summary>

--- a/src/Nancy/Conventions/BuiltInCultureConventions.cs
+++ b/src/Nancy/Conventions/BuiltInCultureConventions.cs
@@ -130,7 +130,7 @@
         /// <param name="context">NancyContext</param>
         /// <param name="configuration">Culture configuration that contains allowed cultures</param>
         /// <returns></returns>
-        public static CultureInfo ConfigurationCulture(NancyContext context, GlobalizationConfiguration configuration)
+        public static CultureInfo GlobalizationConfigurationCulture(NancyContext context, GlobalizationConfiguration configuration)
         {
             if (configuration.DefaultCulture != null)
             {

--- a/src/Nancy/Conventions/BuiltInCultureConventions.cs
+++ b/src/Nancy/Conventions/BuiltInCultureConventions.cs
@@ -124,6 +124,26 @@
 
             return null;
         }
+        /// <summary>
+        /// Checks to see if a default culture has been set on <see cref="GlobalizationConfiguration"/>
+        /// </summary>
+        /// <param name="context">NancyContext</param>
+        /// <param name="configuration">Culture configuration that contains allowed cultures</param>
+        /// <returns></returns>
+        public static CultureInfo ConfigurationCulture(NancyContext context, GlobalizationConfiguration configuration)
+        {
+            if (configuration.DefaultCulture != null)
+            {
+                if (!IsValidCultureInfoName(configuration.DefaultCulture, configuration))
+                {
+                    return null;
+                }
+
+                return new CultureInfo(configuration.DefaultCulture);
+            }
+
+            return null;
+        }
 
         /// <summary>
         /// Uses the Thread.CurrentThread.CurrentCulture
@@ -134,7 +154,6 @@
         public static CultureInfo ThreadCulture(NancyContext context, GlobalizationConfiguration configuration)
         {
 #if DOTNET5_4
-            CultureInfo.CurrentCulture = new CultureInfo(configuration.SupportedCultureNames.First());
             return CultureInfo.CurrentCulture;
 #else
             return Thread.CurrentThread.CurrentCulture;

--- a/src/Nancy/Conventions/BuiltInCultureConventions.cs
+++ b/src/Nancy/Conventions/BuiltInCultureConventions.cs
@@ -153,11 +153,7 @@
         /// <returns>CultureInfo from CurrentThread</returns>
         public static CultureInfo ThreadCulture(NancyContext context, GlobalizationConfiguration configuration)
         {
-#if DOTNET5_4
             return CultureInfo.CurrentCulture;
-#else
-            return Thread.CurrentThread.CurrentCulture;
-#endif
         }
 
         /// <summary>

--- a/src/Nancy/Conventions/BuiltInCultureConventions.cs
+++ b/src/Nancy/Conventions/BuiltInCultureConventions.cs
@@ -146,17 +146,6 @@
         }
 
         /// <summary>
-        /// Uses the Thread.CurrentThread.CurrentCulture
-        /// </summary>
-        /// <param name="context">NancyContext</param>
-        /// <param name="configuration">Culture configuration that contains allowed cultures</param>
-        /// <returns>CultureInfo from CurrentThread</returns>
-        public static CultureInfo ThreadCulture(NancyContext context, GlobalizationConfiguration configuration)
-        {
-            return CultureInfo.CurrentCulture;
-        }
-
-        /// <summary>
         /// Validates culture name
         /// </summary>
         /// <param name="name">Culture name eg\en-GB</param>

--- a/src/Nancy/Conventions/BuiltInCultureConventions.cs
+++ b/src/Nancy/Conventions/BuiltInCultureConventions.cs
@@ -129,7 +129,7 @@
         /// </summary>
         /// <param name="context">NancyContext</param>
         /// <param name="configuration">Culture configuration that contains allowed cultures</param>
-        /// <returns></returns>
+        /// <returns>CultureInfo if found in <see cref="GlobalizationConfiguration"/> Default Culture else null</returns>
         public static CultureInfo GlobalizationConfigurationCulture(NancyContext context, GlobalizationConfiguration configuration)
         {
             if (configuration.DefaultCulture != null)

--- a/src/Nancy/Conventions/DefaultCultureConventions.cs
+++ b/src/Nancy/Conventions/DefaultCultureConventions.cs
@@ -47,7 +47,7 @@
                 BuiltInCultureConventions.HeaderCulture,
                 BuiltInCultureConventions.SessionCulture,
                 BuiltInCultureConventions.CookieCulture,
-                BuiltInCultureConventions.ConfigurationCulture,
+                BuiltInCultureConventions.GlobalizationConfigurationCulture,
                 BuiltInCultureConventions.ThreadCulture
             };
         }

--- a/src/Nancy/Conventions/DefaultCultureConventions.cs
+++ b/src/Nancy/Conventions/DefaultCultureConventions.cs
@@ -48,7 +48,6 @@
                 BuiltInCultureConventions.SessionCulture,
                 BuiltInCultureConventions.CookieCulture,
                 BuiltInCultureConventions.GlobalizationConfigurationCulture,
-                BuiltInCultureConventions.ThreadCulture
             };
         }
     }

--- a/src/Nancy/Conventions/DefaultCultureConventions.cs
+++ b/src/Nancy/Conventions/DefaultCultureConventions.cs
@@ -4,6 +4,9 @@
     using System.Collections.Generic;
     using System.Globalization;
 
+    /// <summary>
+    /// Default implementation of <see cref="IConvention"/>
+    /// </summary>
     public class DefaultCultureConventions : IConvention
     {
         /// <summary>
@@ -44,6 +47,7 @@
                 BuiltInCultureConventions.HeaderCulture,
                 BuiltInCultureConventions.SessionCulture,
                 BuiltInCultureConventions.CookieCulture,
+                BuiltInCultureConventions.ConfigurationCulture,
                 BuiltInCultureConventions.ThreadCulture
             };
         }

--- a/src/Nancy/GlobalizationConfiguration.cs
+++ b/src/Nancy/GlobalizationConfiguration.cs
@@ -15,15 +15,22 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="GlobalizationConfiguration"/> class
         /// </summary>
-        /// <param name="supportedCultureNames"></param>
-        public GlobalizationConfiguration(IEnumerable<string> supportedCultureNames)
+        /// <param name="supportedCultureNames">An array of supported cultures</param>
+        /// <param name="defaultCulture">The default culture of the application</param>
+        public GlobalizationConfiguration(IEnumerable<string> supportedCultureNames, string defaultCulture = null)
         {
             this.SupportedCultureNames = supportedCultureNames;
+            this.DefaultCulture = defaultCulture;
         }
 
         /// <summary>
         /// A set of supported cultures
         /// </summary>
         public IEnumerable<string> SupportedCultureNames { get; private set; }
+
+        /// <summary>
+        /// The default culture for the application
+        /// </summary>
+        public string DefaultCulture { get; set; }
     }
 }

--- a/src/Nancy/GlobalizationConfiguration.cs
+++ b/src/Nancy/GlobalizationConfiguration.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
 
     /// <summary>
@@ -12,7 +13,7 @@
         /// <summary>
         /// A default instance of the <see cref="GlobalizationConfiguration"/> class
         /// </summary>
-        public static readonly GlobalizationConfiguration Default = new GlobalizationConfiguration(supportedCultureNames: new[] { "en-US" }, defaultCulture: "en-US");
+        public static readonly GlobalizationConfiguration Default = new GlobalizationConfiguration(supportedCultureNames: new[] { CultureInfo.CurrentCulture.Name }, defaultCulture: CultureInfo.CurrentCulture.Name);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GlobalizationConfiguration"/> class
@@ -21,12 +22,24 @@
         /// <param name="defaultCulture">The default culture of the application</param>
         public GlobalizationConfiguration(IEnumerable<string> supportedCultureNames, string defaultCulture = null)
         {
-            if (supportedCultureNames != null && supportedCultureNames.Any() && defaultCulture == null)
+            if (supportedCultureNames == null)
             {
-                defaultCulture = supportedCultureNames.FirstOrDefault();
+                throw new ConfigurationException("Invalid Globalization configuration. You must support at least one culture");
             }
 
-            if (!string.IsNullOrEmpty(defaultCulture) && !supportedCultureNames.Contains(defaultCulture, StringComparer.OrdinalIgnoreCase))
+            supportedCultureNames = supportedCultureNames.Where(cultureName => !string.IsNullOrEmpty(cultureName));
+
+            if (!supportedCultureNames.Any())
+            {
+                throw new ConfigurationException("Invalid Globalization configuration. You must support at least one culture");
+            }
+
+            if (string.IsNullOrEmpty(defaultCulture))
+            {
+                defaultCulture = supportedCultureNames.First();
+            }
+
+            if (!supportedCultureNames.Contains(defaultCulture, StringComparer.OrdinalIgnoreCase))
             {
                 throw new ConfigurationException("Invalid Globalization configuration. " + defaultCulture + " does not exist in the supported culture names");
             }

--- a/src/Nancy/GlobalizationConfiguration.cs
+++ b/src/Nancy/GlobalizationConfiguration.cs
@@ -10,14 +10,14 @@
         /// <summary>
         /// A default instance of the <see cref="GlobalizationConfiguration"/> class
         /// </summary>
-        public static readonly GlobalizationConfiguration Default = new GlobalizationConfiguration(supportedCultureNames: new[] { "en-us" });
+        public static readonly GlobalizationConfiguration Default = new GlobalizationConfiguration(supportedCultureNames: new[] { "en-US" }, defaultCulture: "en-US");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GlobalizationConfiguration"/> class
         /// </summary>
         /// <param name="supportedCultureNames">An array of supported cultures</param>
         /// <param name="defaultCulture">The default culture of the application</param>
-        public GlobalizationConfiguration(IEnumerable<string> supportedCultureNames, string defaultCulture = null)
+        public GlobalizationConfiguration(IEnumerable<string> supportedCultureNames, string defaultCulture)
         {
             this.SupportedCultureNames = supportedCultureNames;
             this.DefaultCulture = defaultCulture;

--- a/src/Nancy/GlobalizationConfiguration.cs
+++ b/src/Nancy/GlobalizationConfiguration.cs
@@ -31,6 +31,6 @@
         /// <summary>
         /// The default culture for the application
         /// </summary>
-        public string DefaultCulture { get; set; }
+        public string DefaultCulture { get; private set; }
     }
 }

--- a/src/Nancy/GlobalizationConfiguration.cs
+++ b/src/Nancy/GlobalizationConfiguration.cs
@@ -1,6 +1,8 @@
 ﻿namespace Nancy
 {
+    using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// Globalization configuration
@@ -17,8 +19,18 @@
         /// </summary>
         /// <param name="supportedCultureNames">An array of supported cultures</param>
         /// <param name="defaultCulture">The default culture of the application</param>
-        public GlobalizationConfiguration(IEnumerable<string> supportedCultureNames, string defaultCulture)
+        public GlobalizationConfiguration(IEnumerable<string> supportedCultureNames, string defaultCulture = null)
         {
+            if (supportedCultureNames != null && supportedCultureNames.Any() && defaultCulture == null)
+            {
+                defaultCulture = supportedCultureNames.FirstOrDefault();
+            }
+
+            if (!string.IsNullOrEmpty(defaultCulture) && !supportedCultureNames.Contains(defaultCulture, StringComparer.OrdinalIgnoreCase))
+            {
+                throw new ConfigurationException("Invalid Globalization configuration. " + defaultCulture + " does not exist in the supported culture names");
+            }
+
             this.SupportedCultureNames = supportedCultureNames;
             this.DefaultCulture = defaultCulture;
         }

--- a/src/Nancy/GlobalizationConfigurationExtensions.cs
+++ b/src/Nancy/GlobalizationConfigurationExtensions.cs
@@ -13,10 +13,12 @@
         /// </summary>
         /// <param name="environment">An <see cref="INancyEnvironment"/> that should be configured.</param>
         /// <param name="supportedCultureNames">Cultures that the application can accept</param>
-        public static void Cultures(this INancyEnvironment environment, IEnumerable<string> supportedCultureNames)
+        /// <param name="defaultCulture">Used to set a default culture for the application <remarks>If not specified the first supported culture is used</remarks></param>
+        public static void Cultures(this INancyEnvironment environment, IEnumerable<string> supportedCultureNames, string defaultCulture = null)
         {
             environment.AddValue(new GlobalizationConfiguration(
-                supportedCultureNames: supportedCultureNames));
+                supportedCultureNames: supportedCultureNames,
+                defaultCulture:defaultCulture));
         }
     }
 }

--- a/src/Nancy/GlobalizationConfigurationExtensions.cs
+++ b/src/Nancy/GlobalizationConfigurationExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace Nancy
 {
     using System.Collections.Generic;
+    using System.Linq;
     using Nancy.Configuration;
 
     /// <summary>
@@ -13,9 +14,15 @@
         /// </summary>
         /// <param name="environment">An <see cref="INancyEnvironment"/> that should be configured.</param>
         /// <param name="supportedCultureNames">Cultures that the application can accept</param>
-        /// <param name="defaultCulture">Used to set a default culture for the application <remarks>If not specified the first supported culture is used</remarks></param>
+        /// <param name="defaultCulture">Used to set a default culture for the application</param>
+        /// <remarks>If defaultCulture not specified the first supported culture is used</remarks>
         public static void Cultures(this INancyEnvironment environment, IEnumerable<string> supportedCultureNames, string defaultCulture = null)
         {
+            if (supportedCultureNames != null && supportedCultureNames.Any() && defaultCulture == null)
+            {
+                defaultCulture = supportedCultureNames.FirstOrDefault();
+            }
+
             environment.AddValue(new GlobalizationConfiguration(
                 supportedCultureNames: supportedCultureNames,
                 defaultCulture: defaultCulture));

--- a/src/Nancy/GlobalizationConfigurationExtensions.cs
+++ b/src/Nancy/GlobalizationConfigurationExtensions.cs
@@ -1,7 +1,6 @@
 ﻿namespace Nancy
 {
     using System.Collections.Generic;
-    using System.Linq;
     using Nancy.Configuration;
 
     /// <summary>
@@ -18,11 +17,6 @@
         /// <remarks>If defaultCulture not specified the first supported culture is used</remarks>
         public static void Cultures(this INancyEnvironment environment, IEnumerable<string> supportedCultureNames, string defaultCulture = null)
         {
-            if (supportedCultureNames != null && supportedCultureNames.Any() && defaultCulture == null)
-            {
-                defaultCulture = supportedCultureNames.FirstOrDefault();
-            }
-
             environment.AddValue(new GlobalizationConfiguration(
                 supportedCultureNames: supportedCultureNames,
                 defaultCulture: defaultCulture));

--- a/src/Nancy/GlobalizationConfigurationExtensions.cs
+++ b/src/Nancy/GlobalizationConfigurationExtensions.cs
@@ -18,7 +18,7 @@
         {
             environment.AddValue(new GlobalizationConfiguration(
                 supportedCultureNames: supportedCultureNames,
-                defaultCulture:defaultCulture));
+                defaultCulture: defaultCulture));
         }
     }
 }

--- a/test/Nancy.Tests/Unit/Culture/BuiltInCultureConventionFixture.cs
+++ b/test/Nancy.Tests/Unit/Culture/BuiltInCultureConventionFixture.cs
@@ -293,7 +293,7 @@
         {
             //Given
             var context = CreateContextRequest("/");
-            var expectedCultureName = Thread.CurrentThread.CurrentCulture.Name;
+            var expectedCultureName = CultureInfo.CurrentCulture.Name;
 
             //When
             var culture = BuiltInCultureConventions.ThreadCulture(context, context.Environment.GetValue<GlobalizationConfiguration>());

--- a/test/Nancy.Tests/Unit/Culture/BuiltInCultureConventionFixture.cs
+++ b/test/Nancy.Tests/Unit/Culture/BuiltInCultureConventionFixture.cs
@@ -303,6 +303,19 @@
         }
 
         [Fact]
+        public void Should_return_culture_from_default_culture_on_globalization_configuration()
+        {
+            //Given
+            var context = CreateContextRequest("/");
+
+            //When
+            var culture = BuiltInCultureConventions.ConfigurationCulture(context, context.Environment.GetValue<GlobalizationConfiguration>());
+
+            //Then
+            culture.Name.ShouldEqual("en-US");
+        }
+
+        [Fact]
         public void Validation_should_return_false_if_null_culture_name()
         {
             //Given/When
@@ -371,7 +384,7 @@
             var request = new Request("GET", new Url { Path = path, Scheme = "http" }, null, cultureHeaders);
             context.Request = request;
             var environment = new DefaultNancyEnvironment();
-            environment.Cultures(GlobalizationConfiguration.Default.SupportedCultureNames);
+            environment.Cultures(GlobalizationConfiguration.Default.SupportedCultureNames, GlobalizationConfiguration.Default.SupportedCultureNames.First());
             context.Environment = environment;
             return context;
         }

--- a/test/Nancy.Tests/Unit/Culture/BuiltInCultureConventionFixture.cs
+++ b/test/Nancy.Tests/Unit/Culture/BuiltInCultureConventionFixture.cs
@@ -323,11 +323,25 @@
 
             //When
             var environment = new DefaultNancyEnvironment();
-            environment.Cultures(GlobalizationConfiguration.Default.SupportedCultureNames, defaultCulture:null);
+            environment.Cultures(GlobalizationConfiguration.Default.SupportedCultureNames, defaultCulture: null);
             var culture = BuiltInCultureConventions.GlobalizationConfigurationCulture(context, environment.GetValue<GlobalizationConfiguration>());
 
             //Then
             culture.Name.ShouldEqual("en-US");
+        }
+
+        [Fact]
+        public void Should_throw_configuration_exception_if_default_culture_not_supported_globalization_configuration()
+        {
+            //Given
+            var context = CreateContextRequest("/");
+
+            //When
+            var environment = new DefaultNancyEnvironment();
+            var exception = Record.Exception(() => environment.Cultures(new[] { "en-GB" }, defaultCulture: "quz-EC"));
+
+            //Then
+            exception.ShouldBeOfType<ConfigurationException>();
         }
 
         [Fact]

--- a/test/Nancy.Tests/Unit/Culture/BuiltInCultureConventionFixture.cs
+++ b/test/Nancy.Tests/Unit/Culture/BuiltInCultureConventionFixture.cs
@@ -36,7 +36,7 @@
             var context = PopulateForm("en-GB");
 
             //When
-            var culture = BuiltInCultureConventions.FormCulture(context, new GlobalizationConfiguration(new[] { "en-GB" }));
+            var culture = BuiltInCultureConventions.FormCulture(context, new GlobalizationConfiguration(new[] { "en-GB" }, "en-GB"));
 
             //Then
             culture.Name.ShouldEqual("en-GB");
@@ -82,7 +82,7 @@
             var context = CreateContextRequest(path);
 
             //When
-            var culture = BuiltInCultureConventions.PathCulture(context, new GlobalizationConfiguration(new[] { expected }));
+            var culture = BuiltInCultureConventions.PathCulture(context, new GlobalizationConfiguration(new[] { expected }, expected));
 
             //Then
             culture.Name.ShouldEqual(expected);
@@ -97,7 +97,7 @@
             var context = CreateContextRequest(path);
 
             //When
-            var culture = BuiltInCultureConventions.PathCulture(context, new GlobalizationConfiguration(new string[] { "en-GB" }));
+            var culture = BuiltInCultureConventions.PathCulture(context, new GlobalizationConfiguration(new string[] { "en-GB" }, "en-GB"));
 
             //Then
             context.Request.Url.Path.ShouldEqual(expectedPath);
@@ -150,7 +150,7 @@
             var context = CreateContextRequest("/", headers);
 
             //When
-            var culture = BuiltInCultureConventions.HeaderCulture(context, new GlobalizationConfiguration(new[] { "en-GB", "de-DE", "nl", "es" }));
+            var culture = BuiltInCultureConventions.HeaderCulture(context, new GlobalizationConfiguration(new[] { "en-GB", "de-DE", "nl", "es" }, "en-GB"));
 
             //Then
             culture.Name.ShouldEqual("en-GB");
@@ -169,7 +169,7 @@
             var context = CreateContextRequest("/", headers);
 
             //When
-            var culture = BuiltInCultureConventions.HeaderCulture(context, new GlobalizationConfiguration(new[] { "en-GB" }));
+            var culture = BuiltInCultureConventions.HeaderCulture(context, new GlobalizationConfiguration(new[] { "en-GB" }, "en-GB"));
 
             //Then
             culture.Name.ShouldEqual("en-GB");
@@ -282,7 +282,7 @@
             var context = CreateContextRequest("/", headers);
 
             //When
-            var culture = BuiltInCultureConventions.CookieCulture(context, new GlobalizationConfiguration(new[] { "en-GB" }));
+            var culture = BuiltInCultureConventions.CookieCulture(context, new GlobalizationConfiguration(new[] { "en-GB" }, "en-GB"));
 
             // Then
             culture.Name.ShouldEqual("en-GB");
@@ -309,7 +309,22 @@
             var context = CreateContextRequest("/");
 
             //When
-            var culture = BuiltInCultureConventions.ConfigurationCulture(context, context.Environment.GetValue<GlobalizationConfiguration>());
+            var culture = BuiltInCultureConventions.GlobalizationConfigurationCulture(context, context.Environment.GetValue<GlobalizationConfiguration>());
+
+            //Then
+            culture.Name.ShouldEqual("en-US");
+        }
+
+        [Fact]
+        public void Should_return_first_culture_from_default_culture_on_globalization_configuration()
+        {
+            //Given
+            var context = CreateContextRequest("/");
+
+            //When
+            var environment = new DefaultNancyEnvironment();
+            environment.Cultures(GlobalizationConfiguration.Default.SupportedCultureNames, defaultCulture:null);
+            var culture = BuiltInCultureConventions.GlobalizationConfigurationCulture(context, environment.GetValue<GlobalizationConfiguration>());
 
             //Then
             culture.Name.ShouldEqual("en-US");
@@ -331,7 +346,7 @@
         public void Validation_should_return_false_if_invalid_culture_name(string cultureName)
         {
             //Given/When
-            var configuration = new GlobalizationConfiguration(Enumerable.Empty<string>());
+            var configuration = new GlobalizationConfiguration(Enumerable.Empty<string>(), null);
             var result = BuiltInCultureConventions.IsValidCultureInfoName(cultureName, configuration);
 
             //Then
@@ -350,7 +365,7 @@
         public void Validation_should_return_true_if_valid_culture_name(string cultureName)
         {
             //Given/When
-            var configuration = new GlobalizationConfiguration(new[] { cultureName });
+            var configuration = new GlobalizationConfiguration(new[] { cultureName }, cultureName);
             var result = BuiltInCultureConventions.IsValidCultureInfoName(cultureName, configuration);
 
             //Then

--- a/test/Nancy.Tests/Unit/Culture/BuiltInCultureConventionFixture.cs
+++ b/test/Nancy.Tests/Unit/Culture/BuiltInCultureConventionFixture.cs
@@ -289,20 +289,6 @@
         }
 
         [Fact]
-        public void Should_return_culture_from_current_thread()
-        {
-            //Given
-            var context = CreateContextRequest("/");
-            var expectedCultureName = CultureInfo.CurrentCulture.Name;
-
-            //When
-            var culture = BuiltInCultureConventions.ThreadCulture(context, context.Environment.GetValue<GlobalizationConfiguration>());
-
-            //Then
-            culture.Name.ShouldEqual(expectedCultureName);
-        }
-
-        [Fact]
         public void Should_return_culture_from_default_culture_on_globalization_configuration()
         {
             //Given
@@ -316,14 +302,14 @@
         }
 
         [Fact]
-        public void Should_return_first_culture_from_default_culture_on_globalization_configuration()
+        public void Should_return_first_supported_culture_for_default_culture_on_globalization_configuration()
         {
             //Given
             var context = CreateContextRequest("/");
 
             //When
             var environment = new DefaultNancyEnvironment();
-            environment.Cultures(GlobalizationConfiguration.Default.SupportedCultureNames, defaultCulture: null);
+            environment.Cultures(new[] { "en-US" }, defaultCulture: null);
             var culture = BuiltInCultureConventions.GlobalizationConfigurationCulture(context, environment.GetValue<GlobalizationConfiguration>());
 
             //Then
@@ -345,6 +331,39 @@
         }
 
         [Fact]
+        public void Should_throw_configuration_exception_if_empty_list_of_supported_culutres_passed_to_globalization_configuration()
+        {
+            //Given, When
+            var environment = new DefaultNancyEnvironment();
+            var exception = Record.Exception(() => environment.Cultures(Enumerable.Empty<string>()));
+
+            //Then
+            exception.ShouldBeOfType<ConfigurationException>();
+        }
+
+        [Fact]
+        public void Should_throw_configuration_exception_if_list_of_blank_strings_used_for_supported_culutres_passed_to_globalization_configuration()
+        {
+            //Given, When
+            var environment = new DefaultNancyEnvironment();
+            var exception = Record.Exception(() => environment.Cultures(new []{""}));
+
+            //Then
+            exception.ShouldBeOfType<ConfigurationException>();
+        }
+
+        [Fact]
+        public void Should_throw_configuration_exception_if_null_value_used_for_supported_culutres_passed_to_globalization_configuration()
+        {
+            //Given, When
+            var environment = new DefaultNancyEnvironment();
+            var exception = Record.Exception(() => environment.Cultures(null));
+
+            //Then
+            exception.ShouldBeOfType<ConfigurationException>();
+        }
+
+        [Fact]
         public void Validation_should_return_false_if_null_culture_name()
         {
             //Given/When
@@ -360,7 +379,7 @@
         public void Validation_should_return_false_if_invalid_culture_name(string cultureName)
         {
             //Given/When
-            var configuration = new GlobalizationConfiguration(Enumerable.Empty<string>(), null);
+            var configuration = new GlobalizationConfiguration(new []{"en-US"});
             var result = BuiltInCultureConventions.IsValidCultureInfoName(cultureName, configuration);
 
             //Then
@@ -413,7 +432,7 @@
             var request = new Request("GET", new Url { Path = path, Scheme = "http" }, null, cultureHeaders);
             context.Request = request;
             var environment = new DefaultNancyEnvironment();
-            environment.Cultures(GlobalizationConfiguration.Default.SupportedCultureNames, GlobalizationConfiguration.Default.SupportedCultureNames.First());
+            environment.Cultures(new[] { "en-US" }, "en-US");
             context.Environment = environment;
             return context;
         }


### PR DESCRIPTION
This adds a new globalization culture that adds a DefaultCulture property.  If one is not provided the first one in the list of supported cultures is chosen.

If a user passes in an empty list of cultures it will fall back to the ThreadCultureConvention which now uses `CultureInfo.CurrentCulture` instead of `Thread.CurrentThread.CurrentCulture` which makes it CoreCLR compatible