### PR TITLE
Fixed the Mono version to 4.4.2 for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: csharp
+mono: 4.4.2
 sudo: required
 dist: trusty
 addons:
   apt:
-    packages: 
+    packages:
     - gettext
     - libcurl4-openssl-dev
     - libicu-dev


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [X] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [X] I have provided test coverage for my change (where applicable)

### Description
Travis (mono) builds recently started failing. It appears that this started happening since Mono 4.6.1 became available on Travis

Last successful build
```
0.01s$ mono --version
Mono JIT compiler version 4.4.2 (Stable 4.4.2.11/f72fe45 Fri Jul 29 09:58:49 UTC 2016)
```

First failing build
```
0.01s$ mono --version
Mono JIT compiler version 4.6.1 (Stable 4.6.1.5/ef43c15 Wed Oct 12 09:10:37 UTC 2016)
```

This PR locks the version to `4.4.2` in an attempt to resolve this

<!-- Thanks for contributing to Nancy! -->

