### PR TITLE
Converted Nancy.Tests.Functional to project.json

### DIFF
--- a/Nancy.Next.sln
+++ b/Nancy.Next.sln
@@ -82,6 +82,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Nancy.ViewEngines.Razor.Tes
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Nancy.ViewEngines.Razor.Tests.Models", "test\Nancy.ViewEngines.Razor.Tests.Models\Nancy.ViewEngines.Razor.Tests.Models.xproj", "{31FA18D3-24AD-4AB0-B297-5A2FD871989E}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Nancy.Tests.Functional", "test\Nancy.Tests.Functional\Nancy.Tests.Functional.xproj", "{742AC687-FC9A-4534-BB50-3D91738563A7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -228,6 +230,10 @@ Global
 		{31FA18D3-24AD-4AB0-B297-5A2FD871989E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{31FA18D3-24AD-4AB0-B297-5A2FD871989E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{31FA18D3-24AD-4AB0-B297-5A2FD871989E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{742AC687-FC9A-4534-BB50-3D91738563A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{742AC687-FC9A-4534-BB50-3D91738563A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{742AC687-FC9A-4534-BB50-3D91738563A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{742AC687-FC9A-4534-BB50-3D91738563A7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -268,5 +274,6 @@ Global
 		{C46BFAA7-F471-45A6-A5AC-FCF9390408EE} = {F44224E5-8E58-4D52-A0F0-BCBA2ADC0A0B}
 		{A24271FA-E058-42E0-BB7D-3C8C43DF4B04} = {F44224E5-8E58-4D52-A0F0-BCBA2ADC0A0B}
 		{31FA18D3-24AD-4AB0-B297-5A2FD871989E} = {F44224E5-8E58-4D52-A0F0-BCBA2ADC0A0B}
+		{742AC687-FC9A-4534-BB50-3D91738563A7} = {F44224E5-8E58-4D52-A0F0-BCBA2ADC0A0B}
 	EndGlobalSection
 EndGlobal

--- a/test/Nancy.Tests.Functional/Nancy.Tests.Functional.xproj
+++ b/test/Nancy.Tests.Functional/Nancy.Tests.Functional.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>742ac687-fc9a-4534-bb50-3d91738563a7</ProjectGuid>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/Nancy.Tests.Functional/project.json
+++ b/test/Nancy.Tests.Functional/project.json
@@ -1,0 +1,25 @@
+{
+    "dependencies": {
+        "Nancy": { "target": "project" },
+        "Nancy.Testing": { "target": "project" },
+        "Nancy.ViewEngines.Razor": { "target": "project" },
+        "xunit": "2.1.0",
+        "xunit.runner.dnx": "2.1.0-*"
+    },
+
+    "commands": {
+        "test": "xunit.runner.dnx"
+    },
+
+    "compilationOptions": {
+        "define": [ "DNX" ]
+    },
+
+    "compileFiles": [
+        "../Nancy.Tests/xUnitExtensions/RecordAsync.cs"
+    ],
+
+    "frameworks": {
+        "dnx451": { }
+    }
+}


### PR DESCRIPTION
Bringing back our functional tests on `DNX net451` now that Razor has been re-written using Roslyn. This is a pre-requisite for bringing them onto `dotnet5_4` on the `coreclr`-branch