### PR TITLE
Fixed unit tests that assume the local timezone has a negative offset

### DIFF
--- a/test/Nancy.Tests/Unit/Json/Simple/NancySerializationStrategyFixture.cs
+++ b/test/Nancy.Tests/Unit/Json/Simple/NancySerializationStrategyFixture.cs
@@ -92,7 +92,8 @@ namespace Nancy.Tests.Unit.Json.Simple
 
             //Then
             canSerialize.ShouldBeTrue();
-            serializedObject.ShouldEqual(string.Format("2014-03-09T17:03:25.2340000+{0}", offset.Hours.ToString("00") + ":" + offset.Minutes.ToString("00")));
+            serializedObject.ShouldEqual(string.Format("2014-03-09T17:03:25.2340000{0}:{1}", 
+                offset.Hours.ToString("+00;-00"), offset.Minutes.ToString("00")));
         }
 
         [Fact]
@@ -109,7 +110,8 @@ namespace Nancy.Tests.Unit.Json.Simple
 
             //Then
             canSerialize.ShouldBeTrue();
-            serializedObject.ShouldEqual(string.Format("2014-03-09T17:03:25.2340000+{0}", offset.Hours.ToString("00") + ":" + offset.Minutes.ToString("00")));
+            serializedObject.ShouldEqual(string.Format("2014-03-09T17:03:25.2340000{0}:{1}",
+                offset.Hours.ToString("+00;-00"), offset.Minutes.ToString("00")));
         }
 
         [Fact]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
I've fixed a couple of unit tests related to serialization of timespans that fail when the local timezone's offset is negative. The tests were failing because they had hardcoded a plus sign into the expected output. The actual serialization is fine - this is a change to tests only. 
<!-- Thanks for contributing to Nancy! -->

