### PR TITLE
Added ReflectionTypeLoadException to SafeGetExportedTypes method

### DIFF
--- a/src/Nancy/Extensions/AssemblyExtensions.cs
+++ b/src/Nancy/Extensions/AssemblyExtensions.cs
@@ -31,8 +31,13 @@ namespace Nancy.Extensions
             {
                 types = new Type[] { };
             }
-            catch (FileLoadException) {
+            catch (FileLoadException)
+            {
                 // probably assembly version conflict
+                types = new Type[] { };
+            }
+            catch (ReflectionTypeLoadException)
+            {
                 types = new Type[] { };
             }
             return types;


### PR DESCRIPTION
This exception seems to be thrown on Mono but not on Windows, I tracked it down to a 3rd party dll that `GetExportedTypes` was being called on.