### PR TITLE
Fix a memory leak

### DIFF
--- a/src/Nancy/NancyEngine.cs
+++ b/src/Nancy/NancyEngine.cs
@@ -95,7 +95,8 @@
 
         public Task<NancyContext> HandleRequest(Request request, Func<NancyContext, NancyContext> preRequest, CancellationToken cancellationToken)
         {
-	        var cts = CancellationTokenSource.CreateLinkedTokenSource(this.engineDisposedCts.Token, cancellationToken);
+	        using(var cts = CancellationTokenSource.CreateLinkedTokenSource(this.engineDisposedCts.Token, cancellationToken))
+            {
             cts.Token.ThrowIfCancellationRequested();
 
             var tcs = new TaskCompletionSource<NancyContext>();
@@ -138,10 +139,6 @@
 		                tcs.SetException(ex);
 		                return;
 	                }
-	                finally
-	                {
-		                cts.Dispose();
-	                }
 
                     tcs.SetResult(completeTask.Result);
                 },
@@ -152,6 +149,7 @@
                 true);
 
             return tcs.Task;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [ ] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to Nancy! -->

Dispose the object returned by CreateLinkedTokenSource(...)

I have spent around 6 hours working on memory leak issue. After applying the change here, no memory leak anymore.