### PR TITLE
Bumped AngleSharp version for .Net Standard

### DIFF
--- a/src/Nancy.Testing.MSBuild/packages.config
+++ b/src/Nancy.Testing.MSBuild/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AngleSharp" version="0.9.5" targetFramework="net45" />
+  <package id="AngleSharp" version="0.9.8.1" targetFramework="net45" />
 </packages>

--- a/src/Nancy.Testing/project.json
+++ b/src/Nancy.Testing/project.json
@@ -11,7 +11,7 @@
     },
 
     "dependencies": {
-        "AngleSharp": "0.9.5",
+        "AngleSharp": "0.9.8.1",
         "Nancy": { "target": "project" },
         "Nancy.Authentication.Forms": { "target": "project" }
     },

--- a/test/Nancy.Testing.Tests.MSBuild/packages.config
+++ b/test/Nancy.Testing.Tests.MSBuild/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AngleSharp" version="0.9.5" targetFramework="net45" />
+  <package id="AngleSharp" version="0.9.8.1" targetFramework="net45" />
   <package id="FakeItEasy" version="2.0.0" targetFramework="net45" />
   <package id="FakeItEasy.Analyzer" version="2.1.0" targetFramework="net45" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />

--- a/test/Nancy.Testing.Tests/project.json
+++ b/test/Nancy.Testing.Tests/project.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
-        "AngleSharp": "0.9.5",
+        "AngleSharp": "0.9.8.1",
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
         "FakeItEasy.Analyzer": "2.1.0",
         "Microsoft.NETCore.Platforms": "1.0.1",


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [ ] I have provided test coverage for my change (where applicable)

### Description
Bumped AngleSharp version from [0.9.5](https://www.nuget.org/packages/AngleSharp/0.9.5) to [0.9.8.1](https://www.nuget.org/packages/AngleSharp/0.9.8.1) for .NET Standard support. 

<!-- Thanks for contributing to Nancy! -->

