### PR TITLE
Use GlobalizationConfiguration.DateTimeStyles in DynamicDictionaryValue DateTime parsing

### DIFF
--- a/src/Nancy/Extensions/StringExtensions.cs
+++ b/src/Nancy/Extensions/StringExtensions.cs
@@ -62,7 +62,7 @@ namespace Nancy.Extensions
         public static DynamicDictionary AsQueryDictionary(this string queryString)
         {
             var coll = HttpUtility.ParseQueryString(queryString);
-            var ret = new DynamicDictionary();
+            var ret = new DynamicDictionary(GlobalizationConfiguration.Default);
 
             var found = 0;
             foreach (var key in coll.AllKeys.Where(key => key != null))

--- a/src/Nancy/GlobalizationConfiguration.cs
+++ b/src/Nancy/GlobalizationConfiguration.cs
@@ -13,21 +13,31 @@
         /// <summary>
         /// A default instance of the <see cref="GlobalizationConfiguration"/> class
         /// </summary>
-        public static readonly GlobalizationConfiguration Default = new GlobalizationConfiguration(supportedCultureNames: new[] { CultureInfo.CurrentCulture.Name }, defaultCulture: CultureInfo.CurrentCulture.Name);
+        public static readonly GlobalizationConfiguration Default = new GlobalizationConfiguration
+        {
+            SupportedCultureNames = new[] { CultureInfo.CurrentCulture.Name },
+            DefaultCulture = CultureInfo.CurrentCulture.Name,
+            DateTimeStyles = DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal
+        };
+
+        private GlobalizationConfiguration()
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GlobalizationConfiguration"/> class
         /// </summary>
         /// <param name="supportedCultureNames">An array of supported cultures</param>
         /// <param name="defaultCulture">The default culture of the application</param>
-        public GlobalizationConfiguration(IEnumerable<string> supportedCultureNames, string defaultCulture = null)
+        /// <param name="dateTimeStyles">The <see cref="DateTimeStyles"/> that should be used for date parsing.</param>
+        public GlobalizationConfiguration(IEnumerable<string> supportedCultureNames, string defaultCulture = null, DateTimeStyles? dateTimeStyles = null)
         {
             if (supportedCultureNames == null)
             {
                 throw new ConfigurationException("Invalid Globalization configuration. You must support at least one culture");
             }
 
-            supportedCultureNames = supportedCultureNames.Where(cultureName => !string.IsNullOrEmpty(cultureName));
+            supportedCultureNames = supportedCultureNames.Where(cultureName => !string.IsNullOrEmpty(cultureName)).ToArray();
 
             if (!supportedCultureNames.Any())
             {
@@ -44,18 +54,24 @@
                 throw new ConfigurationException("Invalid Globalization configuration. " + defaultCulture + " does not exist in the supported culture names");
             }
 
-            this.SupportedCultureNames = supportedCultureNames;
+            this.DateTimeStyles = dateTimeStyles ?? Default.DateTimeStyles;
             this.DefaultCulture = defaultCulture;
+            this.SupportedCultureNames = supportedCultureNames;
         }
 
         /// <summary>
-        /// A set of supported cultures
+        /// The <see cref="DateTimeStyles"/> that should be used for date parsing.
         /// </summary>
-        public IEnumerable<string> SupportedCultureNames { get; private set; }
+        public DateTimeStyles DateTimeStyles { get; private set; }
 
         /// <summary>
         /// The default culture for the application
         /// </summary>
         public string DefaultCulture { get; private set; }
+
+        /// <summary>
+        /// A set of supported cultures
+        /// </summary>
+        public IEnumerable<string> SupportedCultureNames { get; private set; }
     }
 }

--- a/src/Nancy/Routing/DefaultRouteResolver.cs
+++ b/src/Nancy/Routing/DefaultRouteResolver.cs
@@ -17,6 +17,7 @@
         private readonly IRouteCache routeCache;
         private readonly IRouteResolverTrie trie;
         private readonly Lazy<RouteConfiguration> configuration;
+        private readonly GlobalizationConfiguration globalizationConfiguraton;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultRouteResolver"/> class, using
@@ -35,6 +36,7 @@
             this.routeCache = routeCache;
             this.trie = trie;
             this.configuration = new Lazy<RouteConfiguration>(environment.GetValue<RouteConfiguration>);
+            this.globalizationConfiguraton = environment.GetValue<GlobalizationConfiguration>();
 
             this.BuildTrie();
         }
@@ -127,7 +129,7 @@
             context.NegotiationContext.SetModule(associatedModule);
 
             var route = associatedModule.Routes.ElementAt(result.RouteIndex);
