### PR TITLE
Fix for Issue #1096 (Model binding errors for invalid dates)

### DIFF
--- a/src/Nancy/ModelBinding/DefaultConverters/FallbackConverter.cs
+++ b/src/Nancy/ModelBinding/DefaultConverters/FallbackConverter.cs
@@ -46,7 +46,7 @@ namespace Nancy.ModelBinding.DefaultConverters
                 {
                     return true;
                 }
-                return null;
+                throw;
             }
         }
     }

--- a/test/Nancy.Tests/Unit/ModelBinding/DefaultBinderFixture.cs
+++ b/test/Nancy.Tests/Unit/ModelBinding/DefaultBinderFixture.cs
@@ -295,25 +295,6 @@ namespace Nancy.Tests.Unit.ModelBinding
         }
 
         [Fact]
-        public void Should_ignore_properties_that_cannot_be_converted()
-        {
-            // Given
-            var binder = this.GetBinder(typeConverters: new[] { new FallbackConverter() });
-            var context = new NancyContext { Request = new FakeRequest("GET", "/") };
-            context.Request.Form["StringProperty"] = "Test";
-            context.Request.Form["IntProperty"] = "12";
-            context.Request.Form["DateProperty"] = "Broken";
-
-            // When
-            var result = (TestModel)binder.Bind(context, typeof(TestModel), null, BindingConfig.Default);
-
-            // Then
-            result.StringProperty.ShouldEqual("Test");
-            result.IntProperty.ShouldEqual(12);
-            result.DateProperty.ShouldEqual(default(DateTime));
-        }
-
-        [Fact]
         public void Should_throw_ModelBindingException_if_convertion_of_a_property_fails()
         {
             // Given
@@ -321,6 +302,7 @@ namespace Nancy.Tests.Unit.ModelBinding
             var context = new NancyContext { Request = new FakeRequest("GET", "/") };
             context.Request.Form["IntProperty"] = "badint";
             context.Request.Form["AnotherIntProperty"] = "morebad";
+            context.Request.Form["DateProperty"] = "bad dates"; // Indiana Jones' monkey is dead :)
 
             // Then
             Type modelType = typeof(TestModel);
@@ -333,6 +315,9 @@ namespace Nancy.Tests.Unit.ModelBinding
                              && exception.PropertyBindingExceptions.Any(pe =>
                                                                         pe.PropertyName == "AnotherIntProperty"
                                                                         && pe.AttemptedValue == "morebad")
+                             && exception.PropertyBindingExceptions.Any(pe =>
+                                                                        pe.PropertyName == "DateProperty"
+                                                                        && pe.AttemptedValue == "bad dates")
                              && exception.PropertyBindingExceptions.All(pe =>
                                                                         pe.InnerException.Message.Contains(pe.AttemptedValue)
                                                                         && pe.InnerException.Message.Contains(modelType.GetProperty(pe.PropertyName).PropertyType.Name)));


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
This is a possible fix for Issue #1096, which is about throwing ModelBindingException for strings that cannot be parsed as dates. That wasn't happening because the FallbackConverter was eating the FormatException thrown by the DateTimeConverter and returning null. My fix is to just rethrow the exception. That might have a broader impact for other types that use the FallbackConverter, but it didn't break any tests, with the exception of Should_ignore_properties_that_cannot_be_converted. I think Should_ignore_properties_that_cannot_be_converted is now invalid because it is asserting that an invalid DateTime should be ignored. Changing that behavior was the whole point.

<!-- Thanks for contributing to Nancy! -->

