### PR TITLE
RFC 5899 Compliant Link Header (master)

### DIFF
--- a/src/Nancy/Responses/Negotiation/DefaultResponseNegotiator.cs
+++ b/src/Nancy/Responses/Negotiation/DefaultResponseNegotiator.cs
@@ -359,7 +359,7 @@
             var baseUrl = string.Concat(requestUrl.BasePath, "/", fileName);
 
             var links = linkProcessors
-                .Select(lp => string.Format("<{0}.{1}>; rel=\"{2}\"", baseUrl, lp.Key, lp.Value));
+                .Select(lp => string.Format("<{0}.{1}>; rel=\"alternate\"; type=\"{2}\"", baseUrl, lp.Key, lp.Value));
 
             return string.Join(",", links);
         }

--- a/src/Nancy/Responses/Negotiation/DefaultResponseNegotiator.cs
+++ b/src/Nancy/Responses/Negotiation/DefaultResponseNegotiator.cs
@@ -233,10 +233,9 @@
         /// <param name="negotiationContext">The negotiation context.</param>
         /// <param name="context">The context.</param>
         /// <returns>A <see cref="Response"/>.</returns>
-        private static Response CreateResponse(
-            IList<CompatibleHeader> compatibleHeaders,
-            NegotiationContext negotiationContext,
-            NancyContext context)
+        private Response CreateResponse(IList<CompatibleHeader> compatibleHeaders,
+                                        NegotiationContext negotiationContext,
+                                        NancyContext context)
         {
             var response = NegotiateResponse(compatibleHeaders, negotiationContext, context);
 
@@ -250,7 +249,7 @@
 
             response.WithHeader("Vary", "Accept");
 
-            AddLinkHeader(compatibleHeaders, response, context.Request.Url);
+            this.AddLinkHeader(compatibleHeaders, response, context.Request.Url);
             SetStatusCode(negotiationContext, response);
             SetReasonPhrase(negotiationContext, response);
             AddCookies(negotiationContext, response);
@@ -353,7 +352,7 @@
         /// <param name="linkProcessors">The link processors.</param>
         /// <param name="existingLinkHeader">The existing Link HTTP Header.</param>
         /// <returns>The link header.</returns>
-        private static string CreateLinkHeader(Url requestUrl, IEnumerable<KeyValuePair<string, MediaRange>> linkProcessors, string existingLinkHeader)
+        protected virtual string CreateLinkHeader(Url requestUrl, IEnumerable<KeyValuePair<string, MediaRange>> linkProcessors, string existingLinkHeader)
         {
             var fileName = Path.GetFileNameWithoutExtension(requestUrl.Path);
             var baseUrl = string.Concat(requestUrl.BasePath, "/", fileName);

--- a/test/Nancy.Tests.Functional.MSBuild/Nancy.Tests.Functional.csproj
+++ b/test/Nancy.Tests.Functional.MSBuild/Nancy.Tests.Functional.csproj
@@ -94,6 +94,9 @@
     <Compile Include="..\Nancy.Tests.Functional\Properties\AssemblyInfo.cs">
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="..\Nancy.Tests.Functional\Tests\JsonLdProcessor.cs">
+      <Link>Tests\JsonLdProcessor.cs</Link>
+    </Compile>
     <Compile Include="..\Nancy.Tests\xUnitExtensions\RecordAsync.cs">
       <Link>RecordAsync.cs</Link>
     </Compile>

--- a/test/Nancy.Tests.Functional/Tests/ContentNegotiationFixture.cs
+++ b/test/Nancy.Tests.Functional/Tests/ContentNegotiationFixture.cs
@@ -461,9 +461,9 @@ namespace Nancy.Tests.Functional.Tests
             var response = await browser.Get("/");
 
             // Then
-            Assert.True(response.Headers["Link"].Contains(@"</.foo>; rel=""foo/bar"""));
-            Assert.True(response.Headers["Link"].Contains(@"</.json>; rel=""application/json"""));
-            Assert.True(response.Headers["Link"].Contains(@"</.xml>; rel=""application/xml"""));
+            Assert.True(response.Headers["Link"].Contains(@"</.foo>; rel=""alternate""; type=""foo/bar"""));
+            Assert.True(response.Headers["Link"].Contains(@"</.json>; rel=""alternate""; type=""application/json"""));
+            Assert.True(response.Headers["Link"].Contains(@"</.xml>; rel=""alternate""; type=""application/xml"""));
         }
 
         [Fact]

--- a/test/Nancy.Tests.Functional/Tests/ContentNegotiationFixture.cs
+++ b/test/Nancy.Tests.Functional/Tests/ContentNegotiationFixture.cs
@@ -467,6 +467,28 @@ namespace Nancy.Tests.Functional.Tests
         }
 
         [Fact]
