### PR TITLE
Backport #2512 to 1.x-WorkingBranch

### DIFF
--- a/src/Nancy/IO/RequestStream.cs
+++ b/src/Nancy/IO/RequestStream.cs
@@ -85,7 +85,12 @@
             this.stream.Position = 0;
         }
 
-        private Task<object> MoveToWritableStream()
+        ~RequestStream()
+        {
+            this.Dispose(false);
+        }
+
+        private Task MoveToWritableStream()
         {
             var tcs = new TaskCompletionSource<object>();
 
@@ -213,7 +218,10 @@
         {
             if (this.isSafeToDisposeStream)
             {
-                ((IDisposable)this.stream).Dispose();
+                if (this.stream != null)
+                {
+                    this.stream.Dispose();
+                }
 
                 var fileStream = this.stream as FileStream;
                 if (fileStream != null)

--- a/src/Nancy/Request.cs
+++ b/src/Nancy/Request.cs
@@ -48,7 +48,7 @@ namespace Nancy
         /// <param name="protocolVersion">The HTTP protocol version.</param>
         public Request(string method,
             Url url,
-            RequestStream body = null,
+            Stream body = null,
             IDictionary<string, IEnumerable<string>> headers = null,
             string ip = null,
             byte[] certificate = null,
@@ -149,10 +149,10 @@ namespace Nancy
         public dynamic Query { get; set; }
 
         /// <summary>
-        /// Gets a <see cref="RequestStream"/> that can be used to read the incoming HTTP body
+        /// Gets a <see cref="Stream"/> that can be used to read the incoming HTTP body
         /// </summary>
-        /// <value>A <see cref="RequestStream"/> object representing the incoming HTTP body.</value>
-        public RequestStream Body { get; private set; }
+        /// <value>A <see cref="Stream"/> object representing the incoming HTTP body.</value>
+        public Stream Body { get; private set; }
 
         /// <summary>
         /// Gets the request cookies.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [ ] I have provided test coverage for my change (where applicable)
^ not covered by tests in this branch

### Description
Replaces references to `RequestStream` with base `Stream` so that it can be swapped with another implementation eg. [Microsof.IO.RecyclableMemoryStream](https://github.com/Microsoft/Microsoft.IO.RecyclableMemoryStream/tree/master/src)

This will allow us to fix our production issues without upgrading to Nancy 2.x and give us some tracing, hopefully we will be able to pin down where the leaking TempFiles issue is coming from.
