### PR TITLE
Remove Wait call to prevent deadlock

### DIFF
--- a/src/Nancy/IO/RequestStream.cs
+++ b/src/Nancy/IO/RequestStream.cs
@@ -2,9 +2,6 @@
 {
     using System;
     using System.IO;
-    using System.Threading.Tasks;
-
-    using Nancy.Extensions;
 
     /// <summary>
     /// A <see cref="Stream"/> decorator that can handle moving the stream out from memory and on to disk when the contents reaches a certain length.
@@ -74,15 +71,7 @@
 
             if (!this.stream.CanSeek)
             {
-                var task =
-                    MoveToWritableStream();
-
-                task.Wait();
-
-                if (task.IsFaulted)
-                {
-                    throw new InvalidOperationException("Unable to copy stream", task.Exception);
-                }
+                this.MoveToWritableStream();
             }
 
             this.stream.Position = 0;
@@ -93,12 +82,13 @@
             this.Dispose(false);
         }
 
-        private Task MoveToWritableStream()
+        private void MoveToWritableStream()
         {
             var sourceStream = this.stream;
+
             this.stream = new MemoryStream(BufferSize);
 
-            return sourceStream.CopyToAsync(this);
+            sourceStream.CopyTo(this.stream);
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description

The call to `Task.Wait()` causes a deadlock on many concurrent requests. This changes the method to do a synchronous copy instead.

Fixes #2533

<!-- Thanks for contributing to Nancy! -->