+        public async Task Should_preserve_existing_link_header()
+        {
+            // Given
+            var browser = new Browser(with =>
+            {
+                with.ResponseProcessors(typeof(XmlProcessor), typeof(JsonLdProcessor));
+
+                with.Module(new ConfigurableNancyModule(x =>
+                {
+                    x.Get("/", CreateNegotiatedResponse());
+                }));
+            });
+
+            // When
+            var response = await browser.Get("/");
+
+            // Then
+            Assert.True(response.Headers["Link"].Contains(@"</context.jsonld>; rel=""http://www.w3.org/ns/json-ld#context""; type=""application/ld+json"""));
+            Assert.True(response.Headers["Link"].Contains(@"</.xml>; rel=""alternate""; type=""application/xml"""));
+        }
+
+        [Fact]
         public async Task Should_set_negotiated_status_code_to_response_when_set_as_integer()
         {
             // Given

--- a/test/Nancy.Tests.Functional/Tests/JsonLdProcessor.cs
+++ b/test/Nancy.Tests.Functional/Tests/JsonLdProcessor.cs
@@ -1,0 +1,41 @@
+﻿namespace Nancy.Tests.Functional.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Nancy.Responses.Negotiation;
+
+    public class JsonLdProcessor : IResponseProcessor
+    {
+        private readonly ISerializer serializer;
+
+        public JsonLdProcessor(IEnumerable<ISerializer> serializers)
+        {
+            this.serializer = serializers.FirstOrDefault(x => x.CanSerialize("application/json"));
+        }
+
+        public IEnumerable<Tuple<string, MediaRange>> ExtensionMappings
+        {
+            get { return new[] { new Tuple<string, MediaRange>("json", new MediaRange("application/json")) }; }
+        }
+
+        public ProcessorMatch CanProcess(MediaRange requestedMediaRange, dynamic model, NancyContext context)
+        {
+            return new ProcessorMatch
+            {
+                ModelResult = MatchResult.DontCare,
+                RequestedContentTypeResult = MatchResult.DontCare
+            };
+        }
+
+        public Response Process(MediaRange requestedMediaRange, dynamic model, NancyContext context)
+        {
+            return new Response
+            {
+                ContentType = "application/json",
+                Contents = stream => this.serializer.Serialize("application/json", model, stream),
+                StatusCode = HttpStatusCode.OK
+            }.WithHeader("Link", "</context.jsonld>; rel=\"http://www.w3.org/ns/json-ld#context\"; type=\"application/ld+json\"");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a few `HttpLink` classes to make the `Link` HTTP header being produced by `DefaultResponseNegotiator` a bit more [RFC 5899](https://tools.ietf.org/html/rfc5988) compliant. The parsing algorithm is not a full ABNF implementation, but I believe it's good enough to claim RFC 5899 compliancy.

To explain why this PR isn't just a simple switch of the `rel` and addition of `type` parameters in `DefaultResponseNegotiator.CreateLinkHeader()`, I believe that when an HTTP server framework adds a header, it's the framework's responsibility to ensure that the header is properly implemented according to the RFC in which it is defined and not leave this up to users of the framework.

Additionally, the `DefaultResponseNegotiator.AddLinkHeader()` method didn't check if a `Link` header already existed, effectively replacing any existing `Link` headers with its own. This is the particular problem that made me start looking into the issue to begin with.

This PR attempts to fix all this and while it might seem massive, I feel this is what's required.