### PR TITLE
Performance tweaks for the RequestHeaders class

### DIFF
--- a/src/Nancy/RequestHeaders.cs
+++ b/src/Nancy/RequestHeaders.cs
@@ -33,7 +33,7 @@ namespace Nancy
         /// <value>An <see cref="IEnumerable{T}"/> that contains the header values if they are available; otherwise it will be empty.</value>
         public IEnumerable<Tuple<string, decimal>> Accept
         {
-            get { return this.GetWeightedValues("Accept").ToList(); }
+            get { return this.GetWeightedValues("Accept"); }
             set { this.SetHeaderValues("Accept", value, GetWeightedValuesAsStrings); }
         }
 
@@ -73,7 +73,7 @@ namespace Nancy
         /// <value>A <see cref="string"/> containing the header value if it is available; otherwise <see cref="string.Empty"/>.</value>
         public string Authorization
         {
-            get { return this.GetValue("Authorization", x => x.First()); }
+            get { return this.GetValue("Authorization", x => x.First(), string.Empty); }
             set { this.SetHeaderValues("Authorization", value, x => new[] { x }); }
         }
 
@@ -93,7 +93,7 @@ namespace Nancy
         /// <value>An <see cref="IEnumerable{T}"/> that contains <see cref="INancyCookie"/> instances if they are available; otherwise it will be empty.</value>
         public IEnumerable<INancyCookie> Cookie
         {
-            get { return this.GetValue("Cookie", GetNancyCookies); }
+            get { return this.GetValue("Cookie", GetNancyCookies, Enumerable.Empty<INancyCookie>()); }
         }
 
         /// <summary>
@@ -102,7 +102,7 @@ namespace Nancy
         /// <value>A <see cref="string"/> containing the header value if it is available; otherwise <see cref="string.Empty"/>.</value>
         public string Connection
         {
-            get { return this.GetValue("Connection", x => x.First()); }
+            get { return this.GetValue("Connection", x => x.First(), string.Empty); }
             set { this.SetHeaderValues("Connection", value, x => new[] { x }); }
         }
 
@@ -112,27 +112,27 @@ namespace Nancy
         /// <value>The length of the contents if it is available; otherwise 0.</value>
         public long ContentLength
         {
-            get { return this.GetValue("Content-Length", x => Convert.ToInt64(x.First())); }
+            get { return this.GetValue("Content-Length", x => Convert.ToInt64(x.First()), 0); }
             set { this.SetHeaderValues("Content-Length", value, x => new[] { x.ToString(CultureInfo.InvariantCulture) }); }
         }
 
         /// <summary>
         /// The mime type of the body of the request (used with POST and PUT requests).
         /// </summary>
-        /// <value>A <see cref="string"/> containing the header value if it is available; otherwise <see cref="string.Empty"/>.</value>
+        /// <value>A <see cref="string"/> containing the header value if it is available; otherwise <see langword="string.Empty"/>.</value>
         public string ContentType
         {
-            get { return this.GetValue("Content-Type", x => x.First()); }
+            get { return this.GetValue("Content-Type", x => x.First(), string.Empty); }
             set { this.SetHeaderValues("Content-Type", value, x => new[] { x }); }
         }
 
         /// <summary>
         /// The date and time that the message was sent.
         /// </summary>
-        /// <value>A <see cref="DateTime"/> instance that specifies when the message was sent. If not available then <see cref="DateTime.MinValue"/> will be returned.</value>
+        /// <value>A <see cref="DateTime"/> instance that specifies when the message was sent. If not available then <see langword="null"/> will be returned.</value>
         public DateTime? Date
         {
-            get { return this.GetValue("Date", x => ParseDateTime(x.First())); }
+            get { return this.GetValue("Date", x => ParseDateTime(x.First()), null); }
             set { this.SetHeaderValues("Date", value, x => new[] { GetDateAsString(value) }); }
         }
 
@@ -142,7 +142,7 @@ namespace Nancy
         /// <value>A <see cref="string"/> containing the header value if it is available; otherwise <see cref="string.Empty"/>.</value>
         public string Host
         {
-            get { return this.GetValue("Host", x => x.First()); }
+            get { return this.GetValue("Host", x => x.First(), string.Empty); }
             set { this.SetHeaderValues("Host", value, x => new[] { x }); }
         }
 
@@ -159,10 +159,10 @@ namespace Nancy
         /// <summary>
         /// Allows a 304 Not Modified to be returned if content is unchanged
         /// </summary>
-        /// <value>A <see cref="DateTime"/> instance that specifies when the requested resource must have been changed since. If not available then <see cref="DateTime.MinValue"/> will be returned.</value>
+        /// <value>A <see cref="DateTime"/> instance that specifies when the requested resource must have been changed since. If not available then <see langword="null"/> will be returned.</value>
         public DateTime? IfModifiedSince
         {
-            get { return this.GetValue("If-Modified-Since", x => ParseDateTime(x.First())); }
+            get { return this.GetValue("If-Modified-Since", x => ParseDateTime(x.First()), null); }
             set { this.SetHeaderValues("If-Modified-Since", value, x => new[] { GetDateAsString(value) }); }
         }
 
