### PR TITLE
Added CoreCLR APIs for Nancy.Testing

### DIFF
--- a/src/Nancy.Testing/AssertEqualityComparer.cs
+++ b/src/Nancy.Testing/AssertEqualityComparer.cs
@@ -2,12 +2,13 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Reflection;
 
     public class AssertEqualityComparer<T> : IEqualityComparer<T>
     {
         private static bool IsTypeNullable(Type type)
         {
-            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+            return type.GetTypeInfo().IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
         }
 
         public bool Equals(T expected, T actual)
@@ -15,7 +16,7 @@
             var type =
                 typeof(T);
 
-            if (!type.IsValueType || IsTypeNullable(type))
+            if (!type.GetTypeInfo().IsValueType || IsTypeNullable(type))
             {
                 var actualIsNull =
                     (Object.Equals(actual, default(T)));

--- a/src/Nancy.Testing/AssertException.cs
+++ b/src/Nancy.Testing/AssertException.cs
@@ -32,6 +32,7 @@ namespace Nancy.Testing
         {
         }
 
+#if !DOTNET5_4
         /// <summary>
         /// Initializes a new instance of the <see cref="AssertException"/> class.
         /// </summary>
@@ -42,5 +43,6 @@ namespace Nancy.Testing
         protected AssertException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
+#endif
     }
 }

--- a/src/Nancy.Testing/BrowserContext.cs
+++ b/src/Nancy.Testing/BrowserContext.cs
@@ -206,7 +206,7 @@
 
             using (
                 var pkcs12 =
-                    Assembly.GetAssembly(typeof (BrowserContext))
+                    typeof (BrowserContext).GetTypeInfo().Assembly
                             .GetManifestResourceStream("Nancy.Testing.Resources.Nancy Testing Cert.pfx"))
             {
                 using (var br = new BinaryReader(pkcs12))

--- a/src/Nancy.Testing/ConfigurableBootstrapper.cs
+++ b/src/Nancy.Testing/ConfigurableBootstrapper.cs
@@ -34,7 +34,7 @@ namespace Nancy.Testing
         private bool enableAutoRegistration;
         private readonly List<Action<TinyIoCContainer, IPipelines>> applicationStartupActions;
         private readonly List<Action<TinyIoCContainer, IPipelines, NancyContext>> requestStartupActions;
-        private readonly Assembly nancyAssembly = typeof(NancyEngine).Assembly;
+        private readonly Assembly nancyAssembly = typeof(NancyEngine).GetTypeInfo().Assembly;
         private Action<INancyEnvironment> configure;
         private readonly IList<Action<NancyInternalConfiguration>> configurationOverrides;
 
@@ -290,7 +290,7 @@ namespace Nancy.Testing
 
                 if (this.disableAutoApplicationStartupRegistration || user.Any())
                 {
-                    tasks = tasks.Where(x => x.Assembly.GetName().Name.StartsWith("Nancy", StringComparison.OrdinalIgnoreCase));
+                    tasks = tasks.Where(x => x.GetTypeInfo().Assembly.GetName().Name.StartsWith("Nancy", StringComparison.OrdinalIgnoreCase));
                 }
 
                 return tasks.Union(user);
@@ -310,7 +310,7 @@ namespace Nancy.Testing
 
                 if (this.disableAutoRequestStartupRegistration || user.Any())
                 {
-                    tasks = tasks.Where(x => x.Assembly.GetName().Name.StartsWith("Nancy", StringComparison.OrdinalIgnoreCase));
+                    tasks = tasks.Where(x => x.GetTypeInfo().Assembly.GetName().Name.StartsWith("Nancy", StringComparison.OrdinalIgnoreCase));
                 }
 
                 return tasks.Union(user);
@@ -432,7 +432,7 @@ namespace Nancy.Testing
             }
 
             return this.ApplicationContainer.ResolveAll<IRegistrations>(false)
