### PR TITLE
Remove redundand argument null check from HttpUtility.UrlDecode method

### DIFF
--- a/src/Nancy/Helpers/HttpUtility.cs
+++ b/src/Nancy/Helpers/HttpUtility.cs
@@ -253,10 +253,7 @@ namespace Nancy.Helpers
             if (bytes == null)
                 return null;
             if (count == 0)
-                return String.Empty;
-
-            if (bytes == null)
-                throw new ArgumentNullException("bytes");
+                return string.Empty;
 
             if (offset < 0 || offset > bytes.Length)
                 throw new ArgumentOutOfRangeException("offset");
@@ -264,8 +261,8 @@ namespace Nancy.Helpers
             if (count < 0 || offset + count > bytes.Length)
                 throw new ArgumentOutOfRangeException("count");
 
-            StringBuilder output = new StringBuilder();
-            MemoryStream acc = new MemoryStream();
+            var output = new StringBuilder();
+            var acc = new MemoryStream();
 
             int end = count + offset;
             int xchar;

--- a/test/Nancy.Tests/Unit/Helpers/HttpUtilityFixture.cs
+++ b/test/Nancy.Tests/Unit/Helpers/HttpUtilityFixture.cs
@@ -1,5 +1,6 @@
 ﻿namespace Nancy.Tests.Unit.Helpers
 {
+    using System.Text;
     using Nancy.Helpers;
 
     using Xunit;
@@ -27,7 +28,7 @@
         {
             // Given
             StaticConfiguration.CaseSensitive = true;
-			var query = "key=value";
+            var query = "key=value";
 
             // When
             var collection = HttpUtility.ParseQueryString(query);
@@ -146,6 +147,28 @@
             {
                 var collection = HttpUtility.ParseQueryString(query);
                 collection.ShouldNotBeNull();
+            }).ShouldBeNull();
+        }
+
+        [Fact]
+        public void UrlDecode_returns_null_when_input_is_null()
+        {
+            byte[] input = null;
+            Record.Exception(() =>
+            {
+                var result = HttpUtility.UrlDecode(input, 0, 10, Encoding.UTF8);
+                result.ShouldBeNull();
+            }).ShouldBeNull();
+        }
+
+        [Fact]
+        public void UrlDecode_returns_null_when_input_string_is_null()
+        {
+            string input = null;
+            Record.Exception(() =>
+            {
+                var result = HttpUtility.UrlDecode(input, Encoding.UTF8);
+                result.ShouldBeNull();
             }).ShouldBeNull();
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description

I was peeking at the source code and found a duplicated null check in the `HttpUtility.UrlDecode()` [method](https://github.com/NancyFx/Nancy/blob/0d7aee7d694e2e1cdb6e67fd585281edc3b089da/src/Nancy/Helpers/HttpUtility.cs#L253-L259).

```csharp
if(bytes == null)
   return null
//...
if (bytes == null)		
   throw new ArgumentNullException("bytes");
```

The second check doesn't make any sense. 

In this PR I removed the second check, added unit test and did a little bit of cleanup in files that I've touched (replaced tabs with spaces in one line, replased `String` to `string` and so on)
