### PR TITLE
Fixed extraction of filename from Content-Disposition header

### DIFF
--- a/src/Nancy/HttpMultipartBoundary.cs
+++ b/src/Nancy/HttpMultipartBoundary.cs
@@ -64,7 +64,7 @@ namespace Nancy
                 if (header.StartsWith("Content-Disposition", StringComparison.CurrentCultureIgnoreCase))
                 {
                     this.Name = Regex.Match(header, @"name=""?(?<name>[^\""]*)", RegexOptions.IgnoreCase).Groups["name"].Value;
-                    this.Filename = Regex.Match(header, @"filename=""?(?<filename>[^\""]*)", RegexOptions.IgnoreCase).Groups["filename"].Value;
+                    this.Filename = Regex.Match(header, @"filename=""?(?<filename>[^\"";]*)", RegexOptions.IgnoreCase).Groups["filename"].Value;
                 }
 
                 if (header.StartsWith("Content-Type", StringComparison.OrdinalIgnoreCase))

--- a/test/Nancy.Tests/Unit/HttpMultipartBoundaryFixture.cs
+++ b/test/Nancy.Tests/Unit/HttpMultipartBoundaryFixture.cs
@@ -189,10 +189,7 @@
 
         private static HttpMultipartSubStream BuildStreamForSingleFile(string name, string filename, string contentType, string content)
         {
-            var memory = new MemoryStream(BuildBoundaryWithSingleFile(
-                BuildContentDispositionHeader(name, filename), contentType, content));
-
-            return new HttpMultipartSubStream(memory, 0, memory.Length);
+            return BuildStreamForSingleFile(BuildContentDispositionHeader(name, filename), contentType, content);
         }
 
         private static byte[] BuildBoundaryWithSingleFile(string contentDispositionHeader, string contentType, string content)


### PR DESCRIPTION
### Prerequisites
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified made sure that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for your change (where applicable)

### Description
Fixed an issue where an unquoted "filename" param value can not be extracted correctly from the Content-Disposition header when the "filename*" param has also been provided by the client.

Details of related NuGet Client issue [here](https://github.com/NuGet/Home/issues/2661)
