### PR TITLE
WIP - First stab at creating a BodyDelegate type

### DIFF
--- a/src/Nancy.MSBuild/BodyDelegate.cs
+++ b/src/Nancy.MSBuild/BodyDelegate.cs
@@ -1,0 +1,31 @@
+namespace Nancy
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+
+    public class BodyDelegate
+    {
+        public Func<Stream, Task> Body { get; set; }
+
+        public static implicit operator BodyDelegate(Func<Stream, Task> body)
+        {
+            return new BodyDelegate { Body = body };
+        }
+
+        public static implicit operator BodyDelegate(Action<Stream> body)
+        {
+            return new BodyDelegate { Body = Wrap(body) };
+        }
+
+        private static Func<Stream, Task> Wrap(Action<Stream> body)
+        {
+            return s =>
+            {
+                body.Invoke(s);
+
+                return Task.FromResult(new object());
+            };
+        }
+    }
+}

--- a/src/Nancy.MSBuild/Nancy.csproj
+++ b/src/Nancy.MSBuild/Nancy.csproj
@@ -1376,6 +1376,7 @@
     <Compile Include="..\Nancy\Routing\Route.cs">
       <Link>Routing\Route.cs</Link>
     </Compile>
+    <Compile Include="BodyDelegate.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\Nancy\Diagnostics\Views\Dashboard.sshtml">

--- a/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
+++ b/src/Nancy/Bootstrapper/NancyBootstrapperBase.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using System.IO;
     using System.Linq;
 
     using Nancy.Configuration;
@@ -313,7 +314,7 @@
                                 {
                                     ContentType = "image/vnd.microsoft.icon",
                                     StatusCode = HttpStatusCode.OK,
-                                    Contents = s => s.Write(this.FavIcon, 0, this.FavIcon.Length)
+                                    Contents = (Action<Stream>)(s => s.Write(this.FavIcon, 0, this.FavIcon.Length))
                                 };
 
                             response.Headers["Cache-Control"] = "public, max-age=604800, must-revalidate";

--- a/src/Nancy/Diagnostics/DiagnosticsViewRenderer.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsViewRenderer.cs
@@ -73,7 +73,7 @@ namespace Nancy.Diagnostics
 
             var stream = new MemoryStream();
 
-            view.Contents.Invoke(stream);
+            view.Contents.Body.Invoke(stream).Wait();
             stream.Position = 0;
             return stream;
         }

--- a/src/Nancy/ErrorHandling/DefaultStatusCodeHandler.cs
+++ b/src/Nancy/ErrorHandling/DefaultStatusCodeHandler.cs
@@ -1,5 +1,6 @@
 namespace Nancy.ErrorHandling
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
@@ -127,13 +128,13 @@ namespace Nancy.ErrorHandling
             }
 
             context.Response.ContentType = "text/html";
-            context.Response.Contents = s =>
+            context.Response.Contents = (Action<Stream>)(s =>
             {
                 using (var writer = new StreamWriter(new UnclosableStreamWrapper(s), Encoding.UTF8))
                 {
                     writer.Write(contents);
                 }
-            };
+            });
         }
 
         private static string LoadResource(string filename)

--- a/src/Nancy/HeadResponse.cs
+++ b/src/Nancy/HeadResponse.cs
@@ -23,11 +23,11 @@
         public HeadResponse(Response response)
         {
             this.innerResponse = response;
-            this.Contents = stream =>
+            this.Contents = (Func<Stream, Task>)(async stream =>
             {
-                this.CheckAndSetContentLength(this.innerResponse);
+                await this.CheckAndSetContentLength(this.innerResponse);
                 GetStringContents(string.Empty)(stream);
-            };
+            });
             this.ContentType = response.ContentType;
             this.Headers = response.Headers;
             this.StatusCode = response.StatusCode;
@@ -48,7 +48,7 @@
             return this.innerResponse.PreExecute(context);
         }
 
-        private void CheckAndSetContentLength(Response response)
+        private async Task CheckAndSetContentLength(Response response)
         {
             if (this.Headers.ContainsKey(ContentLength))
             {
@@ -57,7 +57,7 @@
 
             using (var nullStream = new NullStream())
             {
-                response.Contents.Invoke(nullStream);
+                await response.Contents.Body.Invoke(nullStream);
 
                 this.Headers[ContentLength] = nullStream.Length.ToString(CultureInfo.InvariantCulture);
             }

--- a/src/Nancy/Jsonp.cs
+++ b/src/Nancy/Jsonp.cs
@@ -4,6 +4,7 @@
     using System.IO;
     using System.Linq;
     using System.Text;
+    using System.Threading.Tasks;
     using Nancy.Bootstrapper;
     using Nancy.Configuration;
     using Nancy.Json;
@@ -73,7 +74,7 @@
             // http://stackoverflow.com/questions/111302/best-content-type-to-serve-jsonp
             context.Response.ContentType = string.Concat("application/javascript", Encoding);
 
-            context.Response.Contents = stream =>
+            context.Response.Contents = (Func<Stream, Task>)(async stream =>
             {
                 // disposing of stream is handled elsewhere
                 var writer = new StreamWriter(stream)
@@ -82,9 +83,9 @@
                 };
 
                 writer.Write("{0}(", callback);
-                original(stream);
+                await original.Body.Invoke(stream);
                 writer.Write(");");
-            };
+            });
         }
     }
 }

