### PR TITLE
Swapped out CsQuery with AngleSharp

### DIFF
--- a/src/Nancy.Testing.MSBuild/Nancy.Testing.csproj
+++ b/src/Nancy.Testing.MSBuild/Nancy.Testing.csproj
@@ -89,9 +89,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CsQuery, Version=1.3.3.5, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\CsQuery.1.3.3\lib\net40\CsQuery.dll</HintPath>
+    <Reference Include="AngleSharp, Version=0.9.4.42449, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AngleSharp.0.9.4\lib\net45\AngleSharp.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Nancy.Testing.MSBuild/packages.config
+++ b/src/Nancy.Testing.MSBuild/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
-  <package id="CsQuery" version="1.3.3" targetFramework="net45" />
+  <package id="AngleSharp" version="0.9.4" targetFramework="net45" />
 </packages>

--- a/src/Nancy.Testing/DocumentWrapper.cs
+++ b/src/Nancy.Testing/DocumentWrapper.cs
@@ -1,17 +1,17 @@
 ﻿namespace Nancy.Testing
 {
     using System.Collections.Generic;
+    using System.IO;
     using System.Linq;
-    using System.Text;
-
-    using CsQuery;
+    using AngleSharp.Dom.Html;
+    using AngleSharp.Parser.Html;
 
     /// <summary>
     /// A basic wrapper around CsQuery
     /// </summary>
     public class DocumentWrapper
     {
-        private readonly CQ document;
+        private readonly IHtmlDocument document;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DocumentWrapper"/> class.
@@ -19,9 +19,11 @@
         /// <param name="buffer">The document represented as a byte array.</param>
         public DocumentWrapper(IEnumerable<byte> buffer)
         {
-            var utf8String = Encoding.UTF8.GetString(buffer.ToArray());
-
-            this.document = CQ.Create(utf8String);
+            var parser = new HtmlParser();
+            using (var stream = new MemoryStream(buffer.ToArray()))
+            {
+                this.document = parser.Parse(stream);
+            }
         }
 
         /// <summary>
@@ -31,7 +33,7 @@
         /// <returns>A <see cref="QueryWrapper"/> instance.</returns>
         public QueryWrapper this[string selector]
         {
-            get { return this.document.Select(selector); }
+            get { return new QueryWrapper(this.document.QuerySelectorAll(selector).ToArray()); }
         }
     }
 }

--- a/src/Nancy.Testing/NodeWrapper.cs
+++ b/src/Nancy.Testing/NodeWrapper.cs
@@ -1,20 +1,20 @@
 namespace Nancy.Testing
 {
-    using CsQuery.Implementation;
+    using AngleSharp.Dom;
 
     /// <summary>
-    /// Simple wrapper around a <see cref="DomElement"/>.
+    /// Simple wrapper around a <see cref="IElement"/>.
     /// </summary>
     public class NodeWrapper
     {
-        private readonly DomElement element;
+        private readonly IElement element;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NodeWrapper"/> class, for
         /// the provided <paramref name="element"/>.
         /// </summary>
         /// <param name="element">The dom element that should be wrapped.</param>
-        public NodeWrapper(DomElement element)
+        public NodeWrapper(IElement element)
         {
             this.element = element;
         }
@@ -29,9 +29,22 @@ namespace Nancy.Testing
             return this.element.HasAttribute(name);
         }
 
+        /// <summary>
+        /// Gets the attributes of the element
+        /// </summary>
         public IndexHelper<string, string> Attributes
         {
-            get { return new IndexHelper<string, string>(x => this.element.Attributes[x]); }
+            get
+            {
+                return new IndexHelper<string, string>(x =>
+                {
+                    var attribute = this.element.Attributes[x];
+
+                    return (attribute != null)
+                        ? attribute.Value
+                        : null;
+                });
+            }
         }
 
         /// <summary>
@@ -40,27 +53,7 @@ namespace Nancy.Testing
         /// <value>A <see cref="string"/> containing the inner text of the node.</value>
         public string InnerText
         {
-            get { return this.element.InnerText; }
-        }
-
-        /// <summary>
-        /// Performs an implicit conversion from <see cref="DomElement"/> to <see cref="Nancy.Testing.NodeWrapper"/>.
-        /// </summary>
-        /// <param name="node">The <see cref="DomElement"/> that should be cast.</param>
-        /// <returns>An <see cref="NodeWrapper"/> instance, that contains the results of the cast.</returns>
-        public static implicit operator NodeWrapper(DomElement node)
-        {
-            return new NodeWrapper(node);
-        }
-
-        /// <summary>
-        /// Performs an implicit conversion from <see cref="Nancy.Testing.NodeWrapper"/> to <see cref="DomElement"/>.
-        /// </summary>
-        /// <param name="wrapper">The <see cref="NodeWrapper"/> that should be cast.</param>
-        /// <returns>A <see cref="DomElement"/> instance, that contains the results of the cast.</returns>
-        public static implicit operator DomElement(NodeWrapper wrapper)
-        {
-            return wrapper.element;
+            get { return this.element.TextContent; }
         }
     }
 }

