### PR TITLE
Properly propagate async exceptions

### DIFF
--- a/src/Nancy/AfterPipeline.cs
+++ b/src/Nancy/AfterPipeline.cs
@@ -67,22 +67,11 @@ namespace Nancy
         /// <returns>Async pipeline item instance</returns>
         protected override PipelineItem<Func<NancyContext, CancellationToken, Task>> Wrap(PipelineItem<Action<NancyContext>> pipelineItem)
         {
-            var syncDelegate = pipelineItem.Delegate;
-            Func<NancyContext, CancellationToken, Task> asyncDelegate = (ctx, ct) =>
+            return new PipelineItem<Func<NancyContext, CancellationToken, Task>>(pipelineItem.Name, (ctx, ct) =>
             {
-                try
-                {
-                    syncDelegate.Invoke(ctx);
-                    return completeTask;
-                }
-                catch (Exception e)
-                {
-                    var tcs = new TaskCompletionSource<object>();
-                    tcs.SetException(e);
-                    return tcs.Task;
-                }
-            };
-            return new PipelineItem<Func<NancyContext, CancellationToken, Task>>(pipelineItem.Name, asyncDelegate);
+                pipelineItem.Delegate(ctx);
+                return TaskHelpers.CompletedTask;
+            });
         }
     }
 }

--- a/src/Nancy/BeforePipeline.cs
+++ b/src/Nancy/BeforePipeline.cs
@@ -70,22 +70,7 @@
         /// <returns>Async pipeline item instance</returns>
         protected override PipelineItem<Func<NancyContext, CancellationToken, Task<Response>>> Wrap(PipelineItem<Func<NancyContext, Response>> pipelineItem)
         {
-            var syncDelegate = pipelineItem.Delegate;
-            Func<NancyContext, CancellationToken, Task<Response>> asyncDelegate = (ctx, ct) =>
-            {
-                var tcs = new TaskCompletionSource<Response>();
-                try
-                {
-                    var result = syncDelegate.Invoke(ctx);
-                    tcs.SetResult(result);
-                }
-                catch (Exception e)
-                {
-                    tcs.SetException(e);
-                }
-                return tcs.Task;
-            };
-            return new PipelineItem<Func<NancyContext, CancellationToken, Task<Response>>>(pipelineItem.Name, asyncDelegate);
+            return new PipelineItem<Func<NancyContext, CancellationToken, Task<Response>>>(pipelineItem.Name, (ctx, ct) => Task.FromResult(pipelineItem.Delegate(ctx)));
         }
     }
 }

--- a/test/Nancy.Tests.Functional/Tests/AsyncExceptionTests.cs
+++ b/test/Nancy.Tests.Functional/Tests/AsyncExceptionTests.cs
@@ -4,7 +4,6 @@
     using System.Threading.Tasks;
 
     using Nancy.Testing;
-    using Nancy.Tests.xUnitExtensions;
     using Xunit;
 
     public class AsyncExceptionTests
@@ -25,17 +24,27 @@
         [Fact]
         public async Task When_get_sync_then_should_throw()
         {
-            var ex = await RecordAsync.Exception(async () => await this.browser.Get("/sync"));
+            var ex = await Assert.ThrowsAsync<Exception>(() => this.browser.Get("/sync"));
+
+            // Unwrap exception from PassThroughStatusCodeHandler
+            ex = ex.InnerException.InnerException;
 
             Assert.NotNull(ex);
+            Assert.IsType<Exception>(ex);
+            Assert.Equal("Derp", ex.Message);
         }
 
         [Fact]
         public async Task When_get_async_then_should_throw()
         {
-            var ex = await RecordAsync.Exception(async () => await this.browser.Get("/sync"));
+            var ex = await Assert.ThrowsAsync<Exception>(() => this.browser.Get("/async"));
+
+            // Unwrap exception from PassThroughStatusCodeHandler
+            ex = ex.InnerException.InnerException;
 
             Assert.NotNull(ex);
+            Assert.IsType<Exception>(ex);
+            Assert.Equal("Derp", ex.Message);
         }
     }
 
@@ -51,9 +60,8 @@
 
             Get("/async", async args =>
             {
-                return await Task.Factory
-                    .StartNew(() => { }) // Force continuation on a worker thread
-                    .ContinueWith<dynamic>(t => { throw new Exception("Derp"); });
+                throw new Exception("Derp");
+                return await Task.FromResult(200);
             });
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to Nancy! -->

Fixes #2449

Had to resort to invoking the state machine in order to properly propagate the exceptions. Also cleaned up some of the (old) pipeline code.