### PR TITLE
Re-implemented TryCastResultToResponse to boost performance

### DIFF
--- a/src/Nancy/Responses/Negotiation/DefaultResponseNegotiator.cs
+++ b/src/Nancy/Responses/Negotiation/DefaultResponseNegotiator.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Reflection;
     using System.Text;
 
     using Nancy.Conventions;
@@ -75,18 +76,41 @@
         /// <returns><c>true</c> if the result is a <see cref="Response"/>, <c>false</c> otherwise.</returns>
         private static bool TryCastResultToResponse(dynamic routeResult, out Response response)
         {
-            // This code has to be designed this way in order for the cast operator overloads
-            // to be called in the correct way. It cannot be replaced by the as-operator.
-            try
+            var targetType = routeResult.GetType();
+            var responseType = typeof(Response);
+
+            var methods = responseType.GetMethods(BindingFlags.Public | BindingFlags.Static);
+
+            foreach (var method in methods)
             {
-                response = (Response) routeResult;
+                if (!method.Name.Equals("op_Implicit", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (method.ReturnType != responseType)
+                {
+                    continue;
+                }
+
+                var parameters = method.GetParameters();
+
+                if (parameters.Length != 1)
+                {
+                    continue;
+                }
+
+                if (parameters[0].ParameterType != targetType)
+                {
+                    continue;
+                }
+
+                response = (Response)routeResult;
                 return true;
             }
-            catch
-            {
-                response = null;
-                return false;
-            }
+
+            response = null;
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
The current implementation of `DefaultResponseNegotiator.TryCastResultToResponse` uses exception handling to control the flow. This is (no surprise) slow, but as it turns out it was having a much bigger impact that I had anticipated. The new implementation uses reflection to figure out, up front, if the cast is going to be valid or not. Due to reflection caching in .NET 4.0+ there is really no need to do any caching on our own and the performance gain is amazing.

All requests, that ended up being negotiated (i.e not directly castable to `Response`) would hit this code path and had to take the penalty

This is part of a 100k iteration sample, compared before and after

BEFORE
![image](https://cloud.githubusercontent.com/assets/50543/14012293/3996ceba-f1a5-11e5-854a-1aa647a46bdd.png)

AFTER
![image](https://cloud.githubusercontent.com/assets/50543/14012312/587bf4c2-f1a5-11e5-8b5a-639640652d1a.png)

Perhaps we can squeeze in additional tweaks?