### PR TITLE
Disable appdomains for xunit on Mono

### DIFF
--- a/tools/xunit/xunitmono.sh
+++ b/tools/xunit/xunitmono.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
 BASEDIR=$(dirname $0)
+TESTDIR=$(dirname $1)
 
-mono -O=-gshared ${BASEDIR}/xunit.console.x86.exe $*
+# we need to copy xunit to the test dir so AppDomain.CurrentDomain.BaseDirectory
+# points to the test dir instead of the xunit dir when using -noappdomain
+# as Nancy relies on this to locate views.
+# -noappdomain works around https://bugzilla.xamarin.com/show_bug.cgi?id=39251
+cp ${BASEDIR}/xunit.console.x86.exe ${TESTDIR}
+mono -O=-gshared ${TESTDIR}/xunit.console.x86.exe $* -noappdomain


### PR DESCRIPTION
This should fix the instability you're seeing on Travis.

Mono bug is tracked at https://bugzilla.xamarin.com/show_bug.cgi?id=39251