@@ -182,17 +182,17 @@ namespace Nancy
         /// <value>A <see cref="string"/> containing the header value if it is available; otherwise <see cref="string.Empty"/>.</value>
         public string IfRange
         {
-            get { return this.GetValue("If-Range", x => x.First()); }
+            get { return this.GetValue("If-Range", x => x.First(), string.Empty); }
             set { this.SetHeaderValues("If-Range", value, x => new[] { x }); }
         }
 
         /// <summary>
         /// Only send the response if the entity has not been modified since a specific time.
         /// </summary>
-        /// <value>A <see cref="DateTime"/> instance that specifies when the requested resource may not have been changed since. If not available then <see cref="DateTime.MinValue"/> will be returned.</value>
+        /// <value>A <see cref="DateTime"/> instance that specifies when the requested resource may not have been changed since. If not available then <see langword="null"/> will be returned.</value>
         public DateTime? IfUnmodifiedSince
         {
-            get { return this.GetValue("If-Unmodified-Since", x => ParseDateTime(x.First())); }
+            get { return this.GetValue("If-Unmodified-Since", x => ParseDateTime(x.First()), null); }
             set { this.SetHeaderValues("If-Unmodified-Since", value, x => new[] { GetDateAsString(value) }); }
 
         }
@@ -212,7 +212,7 @@ namespace Nancy
         /// <value>The number of the maximum allowed number of forwards if it is available; otherwise 0.</value>
         public int MaxForwards
         {
-            get { return this.GetValue("Max-Forwards", x => Convert.ToInt32(x.First())); }
+            get { return this.GetValue("Max-Forwards", x => Convert.ToInt32(x.First()), 0); }
             set { this.SetHeaderValues("Max-Forwards", value, x => new[] { x.ToString(CultureInfo.InvariantCulture) }); }
         }
 
@@ -222,7 +222,7 @@ namespace Nancy
         /// <value>A <see cref="string"/> containing the header value if it is available; otherwise <see cref="string.Empty"/>.</value>
         public string Referrer
         {
-            get { return this.GetValue("Referer", x => x.First()); }
+            get { return this.GetValue("Referer", x => x.First(), string.Empty); }
             set { this.SetHeaderValues("Referer", value, x => new[] { x }); }
         }
 
@@ -232,7 +232,7 @@ namespace Nancy
         /// <value>A <see cref="string"/> containing the header value if it is available; otherwise <see cref="string.Empty"/>.</value>
         public string UserAgent
         {
-            get { return this.GetValue("User-Agent", x => x.First()); }
+            get { return this.GetValue("User-Agent", x => x.First(), string.Empty); }
             set { this.SetHeaderValues("User-Agent", value, x => new[] { x }); }
         }
 