--- a/src/Nancy.Testing/QueryWrapper.cs
+++ b/src/Nancy.Testing/QueryWrapper.cs
@@ -3,22 +3,23 @@
     using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
+    using AngleSharp.Dom;
 
-    using CsQuery;
-    using CsQuery.Implementation;
-
+    /// <summary>
+    /// Simple wrapper around a collection of <see cref="IElement"/> instances.
+    /// </summary>
     public class QueryWrapper : IEnumerable<NodeWrapper>
     {
-        private readonly CQ document;
+        private readonly IReadOnlyCollection<IElement> elements;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="QueryWrapper"/> class, using
-        /// the provided <paramref name="document"/>.
+        /// the provided <paramref name="elements"/>.
         /// </summary>
-        /// <param name="document">The document that should be wrapped.</param>
-        public QueryWrapper(CQ document)
+        /// <param name="elements">The elements that were the result of query.</param>
+        public QueryWrapper(IReadOnlyCollection<IElement> elements)
         {
-            this.document = document;
+            this.elements = elements;
         }
 
         /// <summary>
@@ -30,10 +31,7 @@
         {
             get
             {
-                var newDocument = this.document.Selector == null
-                                      ? this.document
-                                      : new CQ(this.document.RenderSelection());
-                return new QueryWrapper(newDocument[selector]);
+                return new QueryWrapper(this.elements.SelectMany(element => element.QuerySelectorAll(selector)).ToArray());
             }
         }
 
@@ -43,7 +41,7 @@
         /// <returns>A <see cref="IEnumerator{T}"/> that can be used to iterate through the collection.</returns>
         public IEnumerator<NodeWrapper> GetEnumerator()
         {
-            return this.document.Select(x => new NodeWrapper(x as DomElement)).GetEnumerator();
+            return this.elements.Select(element => new NodeWrapper(element)).GetEnumerator();
         }
 
         /// <summary>
@@ -52,17 +50,7 @@
         /// <returns>An <see cref="IEnumerator"/> object that can be used to iterate through the collection.</returns>
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetEnumerator();
-        }
-
-        /// <summary>
-        /// Performs an implicit conversion from <see cref="CQ"/> to <see cref="QueryWrapper"/>.
-        /// </summary>
-        /// <param name="document">The <see cref="CQ"/> that should be cast.</param>
-        /// <returns>An <see cref="QueryWrapper"/> instance, that contains the results of the cast.</returns>
-        public static implicit operator QueryWrapper(CQ document)
-        {
-            return new QueryWrapper(document);
+            return this.GetEnumerator();
         }
     }
 }

--- a/src/Nancy.Testing/project.json
+++ b/src/Nancy.Testing/project.json
@@ -9,8 +9,8 @@
     "iconUrl": "http://nancyfx.org/nancy-nuget.png",
 
     "dependencies": {
-        "Nancy.Authentication.Forms": { "target": "project" },
-        "CsQuery": "1.3.3"
+        "AngleSharp": "0.9.4",
+        "Nancy.Authentication.Forms": { "target": "project" }
     },
 
     "resource": [
@@ -20,6 +20,8 @@
     "frameworks": {
         "net451": {
             "frameworkAssemblies": {
+                "System.IO": "4.0.0.0",
+                "System.Runtime": "4.0.10.0",
                 "System.Xml.Linq": "4.0.0.0"
             }
         }

--- a/test/Nancy.Testing.Tests.MSBuild/Nancy.Testing.Tests.csproj
+++ b/test/Nancy.Testing.Tests.MSBuild/Nancy.Testing.Tests.csproj
@@ -86,9 +86,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CsQuery, Version=1.3.3.5, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\CsQuery.1.3.3\lib\net40\CsQuery.dll</HintPath>
+    <Reference Include="AngleSharp, Version=0.9.4.42449, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AngleSharp.0.9.4\lib\net45\AngleSharp.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="FakeItEasy, Version=2.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\FakeItEasy.2.0.0-beta011\lib\net40\FakeItEasy.dll</HintPath>

--- a/test/Nancy.Testing.Tests.MSBuild/packages.config
+++ b/test/Nancy.Testing.Tests.MSBuild/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CsQuery" version="1.3.3" targetFramework="net45" />
+  <package id="AngleSharp" version="0.9.4" targetFramework="net45" />
   <package id="FakeItEasy" version="2.0.0-beta011" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />

--- a/test/Nancy.Testing.Tests/AssertExtensionsTests.cs
+++ b/test/Nancy.Testing.Tests/AssertExtensionsTests.cs
@@ -2,9 +2,7 @@ namespace Nancy.Testing.Tests
 {
     using System;
     using System.Linq;
-
-    using CsQuery;
-
+    using AngleSharp.Parser.Html;
     using Xunit;
 
     public class AssertExtensionsTests
@@ -16,11 +14,13 @@ namespace Nancy.Testing.Tests
         /// </summary>
         public AssertExtensionsTests()
         {
+            var parser = new HtmlParser();
+
             var document =
-                CQ.Create(@"<html><head></head><body><div id='testId' class='myClass' attribute1 attribute2='value2'>Test</div><div class='anotherClass'>Tes</div><span class='class'>some contents</span><span class='class'>This has contents</span></body></html>");
+                parser.Parse(@"<html><head></head><body><div id='testId' class='myClass' attribute1 attribute2='value2'>Test</div><div class='anotherClass'>Tes</div><span class='class'>some contents</span><span class='class'>This has contents</span></body></html>");
 
             this.query =
-                new QueryWrapper(document);
+                new QueryWrapper(new[] { document.DocumentElement });
         }
 
         [Fact]
@@ -333,7 +333,7 @@ namespace Nancy.Testing.Tests
             // Then
             Assert.IsAssignableFrom<AssertException>(result);
         }
-        
+
         [Fact]
         public void ShouldContainAttribute_SingleElementNotContainingAttributeAndValue_ShouldThrowAssert()
         {
@@ -398,7 +398,7 @@ namespace Nancy.Testing.Tests
             // Then
             Assert.Null(result);
         }
-        
+
         [Fact]
         public void ShouldContainAttribute_SingleElementContainingAttributeAndValue_ShouldNotThrowAssert()
         {

--- a/test/Nancy.Testing.Tests/BrowserFixture.cs
+++ b/test/Nancy.Testing.Tests/BrowserFixture.cs
@@ -6,17 +6,17 @@ namespace Nancy.Testing.Tests
     using System.Linq;
     using System.Security.Cryptography.X509Certificates;
     using System.Text;
+    using System.Collections.ObjectModel;
+    using System.Threading.Tasks;
     using Nancy.Extensions;
     using Nancy.Helpers;
     using Nancy.Session;
     using Nancy.Tests;
-    using Xunit;
-    using FakeItEasy;
     using Nancy.Authentication.Forms;
-    using System.Collections.ObjectModel;
-    using System.Threading.Tasks;
     using Nancy.Configuration;
     using Nancy.Tests.xUnitExtensions;
+    using Xunit;
+    using FakeItEasy;
 
     public class BrowserFixture
     {

--- a/test/Nancy.Testing.Tests/QueryWrapperTests.cs
+++ b/test/Nancy.Testing.Tests/QueryWrapperTests.cs
@@ -1,33 +1,38 @@
 namespace Nancy.Testing.Tests
 {
     using System.Linq;
-
-    using CsQuery;
-    using CsQuery.Implementation;
-
+    using AngleSharp.Dom;
+    using AngleSharp.Parser.Html;
     using Xunit;
 
     public class QueryWrapperTests
     {
+        private readonly HtmlParser parser;
+
+        public QueryWrapperTests()
+        {
+            this.parser = new HtmlParser();
+        }
+
         [Fact]
         public void Should_use_cq_find_when_indexer_invoked()
         {
             // Given
             var document =
-                CQ.Create(@"<html><head></head><body><div id='testId' class='myClass'>Test</div></body></html>");
+                this.parser.Parse(@"<html><head></head><body><div id='testId' class='myClass'>Test</div></body></html>");
 
             var queryResult =
-                document.Find("#testId").FirstOrDefault();
+                document.QuerySelectorAll("#testId").FirstOrDefault();
 
             var wrapper =
-                new QueryWrapper(document);
+                new QueryWrapper(new[] { document.DocumentElement });
 
             // When
-            var result = (DomElement)wrapper["#testId"].FirstOrDefault();
+            var result = wrapper["#testId"].FirstOrDefault();
 
             // Then
             Assert.NotNull(result);
-            Assert.Same(queryResult, result);
+            Assert.Equal(queryResult.InnerHtml, result.InnerText);
         }
 
         [Fact]
@@ -35,12 +40,11 @@ namespace Nancy.Testing.Tests
         {
             // Given
             var document =
-                CQ.Create(
-                    @"<html><head></head><body><table><tr><td></td><td></td></tr><tr><td></td><td></td></tr></body></html>");
+                this.parser.Parse(@"<html><head></head><body><table><tr><td></td><td></td></tr><tr><td></td><td></td></tr></table></body></html>");
 
-            var wrapper = new QueryWrapper(document);
+            var wrapper = new QueryWrapper(new[] { document.DocumentElement });
 
-            var row = wrapper["tr:first"];
+            var row = wrapper["tr:first-child"];
 
             // When
             var cells = row["td"];

--- a/test/Nancy.Testing.Tests/project.json
+++ b/test/Nancy.Testing.Tests/project.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
-        "CsQuery": "1.3.3",
+        "AngleSharp": "0.9.4",
         "FakeItEasy": "2.0.0-beta011",
         "Nancy": { "target": "project" },
         "Nancy.Testing": { "target": "project" },


### PR DESCRIPTION
CsQuery has not been maintained for quite a while not, which means that there's no CoreCLR support on the horizon. However, AngleSharp will be releasing a CoreCLR compatible version very soon.

This change is _mostly_ compatible with what we had before, because of our `* Wrapper` classes. However it does not support all the same CSS selectors since CsQuery was a jQuery "port" so it supported the jQuery specific selectors, while AngleSharp follows the CSS specifications