### PR TITLE
Fix for issue-2546: Allow chunked transfer-encoding for ASP.Net hosted requests

### DIFF
--- a/src/Nancy.Hosting.Aspnet/NancyHandler.cs
+++ b/src/Nancy.Hosting.Aspnet/NancyHandler.cs
@@ -98,7 +98,7 @@ namespace Nancy.Hosting.Aspnet
 
             RequestStream body = null;
 
-            if (expectedRequestLength != 0)
+            if (expectedRequestLength != 0 || HasChunkedEncoding(incomingHeaders))
             {
                 body = RequestStream.FromStream(context.Request.InputStream, expectedRequestLength, StaticConfiguration.DisableRequestStreamSwitching ?? true);
             }
@@ -112,6 +112,17 @@ namespace Nancy.Hosting.Aspnet
                 context.Request.UserHostAddress, 
                 certificate,
                 protocolVersion);
+        }
+
+        private static bool HasChunkedEncoding(IDictionary<string, IEnumerable<string>> incomingHeaders)
+        {
+            IEnumerable<string> transferEncodingValue;
+            if (incomingHeaders == null || !incomingHeaders.TryGetValue("Transfer-Encoding", out transferEncodingValue))
+            {
+                return false;
+            }
+            var transferEncodingString = transferEncodingValue.SingleOrDefault() ?? string.Empty;
+            return transferEncodingString.Equals("chunked", StringComparison.OrdinalIgnoreCase);
         }
 
         private static long GetExpectedRequestLength(IDictionary<string, IEnumerable<string>> incomingHeaders)


### PR DESCRIPTION
### Prerequisites
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)
### Description

This allows incoming requests with a header of Transfer-Encoding = chunked to properly set the Request Body
