### PR TITLE
Catch and rethrow ConfigurationException

### DIFF
--- a/src/Nancy/Configuration/ConfigurationException.cs
+++ b/src/Nancy/Configuration/ConfigurationException.cs
@@ -12,7 +12,19 @@ namespace Nancy
         /// Create an instance of <see cref="ConfigurationException"/>
         /// </summary>
         /// <param name="message">A message to be passed into the exception</param>
-        public ConfigurationException(string message) : base(message)
+        public ConfigurationException(string message)
+            : base(message)
+        {
+            
+        }
+
+        /// <summary>
+        /// Create an instance of <see cref="ConfigurationException"/>
+        /// </summary>
+        /// <param name="message">A message to be passed into the exception</param>
+        /// <param name = "exception">An inner exception to buble up</param>
+        public ConfigurationException(string message, Exception exception)
+            : base(message, exception)
         {
             
         }

--- a/src/Nancy/Configuration/DefaultNancyEnvironmentConfigurator.cs
+++ b/src/Nancy/Configuration/DefaultNancyEnvironmentConfigurator.cs
@@ -58,15 +58,19 @@
             return environment;
         }
 
-        private static object SafeGetDefaultConfiguration(INancyDefaultConfigurationProvider configurationProviders)
+        private static object SafeGetDefaultConfiguration(INancyDefaultConfigurationProvider configurationProvider)
         {
             try
             {
-                return configurationProviders.GetDefaultConfiguration();
+                return configurationProvider.GetDefaultConfiguration();
             }
-            catch (Exception)
+            catch(ConfigurationException)
             {
-                return null;
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new ConfigurationException(string.Format("Error loading default confguration for {0}", configurationProvider.Key), ex);
             }
         }
     }


### PR DESCRIPTION
When loading the default configurations, some like `GlobalizationConfiguration` do defensive checks and throw `ConfigurationException` however, these are caught and never bubbled up which result in a error message not directly related to the original issue.