### PR TITLE
Optimizaiton of DefaultModelBinderLocator

### DIFF
--- a/src/Nancy/ModelBinding/DefaultModelBinderLocator.cs
+++ b/src/Nancy/ModelBinding/DefaultModelBinderLocator.cs
@@ -12,7 +12,7 @@ namespace Nancy.ModelBinding
         /// <summary>
         /// Available model binders
         /// </summary>
-        private readonly IEnumerable<IModelBinder> binders;
+        private readonly IReadOnlyCollection<IModelBinder> binders;
 
         /// <summary>
         /// Default model binder to fall back on
@@ -27,7 +27,11 @@ namespace Nancy.ModelBinding
         public DefaultModelBinderLocator(IEnumerable<IModelBinder> binders, IBinder fallbackBinder)
         {
             this.fallbackBinder = fallbackBinder;
-            this.binders = binders;
+
+            if (binders != null)
+            {
+                this.binders = binders.ToArray();
+            }
         }
 
         /// <summary>
@@ -38,7 +42,20 @@ namespace Nancy.ModelBinding
         /// <returns>IModelBinder instance or null if none found</returns>
         public IBinder GetBinderForType(Type modelType, NancyContext context)
         {
-            return this.binders.FirstOrDefault(modelBinder => modelBinder.CanBind(modelType)) ?? this.fallbackBinder;
+            if (this.binders == null)
+            {
+                return this.fallbackBinder;
+            }
+
+            foreach (var modelBinder in this.binders)
+            {
+                if (modelBinder.CanBind(modelType))
+                {
+                    return modelBinder;
+                }
+            }
+
+            return this.fallbackBinder;
         }
     }
 }


### PR DESCRIPTION
Minor tweak while chasing bigger dragons. The `DefaultModelBinderLocator` figured out which model binder is should use for a specific model type. This is part of a 100k requests sample where model binding is involved

- Removed use of LINQ in the resolving

Before
![image](https://cloud.githubusercontent.com/assets/50543/13775721/84901fda-eaa6-11e5-83cf-799a50630737.png)

After
![image](https://cloud.githubusercontent.com/assets/50543/13775718/7d50c56c-eaa6-11e5-887d-e096fa1f7728.png)
