### PR TITLE
[WIP] Updated ViewRenderer to return Task

### DIFF
--- a/samples/Nancy.Demo.CustomModule/UglifiedNancyModule.cs
+++ b/samples/Nancy.Demo.CustomModule/UglifiedNancyModule.cs
@@ -43,9 +43,9 @@
 
         public string ModulePath { get; private set; }
 
-        public ViewRenderer View
+        public LegacyViewRenderer View
         {
-            get { return new ViewRenderer(this); }
+            get { return new LegacyViewRenderer(this); }
         }
 
         public Negotiator Negotiate

--- a/src/Nancy.MSBuild/Nancy.csproj
+++ b/src/Nancy.MSBuild/Nancy.csproj
@@ -1358,11 +1358,20 @@
     <Compile Include="..\Nancy\StaticContentConfigurationExtensions.cs">
       <Link>StaticContentConfigurationExtensions.cs</Link>
     </Compile>
-    <Compile Include="..\Nancy\GlobalizationConfiguration.cs" />
-    <Compile Include="..\Nancy\GlobalizationConfigurationExtensions.cs" />
-    <Compile Include="..\Nancy\DefaultGlobalizationConfigurationProvider.cs" />
+    <Compile Include="..\Nancy\GlobalizationConfiguration.cs" >
+      <Link>StaticContentConfiguration.cs</Link>
+    </Compile>
+    <Compile Include="..\Nancy\GlobalizationConfigurationExtensions.cs" >
+      <Link>StaticContentConfiguration.cs</Link>
+    </Compile>
+    <Compile Include="..\Nancy\DefaultGlobalizationConfigurationProvider.cs" >
+      <Link>StaticContentConfiguration.cs</Link>
+    </Compile>
     <Compile Include="..\Nancy\Configuration\ConfigurationException.cs">
       <Link>Configuration\ConfigurationException.cs</Link>
+    </Compile>
+    <Compile Include="..\Nancy\LegacyViewRenderer.cs">
+      <Link>LegacyViewRenderer.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/Nancy/INancyModule.cs
+++ b/src/Nancy/INancyModule.cs
@@ -93,12 +93,6 @@ namespace Nancy
         dynamic Text { get; }
 
         /// <summary>
-        /// Renders a view from inside a route handler.
-        /// </summary>
-        /// <value>A <see cref="ViewRenderer"/> instance that is used to determine which view that should be rendered.</value>
-        ViewRenderer View { get; }
-
-        /// <summary>
         /// Used to negotiate the content returned based on Accepts header.
         /// </summary>
         /// <value>A <see cref="Negotiator"/> instance that is used to negotiate the content returned.</value>

--- a/src/Nancy/LegacyNancyModule.cs
+++ b/src/Nancy/LegacyNancyModule.cs
@@ -154,9 +154,9 @@ namespace Nancy
         /// Renders a view from inside a route handler.
         /// </summary>
         /// <value>A <see cref="ViewRenderer"/> instance that is used to determine which view that should be rendered.</value>
-        public ViewRenderer View
+        public LegacyViewRenderer View
         {
-            get { return new ViewRenderer(this); }
+            get { return new LegacyViewRenderer(this); }
         }
 
         /// <summary>

--- a/src/Nancy/LegacyViewRenderer.cs
+++ b/src/Nancy/LegacyViewRenderer.cs
@@ -1,13 +1,12 @@
 namespace Nancy
 {
     using System.IO;
-    using System.Threading.Tasks;
     using Nancy.Responses.Negotiation;
 
     /// <summary>
-    /// Helper class for rendering a view from a route handler.
+    /// Helper class for rendering a view from a route handler. Used by <see cref="LegacyNancyModule"/>.
     /// </summary>
-    public class ViewRenderer : IHideObjectMembers
+    public class LegacyViewRenderer : IHideObjectMembers
     {
         private readonly INancyModule module;
 
@@ -15,7 +14,7 @@ namespace Nancy
         /// Initializes a new instance of the <see cref="ViewRenderer"/> class.
         /// </summary>
         /// <param name="module">The <see cref="INancyModule"/> instance that is rendering the view.</param>
-        public ViewRenderer(INancyModule module)
+        public LegacyViewRenderer(INancyModule module)
         {
             this.module = module;
         }
@@ -26,7 +25,7 @@ namespace Nancy
         /// <param name="model">The model that should be passed into the view.</param>
         /// <returns>A delegate that can be invoked with the <see cref="Stream"/> that the view should be rendered to.</returns>
         /// <remarks>The view name is model.GetType().Name with any Model suffix removed.</remarks>
-        public Task<Negotiator> this[dynamic model]
+        public Negotiator this[dynamic model]
         {
             get { return this.GetNegotiator(null, model); }
         }
@@ -37,7 +36,7 @@ namespace Nancy
         /// <param name="viewName">The name of the view to render.</param>
         /// <returns>A delegate that can be invoked with the <see cref="Stream"/> that the view should be rendered to.</returns>
         /// <remarks>The extension in the view name is optional. If it is omitted, then Nancy will try to resolve which of the available engines that should be used to render the view.</remarks>
-        public Task<Negotiator> this[string viewName]
+        public Negotiator this[string viewName]
         {
             get { return this.GetNegotiator(viewName, null); }
         }
@@ -49,12 +48,12 @@ namespace Nancy
         /// <param name="model">The model that should be passed into the view.</param>
         /// <returns>A delegate that can be invoked with the <see cref="Stream"/> that the view should be rendered to.</returns>
         /// <remarks>The extension in the view name is optional. If it is omitted, then Nancy will try to resolve which of the available engines that should be used to render the view.</remarks>
-        public Task<Negotiator> this[string viewName, dynamic model]
+        public Negotiator this[string viewName, dynamic model]
         {
             get { return this.GetNegotiator(viewName, model); }
         }
 
-        private Task<Negotiator> GetNegotiator(string viewName, object model)
+        private Negotiator GetNegotiator(string viewName, object model)
         {
             var negotiationContext = this.module.Context.NegotiationContext;
 
@@ -63,7 +62,7 @@ namespace Nancy
             negotiationContext.PermissableMediaRanges.Clear();
             negotiationContext.PermissableMediaRanges.Add("text/html");
 
-            return Task.FromResult(new Negotiator(this.module.Context));
+            return new Negotiator(this.module.Context);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [X] I have verified made sure that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [X] I have provided test coverage for your change (where applicable)

### Description
Updated `ViewRenderer` to return `Task<Negotiator>` instead of `Negotiator`. This means that from an `NancyModule` you can now call `await View["index"]`. Also created a `LegacyViewRenderer` with the old behavior that is used by `LegacyModule`. I also had to remove the `INancyModule.View` declaration since there is no `IViewRenderer` interface, nor can there be since they differ on the return value. To be honest this should not be on `INancyModule` at all (could prune more, but that's out of the context of this pull-request), it should be an implementation detail.

Also sneaked in a couple of file fixes in `Nancy.sln` for three files that weren't included as links