-            var parameters = DynamicDictionary.Create(result.Parameters);
+            var parameters = DynamicDictionary.Create(result.Parameters, this.globalizationConfiguraton);
 
             return new ResolveResult
             {

--- a/test/Nancy.Tests/Unit/DynamicDictionaryFixture.cs
+++ b/test/Nancy.Tests/Unit/DynamicDictionaryFixture.cs
@@ -32,7 +32,7 @@ namespace Nancy.Tests.Unit
             };
 
             // When
-            dynamic instance = DynamicDictionary.Create(values);
+            dynamic instance = DynamicDictionary.Create(values, GlobalizationConfiguration.Default);
 
             // Then
             ((int)GetIntegerValue(instance.foo)).ShouldEqual(10);
@@ -283,8 +283,8 @@ namespace Nancy.Tests.Unit
         public void Should_implicitly_cast_to_datetime_when_value_is_string_and_is_retrieved_as_member()
         {
             // Given
-            var date = DateTime.Now;
-            this.dictionary.value = date.ToString();
+            var date = new DateTime(2016, 05, 25, 10, 0, 05, DateTimeKind.Utc);
+            this.dictionary.value = date.ToString("O");
 
             // When
             DateTime result = GetDateTimeValue(this.dictionary.value);
@@ -297,8 +297,8 @@ namespace Nancy.Tests.Unit
         public void Should_implicitly_cast_to_datetime_when_value_is_string_and_is_retrieved_as_index()
         {
             // Given
-            var date = DateTime.Now;
-            this.dictionary.value = date.ToString();
+            var date = new DateTime(2016, 05, 25, 10, 0, 05, DateTimeKind.Utc);
+            this.dictionary.value = date.ToString("O");
 
             // When
             DateTime result = GetDateTimeValue(this.dictionary["value"]);
@@ -795,7 +795,7 @@ namespace Nancy.Tests.Unit
         public void String_dictionary_values_are_Json_serialized_as_strings()
         {
             dynamic value = "42";
-            var input = new DynamicDictionaryValue(value);
+            var input = new DynamicDictionaryValue(value, GlobalizationConfiguration.Default);
 
             var sut = new JavaScriptSerializer();
             var actual = sut.Serialize(input);
@@ -807,7 +807,7 @@ namespace Nancy.Tests.Unit
         public void Integer_dictionary_values_are_Json_serialized_as_integers()
         {
             dynamic value = 42;
-            var input = new DynamicDictionaryValue(value);
+            var input = new DynamicDictionaryValue(value, GlobalizationConfiguration.Default);
 
             var sut = new JavaScriptSerializer();
             var actual = sut.Serialize(input);
@@ -1120,7 +1120,7 @@ namespace Nancy.Tests.Unit
             input.Remove("a-b-c");
 
             //then
-            input.ContainsKey("abc").ShouldBeFalse();           
+            input.ContainsKey("abc").ShouldBeFalse();
         }
 
         [Fact]

--- a/test/Nancy.Tests/Unit/DynamicDictionaryValueFixture.cs
+++ b/test/Nancy.Tests/Unit/DynamicDictionaryValueFixture.cs
@@ -3,11 +3,8 @@
     using System;
     using System.Dynamic;
     using System.Globalization;
-
     using FakeItEasy;
-
     using Xunit;
-    using Xunit.Extensions;
 
     public class DynamicDictionaryValueFixture
     {
@@ -984,6 +981,38 @@
 
             //Then
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Should_adjust_to_universal_time_when_globalizationconfiguration_datetimestyles_requires_it()
+        {
+            // Given
+            var expected = new DateTime(2016, 05, 24, 08, 41, 37, DateTimeKind.Utc);
+
+            var config = new GlobalizationConfiguration(new [] {"en-US"}, dateTimeStyles: DateTimeStyles.AdjustToUniversal);
+            var value = new DynamicDictionaryValue("2016-05-24T10:41:37+02:00", config);
+
+            // When
+            DateTime actual = value;
+
+            // Then
+            actual.ShouldEqual(expected);
+        }
+
+        [Fact]
+        public void Should_assume_local_time_when_globalizationconfiguration_datetimestyles_requires_it()
+        {
+            // Given
+            var expected = DateTime.Now;
+
+            var config = new GlobalizationConfiguration(new[] { "en-US" }, dateTimeStyles: DateTimeStyles.AssumeLocal);
+            var value = new DynamicDictionaryValue(expected.ToString("O"), config);
+
+            // When
+            DateTime actual = value;
+
+            // Then
+            actual.ShouldEqual(expected);
         }
 
         [Fact]


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [X] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [X] I have provided test coverage for my change (where applicable)

### Description
This will make `DynamicDictionaryValue` use the `GlobalizationConfiguration.DateTimeStyles` when parsing dates, represented as strings, to `DateTime`. This will let you control how you want dates to be handled in your application. 

Once pull in, we should update #2438 to use the new settings as well