### PR TITLE
Removed unused TFM parameter

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -17,10 +17,7 @@ function Restore-Packages
 
 function Test-Projects
 {
-    param([string] $framework)
     & dotnet test;
-    #& dotnet test -f $framework;
-
     if($LASTEXITCODE -ne 0)
     {
       exit 3
@@ -44,7 +41,7 @@ Get-ChildItem -Path . -Filter *.xproj -Recurse | ForEach-Object { Restore-Packag
 Write-Host "Running tests"
 Get-ChildItem -Path .\test -Filter *.xproj -Exclude Nancy.ViewEngines.Razor.Tests.Models.xproj -Recurse | ForEach-Object {
     Push-Location $_.DirectoryName
-    Test-Projects "netcoreapp1.0"
+    Test-Projects
     Pop-Location
 }
 


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [X] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [X] I have provided test coverage for my change (where applicable)

### Description
Removed a TFM parameter that had been left behind from an older version of `dotnet-test-xunit`

