### PR TITLE
Added aspnetcore configuration usage to Nancy.Demo.Hosting.Kestrel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Gemfile.lock
 packages/
 project.lock.json
 TestAssembly.dll
+.vscode/

--- a/samples/Nancy.Demo.Hosting.Kestrel/AppConfiguration.cs
+++ b/samples/Nancy.Demo.Hosting.Kestrel/AppConfiguration.cs
@@ -1,0 +1,29 @@
+namespace Nancy.Demo.Hosting.Kestrel
+{
+    public class AppConfiguration
+    {
+        public Logging Logging { get; set; }
+        public Smtp Smtp { get; set; }
+    }
+    
+    public class LogLevel
+    {
+        public string Default { get; set; }
+        public string System { get; set; }
+        public string Microsoft { get; set; }
+    }
+
+    public class Logging
+    {
+        public bool IncludeScopes { get; set; }
+        public LogLevel LogLevel { get; set; }
+    }
+
+    public class Smtp
+    {
+        public string Server { get; set; }
+        public string User { get; set; }
+        public string Pass { get; set; }
+        public string Port { get; set; }
+    }
+}

--- a/samples/Nancy.Demo.Hosting.Kestrel/DemoBootstrapper.cs
+++ b/samples/Nancy.Demo.Hosting.Kestrel/DemoBootstrapper.cs
@@ -1,0 +1,24 @@
+namespace Nancy.Demo.Hosting.Kestrel
+{
+    using System;
+    
+    public class DemoBootstrapper : DefaultNancyBootstrapper
+    {
+        public DemoBootstrapper()
+        {
+            
+        }
+        
+        public DemoBootstrapper(AppConfiguration appConfig)
+        {
+            /*
+            We could register appConfig as an instance in the container which can
+            be injected into areas that need it or we could create our own INancyEnvironment
+            extension and use that.
+            */
+            Console.WriteLine(appConfig.Smtp.Server);
+            Console.WriteLine(appConfig.Smtp.User);
+            Console.WriteLine(appConfig.Logging.IncludeScopes);
+        }
+    }   
+}

--- a/samples/Nancy.Demo.Hosting.Kestrel/Program.cs
+++ b/samples/Nancy.Demo.Hosting.Kestrel/Program.cs
@@ -1,17 +1,17 @@
 namespace Nancy.Demo.Hosting.Kestrel
 {
+    using System.IO;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
-    using Microsoft.AspNetCore.Http;
-    using Nancy.Owin;
     
     public class Program
     {
         public static void Main(string[] args)
         {
             var host = new WebHostBuilder()
+                .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseKestrel()
-                .Configure(app => app.UseOwin(x => x.UseNancy()))
+                .UseStartup<Startup>()
                 .Build();
 
             host.Run();

--- a/samples/Nancy.Demo.Hosting.Kestrel/Startup.cs
+++ b/samples/Nancy.Demo.Hosting.Kestrel/Startup.cs
@@ -1,0 +1,31 @@
+namespace Nancy.Demo.Hosting.Kestrel
+{
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Extensions.Configuration;
+    using Nancy.Owin;
+    
+    public class Startup
+    {
+        public IConfiguration Configuration { get; set; }
+        
+        public Startup(IHostingEnvironment env)
+        {
+            var builder = new ConfigurationBuilder()
+                              .AddJsonFile("appsettings.json")
+                              .SetBasePath(env.ContentRootPath);
+
+            Configuration = builder.Build();
+        }
+        
+        public void Configure(IApplicationBuilder app)
+        {
+            
+            var config = this.Configuration;
+            var appConfig = new AppConfiguration();
+            ConfigurationBinder.Bind(config, appConfig);
+
+            app.UseOwin(x => x.UseNancy(opt => opt.Bootstrapper = new DemoBootstrapper(appConfig)));
+        }
+    }
+}

--- a/samples/Nancy.Demo.Hosting.Kestrel/appsettings.json
+++ b/samples/Nancy.Demo.Hosting.Kestrel/appsettings.json
@@ -1,0 +1,16 @@
+{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Verbose",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  },
+  "Smtp": {
+    "Server": "0.0.0.1",
+    "User": "user@company.com",
+    "Pass": "123456789",
+    "Port": "25"
+  }
+}

--- a/samples/Nancy.Demo.Hosting.Kestrel/project.json
+++ b/samples/Nancy.Demo.Hosting.Kestrel/project.json
@@ -14,6 +14,8 @@
                 "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-final",
                 "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-final",
                 "Microsoft.AspNetCore.Owin": "1.0.0-rc2-final",
+                "Microsoft.Extensions.Configuration.Binder":"1.0.0-rc2-final",
+                "Microsoft.Extensions.Configuration.Json":"1.0.0-rc2-final",
                 "Microsoft.NETCore.App": {
                     "type": "platform",
                     "version": "1.0.0-rc2-3002702"


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified made sure that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [ ] I have provided test coverage for your change (where applicable)

### Description
I was tinkering with the new aspnetcore configuration model and was wondering how this may effect Nancy's own configuration model.  We can use the aspnetcore config model to pass an application's settings to a bootstrapper and from there deal with it by either registering an instance of a class that has the application's settings inside it or a user could register their own `INancyEnvironment` extension.

