### PR TITLE
Optimization of ModuleExtensions.GetModuleName

### DIFF
--- a/src/Nancy/Extensions/ModuleExtensions.cs
+++ b/src/Nancy/Extensions/ModuleExtensions.cs
@@ -1,9 +1,6 @@
 namespace Nancy.Extensions
 {
     using System;
-    using System.Diagnostics;
-    using System.Text.RegularExpressions;
-
     using Nancy.ErrorHandling;
 
     /// <summary>
@@ -12,31 +9,22 @@ namespace Nancy.Extensions
     public static class ModuleExtensions
     {
         /// <summary>
-        /// A regular expression used to manipulate parameterized route segments.
-        /// </summary>
-        /// <value>A <see cref="Regex"/> object.</value>
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private static readonly Regex ModuleNameExpression =
-            new Regex(@"(?<name>[\w]+)Module$", RegexOptions.Compiled);
-
-        /// <summary>
         /// Extracts the friendly name of a Nancy module given its type.
         /// </summary>
         /// <param name="module">The module instance</param>
         /// <returns>A string containing the name of the parameter.</returns>
-        /// <exception cref="FormatException"></exception>
         public static string GetModuleName(this INancyModule module)
         {
             var typeName = module.GetType().Name;
-            var nameMatch =
-                ModuleNameExpression.Match(typeName);
 
-            if (nameMatch.Success)
+            var offset = typeName.LastIndexOf("Module", StringComparison.Ordinal);
+
+            if (offset <= 0)
             {
-                return nameMatch.Groups["name"].Value;
+                return typeName;
             }
 
-            return typeName;
+            return typeName.Substring(0, offset);
         }
 
         /// <summary>


### PR DESCRIPTION
Minor tweak while chasing bigger dragons. The `ModuleExtensions.GetModuleName` simply extracts the name of a module, by attempting to strip out the `Module`-suffix. This is part of a 100k requests sample

- Removed use of a Regex in favor of some string manipulation

Before
![image](https://cloud.githubusercontent.com/assets/50543/13795452/1df38586-eb01-11e5-805a-f92065872b4c.png)

After
![image](https://cloud.githubusercontent.com/assets/50543/13795461/30eaa80e-eb01-11e5-9359-ec8056f528c5.png)