### PR TITLE
Optimization of DefaultFieldNameConverter.Convert

### DIFF
--- a/src/Nancy/ModelBinding/DefaultFieldNameConverter.cs
+++ b/src/Nancy/ModelBinding/DefaultFieldNameConverter.cs
@@ -1,11 +1,23 @@
 namespace Nancy.ModelBinding
 {
+    using System.Collections.Concurrent;
+
     /// <summary>
     /// Default field name converter
     /// Converts camel case to pascal case
     /// </summary>
     public class DefaultFieldNameConverter : IFieldNameConverter
     {
+        private readonly ConcurrentDictionary<string, string> cache;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultFieldNameConverter"/> class.
+        /// </summary>
+        public DefaultFieldNameConverter()
+        {
+            this.cache = new ConcurrentDictionary<string, string>();
+        }
+
         /// <summary>
         /// Converts a field name to a property name
         /// </summary>
@@ -18,15 +30,15 @@ namespace Nancy.ModelBinding
                 return fieldName;
             }
 
-            var first = fieldName.Substring(0, 1);
-            var capitalFirst = first.ToUpperInvariant();
-
-            if (first.Equals(capitalFirst))
+            return this.cache.GetOrAdd(fieldName, name =>
             {
-                return fieldName;
-            }
+                if (name.Length > 1)
+                {
+                    return char.ToUpperInvariant(name[0]) + name.Substring(1);
+                }
 
-            return string.Format("{0}{1}", capitalFirst, fieldName.Substring(1));
+                return name.ToUpperInvariant();
+            });
         }
     }
 }


### PR DESCRIPTION
Minor tweak while chasing bigger dragons. The `DefaultFieldNameConverter` basically tries to capitalize field names. This is part of a 100k requests sample where model binding is involved

- Changed string manipulation
- Added caching

Before
![image](https://cloud.githubusercontent.com/assets/50543/13775537/5e2f3afc-eaa5-11e5-87f5-0eeb8e62f51b.png)

After
![image](https://cloud.githubusercontent.com/assets/50543/13775541/6b358490-eaa5-11e5-9bc9-3551a4a4953d.png)
