### PR TITLE
Optimization of Content Negotiation

### DIFF
--- a/src/Nancy/Diagnostics/RequestData.cs
+++ b/src/Nancy/Diagnostics/RequestData.cs
@@ -1,5 +1,7 @@
 namespace Nancy.Diagnostics
 {
+    using Nancy.Responses.Negotiation;
+
     /// <summary>
     /// Stores request trace information about the request.
     /// </summary>
@@ -8,8 +10,8 @@ namespace Nancy.Diagnostics
         /// <summary>
         /// Gets or sets the content type of the request.
         /// </summary>
-        /// <value>A <see cref="string"/> containing the content type.</value>
-        public string ContentType { get; set; }
+        /// <value>A <see cref="MediaRange"/> containing the content type.</value>
+        public MediaRange ContentType { get; set; }
 
         /// <summary>
         /// Gets or sets the headers of the request.

--- a/src/Nancy/ModelBinding/DefaultBinder.cs
+++ b/src/Nancy/ModelBinding/DefaultBinder.cs
@@ -8,6 +8,7 @@ namespace Nancy.ModelBinding
     using System.Text.RegularExpressions;
 
     using Nancy.Extensions;
+    using Nancy.Responses.Negotiation;
 
     /// <summary>
     /// Default binder - used as a fallback when a specific modelbinder
@@ -485,7 +486,7 @@ namespace Nancy.ModelBinding
 
             var contentType = GetRequestContentType(context.Context);
 
-            if (string.IsNullOrEmpty(contentType))
+            if (contentType == null)
             {
                 return null;
             }
@@ -498,19 +499,14 @@ namespace Nancy.ModelBinding
                 : null;
         }
 
-        private static string GetRequestContentType(NancyContext context)
+        private static MediaRange GetRequestContentType(NancyContext context)
         {
             if (context == null || context.Request == null)
             {
-                return String.Empty;
+                return null;
             }
 
-            var contentType =
-                context.Request.Headers.ContentType;
-
-            return (string.IsNullOrEmpty(contentType))
-                ? string.Empty
-                : contentType;
+            return context.Request.Headers.ContentType;
         }
     }
 }

