### PR TITLE
Updated Nancy.ViewEngines.Razor NuGet dependencies

### DIFF
--- a/src/Nancy.ViewEngines.Razor/nancy.viewengines.razor.nuspec
+++ b/src/Nancy.ViewEngines.Razor/nancy.viewengines.razor.nuspec
@@ -13,14 +13,11 @@
     <licenseUrl>https://github.com/NancyFx/Nancy/blob/master/license.txt</licenseUrl>
     <projectUrl>http://nancyfx.org</projectUrl>
     <dependencies>
-      <group>
-        <dependency id="Nancy" />
-        <dependency id="Microsoft.AspNet.Razor" />
-      </group>
-      <group targetFramework="net40">
-        <dependency id="Nancy" />
-        <dependency id="Microsoft.AspNet.Razor" version="2.0.30506" />
-      </group>
+      <dependency id="Nancy" />
+      <dependency id="Microsoft.AspNet.Razor" version="2.0.30506.0" />
+      <dependency id="Microsoft.Net.Compilers" version="1.1.1" />
+      <dependency id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.1" />
+      <dependency id="Microsoft.CodeAnalysis.CSharp" version="1.1.1" />
     </dependencies>
     <tags>Nancy Viewengine Razor</tags>
   </metadata>


### PR DESCRIPTION
When we updated Razor to use Roslyn, we forgot to update the `.nuspec` to include the new dependencies

- `Microsoft.Net.Compilers v1.1.1`
- `Microsoft.CodeDom.Providers.DotNetCompilerPlatform v1.0.1`
- `Microsoft.CodeAnalysis.CSharp v1.1.1`

I have build the packages locally and installed them into a new project. All dependencies were resolved correctly and I was able to render a razor view in a basic Nancy web application.