### PR TITLE
Made kestrel demo homemodule to use non async routing

### DIFF
--- a/samples/Nancy.Demo.Hosting.Kestrel/HomeModule.cs
+++ b/samples/Nancy.Demo.Hosting.Kestrel/HomeModule.cs
@@ -7,20 +7,20 @@
     {
         public HomeModule()
         {
-            Get("/", (args, ct) => Task.FromResult("Hello from Nancy running on CoreCLR"));
+            Get("/", args => "Hello from Nancy running on CoreCLR");
 
-            Get("/conneg/{name}", (args, token) => Task.FromResult(new Person() { Name = args.name }));
+            Get("/conneg/{name}", args => new Person() { Name = args.name });
 
-            Post("/", (parameters, token) =>
+            Post("/", args =>
             {
                 var person = this.BindAndValidate<Person>();
 
                 if (!this.ModelValidationResult.IsValid)
                 {
-                    return Task.FromResult<dynamic>(422);
+                    return 422;
                 }
 
-                return Task.FromResult<dynamic>(person);
+                return person;
             });
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [ ] I have provided test coverage for my change (where applicable)

### Description
This makes the Kestrel demo to use the new routing syntax
