### PR TITLE
Added ASPNET CI Feed to NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,7 @@
 
 <configuration>
   <packageSources>
+    <add key="AspNet CI Feed" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
This issue is part of the #2404 epic

### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [X] I have verified made sure that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [X] I have provided test coverage for your change (where applicable)

### Description
We need to add the CI feed for packages in order to be able to restore the work-in-progress rc2 nugets

