### PR TITLE
Correctly accept all json and xml subtypes

### DIFF
--- a/src/Nancy/Responses/Negotiation/JsonProcessor.cs
+++ b/src/Nancy/Responses/Negotiation/JsonProcessor.cs
@@ -107,8 +107,7 @@
 
             var subtypeString = requestedContentType.Subtype.ToString();
 
-            return (subtypeString.StartsWith("vnd", StringComparison.OrdinalIgnoreCase) &&
-                    subtypeString.EndsWith("+json", StringComparison.OrdinalIgnoreCase));
+            return subtypeString.EndsWith("+json", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Nancy/Responses/Negotiation/XmlProcessor.cs
+++ b/src/Nancy/Responses/Negotiation/XmlProcessor.cs
@@ -119,8 +119,7 @@
 
             var subtypeString = requestedContentType.Subtype.ToString();
 
-            return (subtypeString.StartsWith("vnd", StringComparison.OrdinalIgnoreCase) &&
-                    subtypeString.EndsWith("+xml", StringComparison.OrdinalIgnoreCase));
+            return subtypeString.EndsWith("+xml", StringComparison.OrdinalIgnoreCase);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)


### Description
Currently Nancy accepts all **vendor-specific** json and xml media subtypes. As per [RFC 6839 (json)](https://tools.ietf.org/html/rfc6839#page-4) and [RFC 3023 (xml)](https://tools.ietf.org/html/rfc3023#page-32) all +json and +xml subtypes should be regarded as such. Otherwise many [IANA registered media types](http://www.iana.org/assignments/media-types/media-types.xhtml) will not be handled correctly.