--- a/src/Nancy/Request.cs
+++ b/src/Nancy/Request.cs
@@ -234,21 +234,20 @@ namespace Nancy
 
         private void ParseFormData()
         {
-            if (string.IsNullOrEmpty(this.Headers.ContentType))
+            if (this.Headers.ContentType == null)
             {
                 return;
             }
 
-            var contentType = this.Headers["content-type"].First();
-            var mimeType = contentType.Split(';').First();
-            if (mimeType.Equals("application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase))
+            var contentType = this.Headers.ContentType;
+            if (contentType.Matches("application/x-www-form-urlencoded"))
             {
                 var reader = new StreamReader(this.Body);
                 this.form = reader.ReadToEnd().AsQueryDictionary();
                 this.Body.Position = 0;
             }
 
-            if (!mimeType.Equals("multipart/form-data", StringComparison.OrdinalIgnoreCase))
+            if (!contentType.Matches("multipart/form-data"))
             {
                 return;
             }

--- a/src/Nancy/RequestHeaders.cs
+++ b/src/Nancy/RequestHeaders.cs
@@ -8,6 +8,7 @@ namespace Nancy
     using System.Linq;
 
     using Nancy.Cookies;
+    using Nancy.Responses.Negotiation;
 
     /// <summary>
     /// Provides strongly-typed access to HTTP request headers.
@@ -119,11 +120,11 @@ namespace Nancy
         /// <summary>
         /// The mime type of the body of the request (used with POST and PUT requests).
         /// </summary>
-        /// <value>A <see cref="string"/> containing the header value if it is available; otherwise <see langword="string.Empty"/>.</value>
-        public string ContentType
+        /// <value>A <see cref="MediaRange"/> containing the header value if it is available; otherwise <see langword="null"/>.</value>
+        public MediaRange ContentType
         {
-            get { return this.GetValue("Content-Type", x => x.First(), string.Empty); }
-            set { this.SetHeaderValues("Content-Type", value, x => new[] { x }); }
+            get { return this.GetValue("Content-Type", x => new MediaRange(x.First()), null); }
+            set { this.SetHeaderValues("Content-Type", value, x => new[] { x.ToString() }); }
         }
 
         /// <summary>

--- a/src/Nancy/Responses/Negotiation/DefaultResponseNegotiator.cs
+++ b/src/Nancy/Responses/Negotiation/DefaultResponseNegotiator.cs
@@ -1,6 +1,7 @@
 ﻿namespace Nancy.Responses.Negotiation
 {
     using System;
+    using System.CodeDom.Compiler;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
@@ -15,7 +16,7 @@
     /// </summary>
     public class DefaultResponseNegotiator : IResponseNegotiator
     {
-        private readonly IEnumerable<IResponseProcessor> processors;
+        private readonly IReadOnlyCollection<IResponseProcessor> processors;
         private readonly AcceptHeaderCoercionConventions coercionConventions;
 
         /// <summary>
@@ -25,7 +26,7 @@
         /// <param name="coercionConventions">The Accept header coercion conventions.</param>
         public DefaultResponseNegotiator(IEnumerable<IResponseProcessor> processors, AcceptHeaderCoercionConventions coercionConventions)
         {
-            this.processors = processors;
+            this.processors = processors.ToArray();
             this.coercionConventions = coercionConventions;
         }
 
@@ -332,14 +333,18 @@
         {
             var linkProcessors = new Dictionary<string, MediaRange>();
 
-            var compatibleHeaderMappings = compatibleHeaders
-                .SelectMany(header => header.Processors)
-                .SelectMany(processor => processor.Item1.ExtensionMappings)
-                .Where(mapping => !mapping.Item2.Matches(contentType));
-
-            foreach (var compatibleHeaderMapping in compatibleHeaderMappings)
+            foreach (var header in compatibleHeaders)
             {
-                linkProcessors[compatibleHeaderMapping.Item1] = compatibleHeaderMapping.Item2;
+                foreach (var processor in header.Processors)
+                {
+                    foreach (var mapping in processor.Item1.ExtensionMappings)
+                    {
+                        if (!mapping.Item2.Matches(contentType))
+                        {
+                            linkProcessors[mapping.Item1] = mapping.Item2;
+                        }
+                    }
+                }
             }
 
             return linkProcessors;
@@ -357,15 +362,35 @@
             var fileName = Path.GetFileNameWithoutExtension(requestUrl.Path);
             var baseUrl = string.Concat(requestUrl.BasePath, "/", fileName);
 
-            var links = linkProcessors
-                .Select(lp => string.Format("<{0}.{1}>; rel=\"alternate\"; type=\"{2}\"", baseUrl, lp.Key, lp.Value));
+            var result = new StringBuilder();
+
+            foreach (var linkProcessor in linkProcessors)
+            {
+                if (result.Length > 0)
+                {
+                    result.Append(", ");
+                }
+
+                result.Append("<");
+                result.Append(baseUrl);
+                result.Append(".");
+                result.Append(linkProcessor.Key);
+                result.Append(">; rel=\"alternate\"; type=\"");
+                result.Append(linkProcessor.Value);
+                result.Append("\"");
+            }
 
             if (!string.IsNullOrEmpty(existingLinkHeader))
             {
-                links = links.Concat(new[] { existingLinkHeader });
+                if (result.Length > 0)
+                {
+                    result.Append(", ");
+                }
+
+                result.Append(existingLinkHeader);
             }
 
-            return string.Join(", ", links);
+            return result.ToString();
         }
 
         /// <summary>

--- a/test/Nancy.Tests/Unit/Diagnostics/DefaultRequestTraceFactoryFixture.cs
+++ b/test/Nancy.Tests/Unit/Diagnostics/DefaultRequestTraceFactoryFixture.cs
@@ -91,10 +91,10 @@
             var trace = this.factory.Create(this.request);
 
             // Then
-            trace.RequestData.ContentType.ShouldEqual(request.Headers.ContentType);
-            trace.RequestData.Headers.ShouldBeSameAs(request.Headers);
-            trace.RequestData.Method.ShouldEqual(request.Method);
-            trace.RequestData.Url.ShouldBeSameAs(request.Url);
+            trace.RequestData.ContentType.Matches(this.request.Headers.ContentType).ShouldBeTrue();
+            trace.RequestData.Headers.ShouldBeSameAs(this.request.Headers);
+            trace.RequestData.Method.ShouldEqual(this.request.Method);
+            trace.RequestData.Url.ShouldBeSameAs(this.request.Url);
         }
 
         [Fact]

--- a/test/Nancy.Tests/Unit/RequestFixture.cs
+++ b/test/Nancy.Tests/Unit/RequestFixture.cs
@@ -156,14 +156,14 @@ namespace Nancy.Tests.Unit
             // Given
             var headers = new Dictionary<string, IEnumerable<string>>()
                 {
-                    { "content-type", new[] {"foo"} }
+                    { "content-type", new[] {"foo/bar"} }
                 };
 
             // When
             var request = new Request("GET", new Url { Path = "/", Scheme = "http" }, CreateRequestStream(), headers);
 
             // Then
-            request.Headers.ContentType.ShouldNotBeEmpty();
+            request.Headers.ContentType.ShouldNotBeNull();
         }
 
         [Fact]
@@ -495,7 +495,7 @@ namespace Nancy.Tests.Unit
 
             // When
             var request = new Request("POST", new Url { Path = "/", Scheme = "http" }, CreateRequestStream(memory), headers);
-            
+
             // Then
             ((string)request.Form.name).ShouldEqual("John Doe");
         }
@@ -571,7 +571,7 @@ namespace Nancy.Tests.Unit
             var request = new Request("GET", newUrl, null, headers);
 
             // Then
-            request.Cookies[cookieName].ShouldEqual(cookieData);            
+            request.Cookies[cookieName].ShouldEqual(cookieData);
         }
 
         [Fact]
@@ -798,7 +798,7 @@ namespace Nancy.Tests.Unit
 
             // Then
             ((bool)request.Query.key1).ShouldBeTrue();
-            ((string)request.Query.key1).ShouldEqual("key1"); 
+            ((string)request.Query.key1).ShouldEqual("key1");
         }
 
         [Fact]


### PR DESCRIPTION
This is part of a 100k requests sample

There are a bunch of changes in this one
- `RequestHeaders.ContentType` was changed from `string` to `MediaRange` to reduce the number of `string -> MediaRange` implicit casts that are preformed during route execution
- `RequestHeaders.ContentType` was changed to read-only
- `MediaRange` now implements `IEquatable<MediaRange>`
- Added `MediaRange.Empty`
- Added `MediaRange.IsEmpty` - Together with `Empty` these replaces a couple of `IsNullOrEmpty` checks we performed in places where `contentType` was still a `string`
- Removed parts of the LINQ statements inside the `DefaultResponseNegotiatior` (there are more fish to fry in there, that's for sure)

NOTE: This pull-request does not convert all occurrences where the `contentType` is represented as `string`

Before
![image](https://cloud.githubusercontent.com/assets/50543/14121344/5896546a-f5f7-11e5-882c-e16384f1fdce.png)

After
![image](https://cloud.githubusercontent.com/assets/50543/14121285/0ce39960-f5f7-11e5-8d64-cd0d4aae21f0.png)

Not bad, if I may say so myself :)