### PR TITLE
Added Netstandard support to Nancy.ViewEngines.Markdown

### DIFF
--- a/src/Nancy.ViewEngines.Markdown.MSBuild/Nancy.ViewEngines.Markdown.csproj
+++ b/src/Nancy.ViewEngines.Markdown.MSBuild/Nancy.ViewEngines.Markdown.csproj
@@ -60,9 +60,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MarkdownSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\MarkdownSharp.1.13.0.0\lib\35\MarkdownSharp.dll</HintPath>
+    <Reference Include="Markdown">
+      <HintPath>..\..\packages\Markdown.2.2.0\lib\net451\Markdown.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/src/Nancy.ViewEngines.Markdown.MSBuild/packages.config
+++ b/src/Nancy.ViewEngines.Markdown.MSBuild/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncUsageAnalyzers" version="1.0.0-alpha003" targetFramework="net45" developmentDependency="true" />
-  <package id="MarkdownSharp" version="1.13.0.0" targetFramework="net45" />
+  <package id="Markdown" version="2.2.0" targetFramework="net45" />
 </packages>

--- a/src/Nancy.ViewEngines.Markdown/MarkDownViewEngine.cs
+++ b/src/Nancy.ViewEngines.Markdown/MarkDownViewEngine.cs
@@ -4,7 +4,7 @@ namespace Nancy.ViewEngines.Markdown
     using System.IO;
     using System.Text.RegularExpressions;
 
-    using MarkdownSharp;
+    using HeyRed.MarkdownSharp;
 
     using Nancy.Responses;
     using Nancy.ViewEngines.SuperSimpleViewEngine;

--- a/src/Nancy.ViewEngines.Markdown/MarkdownViewEngineHost.cs
+++ b/src/Nancy.ViewEngines.Markdown/MarkdownViewEngineHost.cs
@@ -4,7 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
 
-    using MarkdownSharp;
+    using HeyRed.MarkdownSharp;
 
     using Nancy.ViewEngines.SuperSimpleViewEngine;
 

--- a/src/Nancy.ViewEngines.Markdown/MarkdownViewengineRender.cs
+++ b/src/Nancy.ViewEngines.Markdown/MarkdownViewengineRender.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Text.RegularExpressions;
 
-    using MarkdownSharp;
+    using HeyRed.MarkdownSharp;
 
     public static class MarkdownViewengineRender
     {

--- a/src/Nancy.ViewEngines.Markdown/project.json
+++ b/src/Nancy.ViewEngines.Markdown/project.json
@@ -17,17 +17,20 @@
     "buildOptions": {
         "xmlDoc": true
     },
+
     "dependencies": {
         "Nancy": {
             "target": "project"
         },
-        "MarkdownSharp": "1.13.0",
+        "Markdown": "2.2.0",
         "AsyncUsageAnalyzers": {
             "type": "build",
             "version": "1.0.0-alpha003"
         }
     },
+
     "frameworks": {
-        "net452": {}
+        "net452": {},
+        "netstandard1.6": {}
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
 Use [Markdown](https://www.nuget.org/packages/Markdown) package which supports netstandard and is actively mantained.
<!-- Thanks for contributing to Nancy! -->

