### PR TITLE
Upgrade Microsoft.NETCore.App to 1.0.1

### DIFF
--- a/samples/Nancy.Demo.Hosting.Kestrel/project.json
+++ b/samples/Nancy.Demo.Hosting.Kestrel/project.json
@@ -3,26 +3,28 @@
         "debugType": "portable",
         "emitEntryPoint": true
     },
-
     "dependencies": {
-        "Nancy": { "target": "project" },
-        "Nancy.Validation.FluentValidation": {"target": "project"}
+        "Nancy": {
+            "target": "project"
+        },
+        "Nancy.Validation.FluentValidation": {
+            "target": "project"
+        }
     },
-
     "frameworks": {
         "netcoreapp1.0": {
             "dependencies": {
                 "Microsoft.AspNetCore.Hosting": "1.0.0",
                 "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
                 "Microsoft.AspNetCore.Owin": "1.0.0",
-                "Microsoft.Extensions.Configuration.Binder":"1.0.0",
-                "Microsoft.Extensions.Configuration.Json":"1.0.0",
+                "Microsoft.Extensions.Configuration.Binder": "1.0.0",
+                "Microsoft.Extensions.Configuration.Json": "1.0.0",
                 "Microsoft.NETCore.App": {
                     "type": "platform",
-                    "version": "1.0.0"
+                    "version": "1.0.1"
                 }
             },
-             "imports": [
+            "imports": [
                 "dotnet54",
                 "portable-net451+win8"
             ]

--- a/test/Nancy.Tests.Functional/project.json
+++ b/test/Nancy.Tests.Functional/project.json
@@ -2,11 +2,14 @@
     "dependencies": {
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
         "Microsoft.NETCore.Platforms": "1.0.1",
-        "Nancy": { "target": "project" },
-        "Nancy.Testing": { "target": "project" },
+        "Nancy": {
+            "target": "project"
+        },
+        "Nancy.Testing": {
+            "target": "project"
+        },
         "xunit": "2.2.0-beta2-build3300"
     },
-
     "buildOptions": {
         "compile": [
             "../Nancy.Tests/xUnitExtensions/RecordAsync.cs"
@@ -16,35 +19,39 @@
             "Views/**/*"
         ]
     },
-
     "frameworks": {
         "netcoreapp1.0": {
             "buildOptions": {
-                "define": [ "CORE" ]
+                "define": [
+                    "CORE"
+                ]
             },
             "dependencies": {
                 "Microsoft.NETCore.App": {
                     "type": "platform",
-                    "version": "1.0.0"
+                    "version": "1.0.1"
                 }
             },
-
             "imports": [
                 "dotnet",
                 "portable-net451+win8"
             ]
         },
-
         "net452": {
             "dependencies": {
-                "Nancy.ViewEngines.Razor": { "target": "project" }
+                "Nancy.ViewEngines.Razor": {
+                    "target": "project"
+                }
             },
             "frameworkAssemblies": {
-                "System.Runtime": { "type": "build" },
-                "System.Threading.Tasks": { "type": "build" }
+                "System.Runtime": {
+                    "type": "build"
+                },
+                "System.Threading.Tasks": {
+                    "type": "build"
+                }
             }
         }
     },
-
     "testRunner": "xunit"
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
This upgrades any reference of Microsoft.NETCore.App 1.0.0 to the new 1.0.1 version