--- a/src/Nancy/Owin/NancyMiddleware.cs
+++ b/src/Nancy/Owin/NancyMiddleware.cs
@@ -152,16 +152,15 @@
                         .ToArray();
                 }
 
-                nancyResponse.Contents(owinResponseBody);
+                using (context)
+                {
+                    return nancyResponse.Contents.Body.Invoke(owinResponseBody);
+                }
             }
             else
             {
                 return next(environment);
             }
-
-            context.Dispose();
-
-            return TaskHelpers.CompletedTask;
         }
 
         private static T Get<T>(IDictionary<string, object> env, string key)

--- a/src/Nancy/Response.cs
+++ b/src/Nancy/Response.cs
@@ -61,7 +61,7 @@ namespace Nancy
         /// </summary>
         /// <value>An <see cref="Action{T}"/> delegate, containing the code that will render contents to the response stream.</value>
         /// <remarks>The host of Nancy will pass in the output stream after the response has been handed back to it by Nancy.</remarks>
-        public Action<Stream> Contents { get; set; }
+        public BodyDelegate Contents { get; set; }
 
         /// <summary>
         /// Gets the collection of HTTP response headers that should be sent back to the client.

--- a/src/Nancy/Responses/EmbeddedFileResponse.cs
+++ b/src/Nancy/Responses/EmbeddedFileResponse.cs
@@ -7,6 +7,7 @@
     using System.Security.Cryptography;
     using System.Text;
     using System.Text.RegularExpressions;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Represent an HTML response with embeded file content.
@@ -42,17 +43,17 @@
                 content.Seek(0, SeekOrigin.Begin);
             }
 
-            this.Contents = stream =>
+            this.Contents = (Func<Stream, Task>)(async stream =>
             {
                 if (content != null)
                 {
-                    content.CopyTo(stream);
+                    await content.CopyToAsync(stream);
                 }
                 else
                 {
                     stream.Write(ErrorText, 0, ErrorText.Length);
                 }
-            };
+            });
         }
 
         private Stream GetResourceContent(Assembly assembly, string resourcePath, string name)

--- a/src/Nancy/Responses/Negotiation/XmlProcessor.cs
+++ b/src/Nancy/Responses/Negotiation/XmlProcessor.cs
@@ -2,7 +2,9 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Linq;
+    using System.Net.Mime;
 
     /// <summary>
     /// Processes the model for xml media types and extension.
@@ -83,13 +85,13 @@
         {
             return new Response
             {
-                Contents = stream =>
+                Contents = (Action<Stream>)(stream =>
                 {
                     if (model != null)
                     {
                         serializer.Serialize("application/xml", model, stream);
                     }
-                },
+                }),
                 ContentType = "application/xml",
                 StatusCode = HttpStatusCode.OK
             };

--- a/src/Nancy/Responses/TextResponse.cs
+++ b/src/Nancy/Responses/TextResponse.cs
@@ -1,6 +1,8 @@
 ﻿namespace Nancy.Responses
 {
+    using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Text;
 
     using Nancy.Cookies;
@@ -36,11 +38,11 @@
 
             if (contents != null)
             {
-                this.Contents = stream =>
+                this.Contents = (Action<Stream>)(stream =>
                 {
                     var data = encoding.GetBytes(contents);
                     stream.Write(data, 0, data.Length);
-                };
+                });
             }
         }
 
@@ -66,11 +68,11 @@
 
             if (contents != null)
             {
-                this.Contents = stream =>
+                this.Contents = (Action<Stream>)(stream =>
                 {
                     var data = encoding.GetBytes(contents);
                     stream.Write(data, 0, data.Length);
-                };
+                });
             }
 
             if (headers != null)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description

Initial stab at pulling out the body delegate to its own type to allow for casts to/from the actual async and non-async delegate signatures - idea being we patch up everything by adding a cast to Action<Stream> to make it build (unfortunately implicit casts and delegates still need an explicit cast), then we can work through bit by bit making them async, then remove the cast option from the sync delegate type at a later date.

Already fixed up the Nancy project itself, which shows both "asyncing" the bits that make sense, and just straight casting the bits that don't (such as when writing a string).

