### PR TITLE
Made the Negotiator awaitable

### DIFF
--- a/src/Nancy/Responses/Negotiation/Negotiator.cs
+++ b/src/Nancy/Responses/Negotiation/Negotiator.cs
@@ -1,7 +1,12 @@
 namespace Nancy.Responses.Negotiation
 {
     using System;
+    using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
 
+    /// <summary>
+    /// Configurator for a negotiated response.
+    /// </summary>
     public class Negotiator : IHideObjectMembers
     {
         // TODO - this perhaps should be an interface, along with the view thing above
@@ -28,5 +33,14 @@ namespace Nancy.Responses.Negotiation
         /// </summary>
         /// <value>A <see cref="NegotiationContext"/> instance.</value>
         public NegotiationContext NegotiationContext { get; private set; }
+
+        /// <summary>
+        /// Gets the awaiter for the class.
+        /// </summary>
+        /// <returns>A <see cref="TaskAwaiter{TResult}"/> instance.</returns>
+        public TaskAwaiter<Negotiator> GetAwaiter()
+        {
+            return Task.FromResult(this).GetAwaiter();
+        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [X] I have verified made sure that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [X] I have provided test coverage for your change (where applicable)

### Description
Enables the use of `Negotiator` from inside an async module by calling `await` on it. This approach still enables the non-await call to it from inside `LegacyNancyModule`


```c#
public class TestModule : NancyModule
{
    public TestModule() : base("asyncnegotiator")
    {
        Get["/"] = async (parameters, ct) =>
        {
            return await Negotiate
                .WithModel(new RatPack { FirstName = "Nancy " })
                .WithMediaRangeModel("text/html", new RatPack { FirstName = "Nancy fancy pants" })
                .WithView("negotiatedview")
                .WithHeader("X-Custom", "SomeValue");
        };
    }
}
```

