### PR TITLE
Added a using statement that is used when in test projects on netcoreapp

### DIFF
--- a/test/Nancy.Tests/ShouldExtensions.cs
+++ b/test/Nancy.Tests/ShouldExtensions.cs
@@ -5,7 +5,7 @@
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
-
+    using System.Reflection;
     using Xunit;
 
     public static class ShouldAssertExtensions


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description

Added a using statement that is used when test projects on netcoreapp1.0 include ShouldExtensions in compilation