### PR TITLE
Changed hint path for AngleSharp in Nancy.Testing

### DIFF
--- a/src/Nancy.Testing.MSBuild/Nancy.Testing.csproj
+++ b/src/Nancy.Testing.MSBuild/Nancy.Testing.csproj
@@ -90,7 +90,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AngleSharp, Version=0.9.4.42449, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AngleSharp.0.9.4\lib\net45\AngleSharp.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\AngleSharp.0.9.4\lib\net45\AngleSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -223,7 +223,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>


### PR DESCRIPTION
Changed the hint path, of the `AngleSharp` NuGet reference, in `Nancy.Testing` to be relative to the `$(SolutionDir)`. This makes it possible for us to include Nancy.Testing` in other repository solutions when it has been added as part of a sub module

Thanks @khellang for the idea! :heart: