### PR TITLE
Fix for deserializing JSON number to ulong and ushort values

### DIFF
--- a/src/Nancy/Json/Simple/SimpleJson.cs
+++ b/src/Nancy/Json/Simple/SimpleJson.cs
@@ -1387,7 +1387,7 @@ namespace Nancy.Json.Simple
                 return value;
             if ((valueIsDouble && type != typeof(double)) || (valueIsLong && type != typeof(long)))
             {
-                obj = type == typeof(int) || type == typeof(uint) || type == typeof(long) || type == typeof(double) || type == typeof(float) || type == typeof(bool) || type == typeof(decimal) || type == typeof(byte) || type == typeof(short)
+                obj = type == typeof(int) || type == typeof(uint) || type == typeof(long) || type == typeof(ulong) || type == typeof(double) || type == typeof(float) || type == typeof(bool) || type == typeof(decimal) || type == typeof(byte) || type == typeof(short) || type == (typeof(ushort))
                     ? Convert.ChangeType(value, type, CultureInfo.InvariantCulture)
                     : value;
             }

--- a/test/Nancy.Tests/Unit/Json/SimpleJsonFixture.cs
+++ b/test/Nancy.Tests/Unit/Json/SimpleJsonFixture.cs
@@ -47,6 +47,28 @@
             result.ShouldEqual("{\"enumModel\":\"Freddy\"}");
         }
 
+        [Fact]
+        public void Should_deserialize_json_number_to_ulong()
+        {
+            // Given
+            var json = "42";
+            // When
+            var result = SimpleJson.DeserializeObject(json, typeof(ulong), DateTimeStyles.None);
+            // Then
+            result.ShouldEqual(42ul);
+        }
+
+        [Fact]
+        public void Should_deserialize_json_number_to_ushort()
+        {
+            // Given
+            var json = "42";
+            // When
+            var result = SimpleJson.DeserializeObject(json, typeof(ushort), DateTimeStyles.None);
+            // Then
+            result.ShouldEqual((ushort)42);
+        }
+
         public class ModelTest
         {
             public TestEnum EnumModel { get; set; }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description

I found an issue with binding to a model that has a ulong property on it which showed up as a cast exception. Tracing through I found a simple case of a missing cast from the default long value that a number is parsed to to the requested ulong type. While in there I noticed that the same was true for ushort values.

This PR includes a couple of short unit tests for the deserialization of JSON numbers to ulong and ushort values as well as the fix.


