### PR TITLE
Add missing await and add ConfigureAwait(false) calls

### DIFF
--- a/src/Nancy.Hosting.Self/NancyHost.cs
+++ b/src/Nancy.Hosting.Self/NancyHost.cs
@@ -131,7 +131,7 @@
                     while(!this.stop)
                     {
                         HttpListenerContext context = await this.listener.GetContextAsync().ConfigureAwait(false);
-                        Process(context);
+                        await this.Process(context).ConfigureAwait(false);
                     }
                 }
                 catch(Exception ex)

--- a/src/Nancy.Hosting.Self/NancyHost.cs
+++ b/src/Nancy.Hosting.Self/NancyHost.cs
@@ -130,7 +130,7 @@
                 {
                     while(!this.stop)
                     {
-                        HttpListenerContext context = await listener.GetContextAsync();
+                        HttpListenerContext context = await this.listener.GetContextAsync().ConfigureAwait(false);
                         Process(context);
                     }
                 }
@@ -159,7 +159,7 @@
                 throw new InvalidOperationException("Unable to configure namespace reservation");
             }
 
-            if (!TryStartListener())
+            if (!this.TryStartListener())
             {
                 throw new InvalidOperationException("Unable to start listener");
             }
@@ -209,8 +209,8 @@
 
         private string GetUser()
         {
-            return !string.IsNullOrWhiteSpace(this.configuration.UrlReservations.User) 
-                ? this.configuration.UrlReservations.User 
+            return !string.IsNullOrWhiteSpace(this.configuration.UrlReservations.User)
+                ? this.configuration.UrlReservations.User
                 : WindowsIdentity.GetCurrent().Name;
         }
 
@@ -336,7 +336,7 @@
 
             response.StatusCode = (int)nancyResponse.StatusCode;
 
-            if (configuration.AllowChunkedEncoding)
+            if (this.configuration.AllowChunkedEncoding)
             {
                 OutputWithDefaultTransferEncoding(nancyResponse, response);
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [ ] I have provided test coverage for my change (where applicable)

### Description

This is a fix for #2471 along with some missing `this.`'s.

I wasn't sure if the call to `Process()`  on line 134 was supposed to be awaited or not. Trying out the self host demo worked but that was as far as I went (I'm not familiar with the self host project).