### PR TITLE
Replace dependency on RequestStream in Request.Body with Stream

### DIFF
--- a/src/Nancy/Request.cs
+++ b/src/Nancy/Request.cs
@@ -47,7 +47,7 @@ namespace Nancy
         /// <param name="protocolVersion">The HTTP protocol version.</param>
         public Request(string method,
             Url url,
-            RequestStream body = null,
+            Stream body = null,
             IDictionary<string, IEnumerable<string>> headers = null,
             string ip = null,
             X509Certificate certificate = null,
@@ -148,10 +148,10 @@ namespace Nancy
         public dynamic Query { get; set; }
 
         /// <summary>
-        /// Gets a <see cref="RequestStream"/> that can be used to read the incoming HTTP body
+        /// Gets a <see cref="Stream"/> that can be used to read the incoming HTTP body
         /// </summary>
-        /// <value>A <see cref="RequestStream"/> object representing the incoming HTTP body.</value>
-        public RequestStream Body { get; private set; }
+        /// <value>A <see cref="Stream"/> object representing the incoming HTTP body.</value>
+        public Stream Body { get; private set; }
 
         /// <summary>
         /// Gets the request cookies.

--- a/test/Nancy.Tests.Functional/Modules/SerializerTestModule.cs
+++ b/test/Nancy.Tests.Functional/Modules/SerializerTestModule.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Globalization;
     using Nancy.Extensions;
+    using Nancy.IO;
     using Nancy.ModelBinding;
 
     public class SerializerTestModule : NancyModule
@@ -25,7 +26,7 @@
 
             Post("/serializer/date", args =>
             {
-                var s = this.Request.Body.AsString();
+                var s = ((RequestStream)this.Request.Body).AsString();
                 var model = this.Bind<FakeSerializerModel>();
                 return model;
             });


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open -  overlaps with #1920
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
Use case:
We're uploading large blob files via a Nancy API
The default `RequestStream` implementation spools out to disk where the size of the incoming request is >85kb to avoid pressure on the Large Object Heap
When requests are aborted, or generally when errors occur, these temp files can leak and cause %TEMPDIR% to run out of space. (I have submitted a few PRs around this in the past but it seems we can't avoid this behaviour, we can't clean up the file in the `RequestStream` destructor as in the finalizer we have lost the reference to the `File`)
Since `RequestStream` is a drop-in-replacement for `Stream`, it seems logical to use the base class as the `Body` property on `Request`, this will allow me to swap in a different `Stream` implementation such as https://github.com/Microsoft/Microsoft.IO.RecyclableMemoryStream
This also includes tracing so I can troubleshoot where Nancy may be leaking the `Request.Body` stream.
I can't inherit from/override `RequestStream` since it has no paramaterless ctor, and this would be a cleaner approach anyhow.

Warning: possible conflicts with #1920