### PR TITLE
Force dotnet install in build scripts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
 - set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
 
 build_script:
-- ps: .\build.ps1 --verbosity diagnostic
+- ps: .\build.ps1 -verbosity diagnostic
 
 artifacts:
 - path: artifacts\packages\**\*.nupkg

--- a/build.ps1
+++ b/build.ps1
@@ -15,20 +15,6 @@ Param(
 
 Function Install-Dotnet()
 {
-  $existingPaths = $Env:Path -Split ';' | Where-Object { (![string]::IsNullOrEmpty($_)) -and (Test-Path $_) }
-  $DOTNET_EXE_IN_PATH = (Get-ChildItem -Path $existingPaths -Filter "dotnet.exe" | Select -First 1).FullName
-  $GlobalDotNetFound =  (![string]::IsNullOrEmpty($DOTNET_EXE_IN_PATH)) -and (Test-Path $DOTNET_EXE_IN_PATH)
-  $LocalDotNetFound = Test-Path (Join-Path $PSScriptRoot ".dotnet")
-
-  if ($GlobalDotNetFound)
-  {
-    return
-  }
-
-  if((!$LocalDotNetFound) -Or ((Test-Path Env:\APPVEYOR) -eq $true))
-  {
-    Write-Output "Dotnet CLI was not found."
-
     # Prepare the dotnet CLI folder
     $env:DOTNET_INSTALL_DIR="$(Convert-Path "$PSScriptRoot")\.dotnet\win7-x64"
     if (!(Test-Path $env:DOTNET_INSTALL_DIR))
@@ -40,7 +26,7 @@ Function Install-Dotnet()
     if (!(Test-Path .\dotnet\install.ps1))
     {
       Write-Output "Downloading version 1.0.0-preview2 of Dotnet CLI installer..."
-      Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview2/scripts/obtain/dotnet-install.ps1" -OutFile ".\.dotnet\dotnet-install.ps1"
+      Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview1/scripts/obtain/dotnet-install.ps1" -OutFile ".\.dotnet\dotnet-install.ps1"
     }
 
     # Run the dotnet CLI install
@@ -51,7 +37,6 @@ Function Install-Dotnet()
     # by Install-DotNetCli if it's already installed.
     Remove-PathVariable $env:DOTNET_INSTALL_DIR
     $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
-  }
 }
 
 Function Remove-PathVariable([string]$VariableToRemove)

--- a/build.sh
+++ b/build.sh
@@ -27,11 +27,9 @@ for i in "$@"; do
 done
 
 function installdotnet() {
-  if ! [ -x "$(command -v dotnet)" ] ; then
-      echo "Installing dotnet"
-      curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview1/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version 1.0.0-preview1-002702 --install-dir .dotnet
-      export PATH=.dotnet:$PATH
-  fi
+  echo "Installing dotnet"
+  curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0-preview1/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version 1.0.0-preview1-002702 --install-dir .dotnet
+  export PATH=.dotnet:$PATH
 }
 
 function installcake() {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to Nancy! -->

Force dotnet install even if installed globally as may be diff version that is installed so therefore we need to use the one the Nancy team requires