### PR TITLE
Made Json class public, reuse utility to check media type

### DIFF
--- a/src/Nancy/Json/Json.cs
+++ b/src/Nancy/Json/Json.cs
@@ -30,8 +30,10 @@ namespace Nancy.Json
 {
     using System;
 
-    internal static class Json
+    public static class Json
     {
+        private const StringComparison ComparisonType = StringComparison.OrdinalIgnoreCase;
+
         /// <summary>
         /// Attempts to detect if the content type is JSON.
         /// Supports:
@@ -49,12 +51,18 @@ namespace Nancy.Json
                 return false;
             }
 
-            var contentMimeType = contentType.Split(';')[0];
+            var index = contentType.IndexOf(';');
 
-            return contentMimeType.Equals("application/json", StringComparison.OrdinalIgnoreCase) ||
-            contentMimeType.StartsWith("application/json-", StringComparison.OrdinalIgnoreCase) ||
-            contentMimeType.Equals("text/json", StringComparison.OrdinalIgnoreCase) ||
-            contentMimeType.EndsWith("+json", StringComparison.OrdinalIgnoreCase);
+            if (index >= 0)
+            {
+                contentType = contentType.Substring(0, index);
+            }
+
+            contentType = contentType.Trim();
+
+            return contentType.StartsWith("application/json", ComparisonType)
+                || contentType.Equals("text/json", ComparisonType)
+                || contentType.EndsWith("+json", ComparisonType);
         }
     }
 }

--- a/src/Nancy/Responses/DefaultJsonSerializer.cs
+++ b/src/Nancy/Responses/DefaultJsonSerializer.cs
@@ -36,7 +36,7 @@
         /// <returns>True if supported, false otherwise</returns>
         public bool CanSerialize(MediaRange mediaRange)
         {
-            return IsJsonType(mediaRange);
+            return Json.IsJsonContentType(mediaRange);
         }
 
         /// <summary>
@@ -76,30 +76,6 @@
                     }
                 }
             }
-        }
-
-        /// <summary>
-        /// Attempts to detect if the content type is JSON.
-        /// Supports:
-        ///   application/json
-        ///   text/json
-        ///   application/vnd[something]+json
-        /// Matches are case insentitive to try and be as "accepting" as possible.
-        /// </summary>
-        /// <param name="contentType">Request content type</param>
-        /// <returns>True if content type is JSON, false otherwise</returns>
-        private static bool IsJsonType(string contentType)
-        {
-            if (string.IsNullOrEmpty(contentType))
-            {
-                return false;
-            }
-
-            var contentMimeType = contentType.Split(';')[0];
-
-            return contentMimeType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase)
-                || contentMimeType.Equals("text/json", StringComparison.OrdinalIgnoreCase)
-                || contentMimeType.EndsWith("+json", StringComparison.OrdinalIgnoreCase);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description

This means the other JSON serializers can use the `Json.IsJsonContentType` and reuse the logic.