@@ -295,58 +295,114 @@ namespace Nancy
 
         private IEnumerable<Tuple<string, decimal>> GetWeightedValues(string headerName)
         {
-            return this.cache.GetOrAdd(headerName, header => {
+            return this.cache.GetOrAdd(headerName, r =>
+            {
+                var values = this.GetValue(r);
+                var result = new List<Tuple<string, decimal>>();
 
-                var values = this.GetSplitValues(header);
-
-                var parsed = values.Select(x =>
+                foreach (var header in values)
                 {
-                    var sections = x.Split(new[] { ";" }, StringSplitOptions.RemoveEmptyEntries);
-                    var mediaRange = sections[0].Trim();
-                    var quality = 1m;
+                    var buffer = string.Empty;
+                    var name = string.Empty;
+                    var quality = string.Empty;
+                    var isReadingQuality = false;
+                    var isInQuotedSection = false;
 
-                    for (var index = 1; index < sections.Length; index++)
+                    for (var index = 0; index < header.Length; index++)
                     {
-                        var trimmedValue = sections[index].Trim();
-                        if (trimmedValue.StartsWith("q=", StringComparison.OrdinalIgnoreCase))
+                        var character = header[index];
+
+                        if (character.Equals(' ') && (index != header.Length - 1) && !isInQuotedSection)
                         {
-                            decimal temp;
-                            var stringValue = trimmedValue.Substring(2);
-                            if (decimal.TryParse(stringValue, NumberStyles.Number, CultureInfo.InvariantCulture, out temp))
+                            continue;
+                        }
+
+                        if (character.Equals('"'))
+                        {
+                            isInQuotedSection = !isInQuotedSection;
+                        }
+
+                        if (isInQuotedSection)
+                        {
+                            buffer += character;
+
+                            if (index != header.Length - 1)
                             {
-                                quality = temp;
+                                continue; ;
                             }
                         }
-                        else
+
+                        if (character.Equals(';') || character.Equals(',') || (index == header.Length - 1))
                         {
-                            mediaRange += ";" + trimmedValue;
+                            if (!(character.Equals(';') || character.Equals(',')))
+                            {
+                                buffer += character;
+                            }
+
+                            if (isReadingQuality)
+                            {
+                                quality = buffer;
+                            }
+                            else
+                            {
+                                if (name.Length > 0)
+                                {
+                                    name += ';';
+                                }
+
+                                name += buffer;
+                            }
+
+                            buffer = string.Empty;
+                            isReadingQuality = false;
+                            isInQuotedSection = false;
                         }
+
+                        if (character.Equals(';'))
+                        {
+                            continue;
+                        }
+
+                        if ((character.Equals('q') || character.Equals('Q')) && (index != header.Length - 1))
+                        {
+                            if (header[index + 1].Equals('='))
+                            {
+                                isReadingQuality = true;
+                                continue;
+                            }
+                        }
+
+                        if (isReadingQuality && character.Equals('='))
+                        {
+                            continue;
+                        }
+
+                        if (character.Equals(',') || (index == header.Length - 1))
+                        {
+                            var actualQuality = 1m;
+                            decimal temp;
+
+                            if (decimal.TryParse(quality, NumberStyles.Number, CultureInfo.InvariantCulture, out temp))
+                            {
+                                actualQuality = temp;
+                            }
+
+                            result.Add(new Tuple<string, decimal>(name, actualQuality));
+
+                            name = string.Empty;
+                            quality = string.Empty;
+                            buffer = string.Empty;
+                            isReadingQuality = false;
+
+                            continue;
+                        }
+
+                        buffer += character;
                     }
+                }
 
-                    return new Tuple<string, decimal>(mediaRange, quality);
-                });
-
-                return parsed.OrderByDescending(x => x.Item2).ToArray();
+                return result.OrderByDescending(x => x.Item2);
             });
-        }
-
-        private static object GetDefaultValue(Type T)
-        {
-            if (IsGenericEnumerable(T))
-            {
-                var enumerableType = T.GetGenericArguments().First();
-                var x = typeof(List<>).MakeGenericType(new[] { enumerableType });
-                return Activator.CreateInstance(x);
-            }
-
-            if (T == typeof(DateTime))
-            {
-                return null;
-            }
-
-            return T == typeof(string) ?
-                string.Empty :
-                null;
         }
 
         private static IEnumerable<INancyCookie> GetNancyCookies(IEnumerable<string> cookies)
@@ -372,27 +428,24 @@ namespace Nancy
 
         private IEnumerable<string> GetValue(string name)
         {
-            return this.GetValue(name, x => x);
+            return this.GetValue(name, x => x, new string[] {});
         }
 
-        private T GetValue<T>(string name, Func<IEnumerable<string>, T> converter)
+        private T GetValue<T>(string name, Func<IEnumerable<string>, T> converter, T defaultValue)
         {
-            if (!this.headers.ContainsKey(name))
+            IEnumerable<string> values;
+
+            if (!this.headers.TryGetValue(name, out values))
             {
-                return (T)(GetDefaultValue(typeof(T)) ?? default(T));
+                return defaultValue;
             }
 
-            return converter.Invoke(this.headers[name]);
+            return converter.Invoke(values);
         }
 
         private static IEnumerable<string> GetWeightedValuesAsStrings(IEnumerable<Tuple<string, decimal>> values)
         {
             return values.Select(x => string.Concat(x.Item1, ";q=", x.Item2.ToString(CultureInfo.InvariantCulture)));
-        }
-
-        private static bool IsGenericEnumerable(Type T)
-        {
-            return !(T == typeof(string)) && T.IsGenericType && T.GetGenericTypeDefinition() == typeof(IEnumerable<>);
         }
 
         private static DateTime? ParseDateTime(string value)


### PR DESCRIPTION
I made some modifications to the `RequestHeaders.cs` class, more specifically to the headers that can have quality values assigned and calls the `GetWeightedValues` method internally. The value parsing was re-written to be a forward-reading algorithm, with reduced string manipulation (splits etc). This is the first pass and there are probably more improvements that can be performed so reviews and recommendations are more than welcome

Also removed from reflection + `Activator.CreateInstance` code that were used to get default fallback values based on a `Type` which in certain circumstances included creating a generic type on the fly.

Before
![image](https://cloud.githubusercontent.com/assets/50543/13743807/49903e5a-e9e4-11e5-9388-9a4dd11a867e.png)

After
![image](https://cloud.githubusercontent.com/assets/50543/13743796/359ad324-e9e4-11e5-9b9f-4933f432f3a9.png)

All tests pass, though there might be some unintentional side-effects for how the values are parsed that perhaps we do not have test coverage for