### PR TITLE
Updated targets to point to 4.5 directory

### DIFF
--- a/src/Nancy.ViewEngines.Razor/targets/Nancy.ViewEngines.Razor.targets
+++ b/src/Nancy.ViewEngines.Razor/targets/Nancy.ViewEngines.Razor.targets
@@ -9,6 +9,6 @@
 
   <Target Name="CopyRazorFiles" Condition="'$(Configuration)'=='DEBUG'">
      <Copy SourceFiles="$(MSBuildThisFileDirectory)..\BuildProviders\Nancy.ViewEngines.Razor.BuildProviders.dll" DestinationFolder="$(DestinationFolder)" ContinueOnError="true" />
-     <Copy SourceFiles="$(MSBuildThisFileDirectory)..\lib\net40\Nancy.ViewEngines.Razor.dll" DestinationFolder="$(DestinationFolder)" ContinueOnError="true" />
+     <Copy SourceFiles="$(MSBuildThisFileDirectory)..\lib\net45\Nancy.ViewEngines.Razor.dll" DestinationFolder="$(DestinationFolder)" ContinueOnError="true" />
    </Target>
 </Project>


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [X] I have verified made sure that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [ ] I have provided test coverage for your change (where applicable)

### Description

Updated razor targets to point to lib 45 directory instead of 4.0. Fixes compile warning that the file cannot be found.