-                       .Where(x => x.GetType().Assembly == nancyAssembly);
+                       .Where(x => x.GetType().GetTypeInfo().Assembly == nancyAssembly);
         }
 
         /// <summary>

--- a/src/Nancy.Testing/NancyContextExtensions.cs
+++ b/src/Nancy.Testing/NancyContextExtensions.cs
@@ -3,7 +3,7 @@ namespace Nancy.Testing
     using System;
     using System.IO;
     using System.Xml.Serialization;
-
+    using Nancy.Extensions;
     using Nancy.Json;
 
     /// <summary>
@@ -43,7 +43,7 @@ namespace Nancy.Testing
                 {
                     context.Response.Contents.Invoke(contentsStream);
                     contentsStream.Position = 0;
-                    return new DocumentWrapper(contentsStream.GetBuffer());
+                    return new DocumentWrapper(contentsStream.GetBufferSegment());
                 }
             });
         }
@@ -78,9 +78,9 @@ namespace Nancy.Testing
                 {
                     context.Response.Contents.Invoke(contentsStream);
                     contentsStream.Position = 0;
-                    var serializer = new XmlSerializer(typeof (TModel));
+                    var serializer = new XmlSerializer(typeof(TModel));
                     var model = serializer.Deserialize(contentsStream);
-                    return (TModel) model;
+                    return (TModel)model;
                 }
             });
         }

--- a/src/Nancy.Testing/Properties/Resources.Designer.cs
+++ b/src/Nancy.Testing/Properties/Resources.Designer.cs
@@ -14,8 +14,10 @@ namespace Nancy.Testing.Properties {
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
+    using System.Reflection;
     using System.Resources;
     using System.Runtime.CompilerServices;
+    using System.Text;
 
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
@@ -44,7 +46,7 @@ namespace Nancy.Testing.Properties {
         internal static ResourceManager ResourceManager {
             get {
                 if (ReferenceEquals(resourceMan, null)) {
-                    ResourceManager temp = new ResourceManager("Nancy.Testing.Properties.Resources", typeof(Resources).Assembly);
+                    ResourceManager temp = new ResourceManager("Nancy.Testing.Properties.Resources", typeof(Resources).GetTypeInfo().Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -70,8 +72,8 @@ namespace Nancy.Testing.Properties {
         /// </summary>
         internal static byte[] NancyTestingCert {
             get {
-                object obj = ResourceManager.GetObject("NancyTestingCert", resourceCulture);
-                return ((byte[])(obj));
+                var cert = ResourceManager.GetString("NancyCert");
+                return Encoding.UTF8.GetBytes(cert);
             }
         }
     }

--- a/src/Nancy.Testing/project.json
+++ b/src/Nancy.Testing/project.json
@@ -10,6 +10,7 @@
 
     "dependencies": {
         "AngleSharp": "0.9.4",
+        "Nancy": { "target": "project" },
         "Nancy.Authentication.Forms": { "target": "project" }
     },
 
@@ -18,6 +19,12 @@
     ],
 
     "frameworks": {
+        "dotnet5.4": {
+            "dependencies": {
+                "System.Xml.XmlDocument": "4.0.1-beta-23516",
+                "System.Xml.XDocument": "4.0.11-beta-23516"
+            }
+        },
         "net451": {
             "frameworkAssemblies": {
                 "System.IO": "4.0.0.0",

--- a/src/Nancy/Extensions/MemoryStreamExtensions.cs
+++ b/src/Nancy/Extensions/MemoryStreamExtensions.cs
@@ -3,7 +3,7 @@
     using System;
     using System.IO;
 
-    internal static class MemoryStreamExtensions
+    public static class MemoryStreamExtensions
     {
         public static ArraySegment<byte> GetBufferSegment(this MemoryStream stream)
         {


### PR DESCRIPTION
This makes Nancy.Testing dotnet5.4 compatible apart from some areas:

- [x] Nancy.Forms.Authentication
- [x] CSQuery
- [x] `Assembly.GetEntryAssembly`