### PR TITLE
Check that the body deserializer stream is Seekable before doing so

### DIFF
--- a/src/Nancy/ModelBinding/DefaultBodyDeserializers/JsonBodyDeserializer.cs
+++ b/src/Nancy/ModelBinding/DefaultBodyDeserializers/JsonBodyDeserializer.cs
@@ -48,7 +48,11 @@ namespace Nancy.ModelBinding.DefaultBodyDeserializers
 
             serializer.RegisterConverters(this.configuration.Converters, this.configuration.PrimitiveConverters);
 
-            bodyStream.Position = 0;
+            if (bodyStream.CanSeek)
+            {
+                bodyStream.Position = 0;
+            }
+
             string bodyText;
             using (var bodyReader = new StreamReader(bodyStream))
             {

--- a/src/Nancy/ModelBinding/DefaultBodyDeserializers/XmlBodyDeserializer.cs
+++ b/src/Nancy/ModelBinding/DefaultBodyDeserializers/XmlBodyDeserializer.cs
@@ -40,7 +40,11 @@ namespace Nancy.ModelBinding.DefaultBodyDeserializers
         /// <returns>Model instance</returns>
         public object Deserialize(MediaRange mediaRange, Stream bodyStream, BindingContext context)
         {
-            bodyStream.Position = 0;
+            if (bodyStream.CanSeek)
+            {
+                bodyStream.Position = 0;
+            }
+
             var ser = new XmlSerializer(context.DestinationType);
             return ser.Deserialize(bodyStream);
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Code unification with other serializers, see https://github.com/NancyFx/Nancy.Serialization.JsonNet/pull/38 for more details.

(No tests on this specific detail for now, and I don't know if this repo had tests on the position reset behavior, can add them if needed)
<!-- Thanks for contributing to Nancy! -->

