### PR TITLE
Added guard around loading assemblies for inspection

### DIFF
--- a/src/Nancy/AppDomainAssemblyCatalog.cs
+++ b/src/Nancy/AppDomainAssemblyCatalog.cs
@@ -68,11 +68,11 @@ namespace Nancy
 
                     if (!loadedNancyReferencingAssemblyNames.Any(loadedNancyReferencingAssemblyName => AssemblyName.ReferenceMatchesDefinition(loadedNancyReferencingAssemblyName, unloadedAssemblyName)))
                     {
-                        var inspectionAssembly = inspectionAppDomain.Load(unloadedAssemblyName);
+                        var inspectionAssembly = SafeLoadAssembly(inspectionAppDomain, unloadedAssemblyName);
 
-                        if (IsNancyReferencing(inspectionAssembly))
+                        if (inspectionAssembly != null && IsNancyReferencing(inspectionAssembly))
                         {
-                            var assembly = SafeLoadAssembly(unloadedAssemblyName);
+                            var assembly = SafeLoadAssembly(AppDomain.CurrentDomain, unloadedAssemblyName);
 
                             if (assembly != null)
                             {
@@ -135,11 +135,11 @@ namespace Nancy
             }
         }
 
-        private static Assembly SafeLoadAssembly(AssemblyName assemblyName)
+        private static Assembly SafeLoadAssembly(AppDomain domain, AssemblyName assemblyName)
         {
             try
             {
-                return AppDomain.CurrentDomain.Load(assemblyName);
+                return domain.Load(assemblyName);
             }
             catch
             {


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [X] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [X] I have provided test coverage for my change (where applicable)

### Description
Fix for #2553 

Could not use `Assembly.ReflectionOnlyLoad(...)` is it loads it into the current `AppDomain`
