### PR TITLE
Updated the message that is displayed when an internal server error occurs and DisplayErrorTraces is disabled

### DIFF
--- a/src/Nancy.ViewEngines.Razor/NancyRazorErrorView.cs
+++ b/src/Nancy.ViewEngines.Razor/NancyRazorErrorView.cs
@@ -10,7 +10,7 @@
     {
         private readonly TraceConfiguration traceConfiguration;
 
-        private const string DisableErrorTracesTrueMessage = "Error details are currently disabled. Please set <code>StaticConfiguration.DisableErrorTraces = false;</code> to enable.";
+        private const string DisplayErrorTracesFalseMessage =  "Error details are currently disabled.<br />To enable it, please set <code>TraceConfiguration.DisplayErrorTraces</code> to true.<br />For example by overriding your Bootstrapper's <code>Configure</code> method and calling <code>environment.Tracing(enabled: false, displayErrorTraces: true);</code>.";
 
         private static string template;
 
@@ -46,7 +46,7 @@
         /// </summary>
         public override void Execute()
         {
-            base.WriteLiteral(Template.Replace("[DETAILS]", this.traceConfiguration.DisplayErrorTraces ? this.Message : DisableErrorTracesTrueMessage));
+            base.WriteLiteral(Template.Replace("[DETAILS]", this.traceConfiguration.DisplayErrorTraces ? this.Message : DisplayErrorTracesFalseMessage));
         }
 
         private static string LoadResource(string filename)

--- a/src/Nancy/ErrorHandling/DefaultStatusCodeHandler.cs
+++ b/src/Nancy/ErrorHandling/DefaultStatusCodeHandler.cs
@@ -15,7 +15,7 @@ namespace Nancy.ErrorHandling
     /// </summary>
     public class DefaultStatusCodeHandler : IStatusCodeHandler
     {
-        private const string DisableErrorTracesTrueMessage = "Error details are currently disabled. Please set <code>StaticConfiguration.DisableErrorTraces = false;</code> to enable.";
+        private const string DisplayErrorTracesFalseMessage = "Error details are currently disabled.<br />To enable it, please set <code>TraceConfiguration.DisplayErrorTraces</code> to true.<br />For example by overriding your Bootstrapper's <code>Configure</code> method and calling <code>environment.Tracing(enabled: false, displayErrorTraces: true);</code>.";
 
         private readonly IDictionary<HttpStatusCode, string> errorMessages;
         private readonly IDictionary<HttpStatusCode, string> errorPages;
@@ -86,7 +86,7 @@ namespace Nancy.ErrorHandling
             // from swapping a view model with a `DefaultStatusCodeHandlerResult`
             context.NegotiationContext = new NegotiationContext();
 
-            var result = new DefaultStatusCodeHandlerResult(statusCode, this.errorMessages[statusCode], !this.configuration.DisplayErrorTraces ? DisableErrorTracesTrueMessage : context.GetExceptionDetails());
+            var result = new DefaultStatusCodeHandlerResult(statusCode, this.errorMessages[statusCode], !this.configuration.DisplayErrorTraces ? DisplayErrorTracesFalseMessage : context.GetExceptionDetails());
             try
             {
                 context.Response = this.responseNegotiator.NegotiateResponse(result, context);


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified made sure that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [ ] I have provided test coverage for your change (where applicable)

### Description
I've updated the messages, because the mentioned properties do not exist in StaticConfiguration in Nancy 2.0 alpha anymore and I've also updated the property names accordingly.