### PR TITLE
Exclude nunit and nCrunch from automatic bootstrap registration

### DIFF
--- a/src/Nancy/DefaultNancyBootstrapper.cs
+++ b/src/Nancy/DefaultNancyBootstrapper.cs
@@ -35,6 +35,8 @@ namespace Nancy
                 asm => asm.FullName.StartsWith("SMDiagnostics", StringComparison.Ordinal),
                 asm => asm.FullName.StartsWith("CppCodeProvider", StringComparison.Ordinal),
                 asm => asm.FullName.StartsWith("WebDev.WebHost40", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("nunit", StringComparison.Ordinal),
+                asm => asm.FullName.StartsWith("nCrunch", StringComparison.Ordinal),
             };
 
         /// <summary>


### PR DESCRIPTION
Pr for #2401

I have just tracked a large amount of slow tests down to this.

xunit and other test frameworks are ignored, but not nunit and ncrunch. ("MonoDevelop.NUnit" is excluded, but not regular "NUnit").

They are commonly used, make no sense to have auto discover anything from them, and though I can fix it for my project it would be a general benefit to fix for all users.

e.g. this is where "xunit" is ignored:

/src/Nancy/DefaultNancyBootstrapper.cs:

```
asm => asm.FullName.StartsWith("xunit", StringComparison.Ordinal),
```