### PR TITLE
Add netcoreapp1.0 test target to Nancy.Tests

### DIFF
--- a/test/Nancy.Tests/Helpers/AssemblyHelpers.cs
+++ b/test/Nancy.Tests/Helpers/AssemblyHelpers.cs
@@ -1,0 +1,31 @@
+﻿namespace Nancy.Tests.Helpers
+{
+    using System.IO;
+    using System.Reflection;
+
+#if CORE
+    using System.Runtime.Loader;
+#endif
+
+    /// <summary>
+    /// Convenience class with helper methods for <see cref="Assembly"/>.
+    /// </summary>
+    public static class AssemblyHelpers
+    {
+        /// <summary>
+        /// Loads an assembly from the emitted image contained in <paramref name="stream"/>.
+        /// </summary>
+        /// <param name="stream">The steam that contains the emitted assembly.</param>
+        /// <returns>The loaded assembly.</returns>
+        public static Assembly Load(MemoryStream stream)
+        {
+#if CORE
+            stream.Position = 0;
+            return AssemblyLoadContext.Default.LoadFromStream(stream);
+#else
+            return Assembly.Load(stream.ToArray());
+#endif
+
+        }
+    }
+}

--- a/test/Nancy.Tests/NoAppStartupsFixture.cs
+++ b/test/Nancy.Tests/NoAppStartupsFixture.cs
@@ -44,9 +44,7 @@
 
         private static void ThrowWhenNoAppStartupsFixtureRuns()
         {
-            var frames = new StackTrace().GetFrames();
-
-            if (frames != null && frames.Select(f => f.GetMethod().DeclaringType).Any(t => t == typeof(NoAppStartupsFixture)))
+            if ( Environment.StackTrace.Contains(typeof(NoAppStartupsFixture).FullName))
             {
                 throw new Exception();
             }

--- a/test/Nancy.Tests/Resources/Link.Texts.Designer.cs
+++ b/test/Nancy.Tests/Resources/Link.Texts.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace Nancy.Tests.Resources {
     using System;
-    
-    
+    using Nancy.Extensions;
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -39,7 +39,7 @@ namespace Nancy.Tests.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Nancy.Tests.Resources.Link.Texts", typeof(Link_Texts).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Nancy.Tests.Resources.Link.Texts", typeof(Link_Texts).GetAssembly());
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/test/Nancy.Tests/Resources/Menu.Designer.cs
+++ b/test/Nancy.Tests/Resources/Menu.Designer.cs
@@ -10,8 +10,9 @@
 
 namespace Nancy.Demo.Hosting.Aspnet.Resources {
     using System;
-    
-    
+    using Nancy.Extensions;
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -39,7 +40,7 @@ namespace Nancy.Demo.Hosting.Aspnet.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Nancy.Demo.Hosting.Aspnet.Resources.Menu", typeof(Menu).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Nancy.Demo.Hosting.Aspnet.Resources.Menu", typeof(Menu).GetAssembly());
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/test/Nancy.Tests/Resources/Menu.Texts.Designer.cs
+++ b/test/Nancy.Tests/Resources/Menu.Texts.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace Nancy.Tests.Resources {
     using System;
-    
-    
+    using Nancy.Extensions;
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -39,7 +39,7 @@ namespace Nancy.Tests.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Nancy.Tests.Resources.Menu.Texts", typeof(Menu_Texts).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Nancy.Tests.Resources.Menu.Texts", typeof(Menu_Texts).GetAssembly());
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/test/Nancy.Tests/Unit/AppDomainAssemblyCatalogFixture.cs
+++ b/test/Nancy.Tests/Unit/AppDomainAssemblyCatalogFixture.cs
@@ -1,4 +1,5 @@
-﻿namespace Nancy.Tests.Unit
+﻿#if !CORE
+namespace Nancy.Tests.Unit
 {
     using System;
     using System.CodeDom.Compiler;
@@ -69,3 +70,4 @@
         }
     }
 }
+#endif

--- a/test/Nancy.Tests/Unit/Bootstrapper/NancyBootstrapperBaseFixture.cs
+++ b/test/Nancy.Tests/Unit/Bootstrapper/NancyBootstrapperBaseFixture.cs
@@ -327,7 +327,7 @@
         {
             if (this.ShouldThrowWhenGettingEngine)
             {
-                throw new ApplicationException("Something when wrong when trying to compose the engine.");
+                throw new Exception("Something when wrong when trying to compose the engine.");
             }
 
             return this.FakeNancyEngine;

--- a/test/Nancy.Tests/Unit/Bootstrapper/NancyBootstrapperWithRequestContainerBaseFixture.cs
+++ b/test/Nancy.Tests/Unit/Bootstrapper/NancyBootstrapperWithRequestContainerBaseFixture.cs
@@ -245,7 +245,7 @@
             {
                 if (this.ShouldThrowWhenGettingEngine)
                 {
-                    throw new ApplicationException("Something when wrong when trying to compose the engine.");
+                    throw new Exception("Something when wrong when trying to compose the engine.");
                 }
 
                 return this.FakeNancyEngine;

--- a/test/Nancy.Tests/Unit/Diagnostics/InteractiveDiagnosticsFixture.cs
+++ b/test/Nancy.Tests/Unit/Diagnostics/InteractiveDiagnosticsFixture.cs
@@ -3,6 +3,7 @@
     using Nancy.Diagnostics;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reflection;
     using Xunit;
 
     public class InteractiveDiagnosticsFixture

--- a/test/Nancy.Tests/Unit/IO/RequestStreamFixture.cs
+++ b/test/Nancy.Tests/Unit/IO/RequestStreamFixture.cs
@@ -436,6 +436,7 @@ namespace Nancy.Tests.Unit.IO
             request.IsInMemory.ShouldBeTrue();
         }
 
+#if !CORE // BeginRead, EndRead, BeginWrite, EndWrite don't exist in .NET Core
         [Fact]
         public void Should_call_beginread_on_underlaying_stream_when_beginread_is_called()
         {
@@ -553,6 +554,7 @@ namespace Nancy.Tests.Unit.IO
             // Then
             A.CallTo(() => stream.EndWrite(asyncResult)).MustHaveHappened();
         }
+#endif
 
         private static Stream CreateFakeStream()
         {

--- a/test/Nancy.Tests/Unit/Localization/ResourceBasedTextResourceFixture.cs
+++ b/test/Nancy.Tests/Unit/Localization/ResourceBasedTextResourceFixture.cs
@@ -3,6 +3,7 @@
     using System;
     using FakeItEasy;
 
+    using Nancy.Extensions;
     using Nancy.Localization;
 
     using Xunit;
@@ -14,7 +15,7 @@
         {
             // Given
             var resourceAssemblyProvider = A.Fake<IResourceAssemblyProvider>();
-            A.CallTo(() => resourceAssemblyProvider.GetAssembliesToScan()).Returns(new[] { typeof(NancyEngine).Assembly });
+            A.CallTo(() => resourceAssemblyProvider.GetAssembliesToScan()).Returns(new[] { typeof(NancyEngine).GetAssembly() });
 
             var defaultTextResource = new ResourceBasedTextResource(resourceAssemblyProvider);
             var context = new NancyContext();
@@ -31,7 +32,7 @@
         {
             // Given
             var resourceAssemblyProvider = A.Fake<IResourceAssemblyProvider>();
-            A.CallTo(() => resourceAssemblyProvider.GetAssembliesToScan()).Returns(new[] { this.GetType().Assembly });
+            A.CallTo(() => resourceAssemblyProvider.GetAssembliesToScan()).Returns(new[] { this.GetType().GetAssembly() });
 
             var defaultTextResource = new ResourceBasedTextResource(resourceAssemblyProvider);
             var context = new NancyContext();
@@ -51,7 +52,7 @@
                 "More than one text resources match the Texts key. Try providing a more specific key.";
 
             var resourceAssemblyProvider = A.Fake<IResourceAssemblyProvider>();
-            A.CallTo(() => resourceAssemblyProvider.GetAssembliesToScan()).Returns(new[] { this.GetType().Assembly });
+            A.CallTo(() => resourceAssemblyProvider.GetAssembliesToScan()).Returns(new[] { this.GetType().GetAssembly() });
 
             var defaultTextResource = new ResourceBasedTextResource(resourceAssemblyProvider);
             var context = new NancyContext();

--- a/test/Nancy.Tests/Unit/ModelBinding/BindingMemberInfoFixture.cs
+++ b/test/Nancy.Tests/Unit/ModelBinding/BindingMemberInfoFixture.cs
@@ -2,12 +2,12 @@
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Reflection;
     using System.Xml.Serialization;
 
     using Nancy.ModelBinding;
     using Nancy.Testing;
     using Xunit;
-    using Xunit.Sdk;
 
     public class BindingMemberInfoFixture
     {

--- a/test/Nancy.Tests/Unit/ModelBinding/DefaultBinderFixture.cs
+++ b/test/Nancy.Tests/Unit/ModelBinding/DefaultBinderFixture.cs
@@ -5,6 +5,7 @@ namespace Nancy.Tests.Unit.ModelBinding
     using System.Globalization;
     using System.IO;
     using System.Linq;
+    using System.Reflection;
     using System.Text;
     using System.Xml.Serialization;
     using FakeItEasy;

--- a/test/Nancy.Tests/Unit/ModelBinding/DefaultBodyDeserializers/JsonBodyDeserializerFixture.cs
+++ b/test/Nancy.Tests/Unit/ModelBinding/DefaultBodyDeserializers/JsonBodyDeserializerFixture.cs
@@ -12,6 +12,7 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
     using Nancy.Json;
     using Nancy.ModelBinding;
     using Nancy.ModelBinding.DefaultBodyDeserializers;
+    using Nancy.Tests.xUnitExtensions;
     using Xunit;
     using Xunit.Extensions;
 
@@ -284,12 +285,11 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
 
 #if !MONO
         [Fact]
+        [UsingCulture("de-DE")]
         public void Should_Serialize_Doubles_In_Different_Cultures()
         {
             // TODO - fixup on mono, seems to throw inside double.parse
             // Given
-            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
-
             var modelWithDoubleValues =
                 new ModelWithDoubleValues
                     {
@@ -377,7 +377,7 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
                 return other.StringProperty == this.StringProperty &&
                        other.IntProperty == this.IntProperty &&
                        !other.ArrayProperty.Except(this.ArrayProperty).Any() &&
-                       other.DateProperty.ToShortDateString() == this.DateProperty.ToShortDateString();
+                       other.DateProperty.ToString("d") == this.DateProperty.ToString("d");
             }
 
             public override bool Equals(object obj)

--- a/test/Nancy.Tests/Unit/ModelBinding/DefaultBodyDeserializers/XmlBodyDeserializerfixture.cs
+++ b/test/Nancy.Tests/Unit/ModelBinding/DefaultBodyDeserializers/XmlBodyDeserializerfixture.cs
@@ -133,7 +133,8 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultBodyDeserializers
             using (var ms = new MemoryStream())
             {
                 ser.Serialize(ms, input);
-                xml = Encoding.Default.GetString(ms.ToArray());
+                // codepage 0 represents the system's default encoding
+                xml = Encoding.GetEncoding(0).GetString(ms.ToArray());
             }
             return xml;
         }

--- a/test/Nancy.Tests/Unit/ModelBinding/DefaultModelBinderLocatorFixture.cs
+++ b/test/Nancy.Tests/Unit/ModelBinding/DefaultModelBinderLocatorFixture.cs
@@ -1,6 +1,7 @@
 namespace Nancy.Tests.Unit.ModelBinding
 {
     using System;
+    using System.Reflection;
 
     using FakeItEasy;
     using Nancy.Configuration;

--- a/test/Nancy.Tests/Unit/NancyCookieFixture.cs
+++ b/test/Nancy.Tests/Unit/NancyCookieFixture.cs
@@ -5,7 +5,7 @@ namespace Nancy.Tests.Unit
     using System.Threading;
 
     using Nancy.Cookies;
-
+    using Nancy.Tests.xUnitExtensions;
     using Xunit;
 
     public class NancyCookieFixture
@@ -37,25 +37,17 @@ namespace Nancy.Tests.Unit
         }
 
         [Fact]
+        [UsingCulture("fr-FR")]
         public void Should_stringify_an_expiry_to_english()
         {
-            var originalCulture = Thread.CurrentThread.CurrentCulture;
-            try
-            {
-                // Given
-                Thread.CurrentThread.CurrentCulture = new CultureInfo("fr-FR");
-                var date = new DateTime(2015, 10, 8, 9, 10, 11, DateTimeKind.Utc);
+            // Given
+            var date = new DateTime(2015, 10, 8, 9, 10, 11, DateTimeKind.Utc);
 
-                // When
-                var cookie = new NancyCookie("leto", "worm") { Expires = date }.ToString();
+            // When
+            var cookie = new NancyCookie("leto", "worm") { Expires = date }.ToString();
 
-                // Then
-                cookie.ShouldEqual("leto=worm; path=/; expires=Thu, 08-Oct-2015 09:10:11 GMT");
-            }
-            finally
-            {
-                Thread.CurrentThread.CurrentCulture = originalCulture;
-            }
+            // Then
+            cookie.ShouldEqual("leto=worm; path=/; expires=Thu, 08-Oct-2015 09:10:11 GMT");
         }
 
         [Fact]

--- a/test/Nancy.Tests/Unit/Responses/EmbeddedFileResponseFixture.cs
+++ b/test/Nancy.Tests/Unit/Responses/EmbeddedFileResponseFixture.cs
@@ -2,6 +2,7 @@
 {
     using System.IO;
 
+    using Nancy.Extensions;
     using Nancy.Responses;
 
     using Xunit;
@@ -13,7 +14,7 @@
         {
             // Given, when
             var response =
-                new EmbeddedFileResponse(this.GetType().Assembly, "Nancy.Tests", "Resources.Views.staticviewresource.html");
+                new EmbeddedFileResponse(this.GetType().GetAssembly(), "Nancy.Tests", "Resources.Views.staticviewresource.html");
 
             // Then
             response.Headers["ETag"].ShouldEqual("\"B9D9DC2B50ADFD0867749D4837C63556339080CE\"");
@@ -24,7 +25,7 @@
         {
             // Given
             var response =
-                new EmbeddedFileResponse(this.GetType().Assembly, "Nancy.Tests", "Resources.Views.staticviewresource.html");
+                new EmbeddedFileResponse(this.GetType().GetAssembly(), "Nancy.Tests", "Resources.Views.staticviewresource.html");
 
             var outputStream = new MemoryStream();
 
@@ -40,7 +41,7 @@
         {
             // Given, when
             var response =
-                new EmbeddedFileResponse(this.GetType().Assembly, "Nancy.Tests", "i_dont_exist.jpg");
+                new EmbeddedFileResponse(this.GetType().GetAssembly(), "Nancy.Tests", "i_dont_exist.jpg");
 
             // Then
             response.Headers.ContainsKey("ETag").ShouldBeFalse();
@@ -51,7 +52,7 @@
         {
             // Given
             var response =
-                new EmbeddedFileResponse(this.GetType().Assembly, "Nancy.Tests", "i_dont_exist.jpg");
+                new EmbeddedFileResponse(this.GetType().GetAssembly(), "Nancy.Tests", "i_dont_exist.jpg");
 
             var outputStream = new MemoryStream();
 
@@ -67,7 +68,7 @@
         {
             // Given, when
             var response =
-                new EmbeddedFileResponse(this.GetType().Assembly, "nancy.tests", "Resources.Views.staticviewresource.html");
+                new EmbeddedFileResponse(this.GetType().GetAssembly(), "nancy.tests", "Resources.Views.staticviewresource.html");
 
             // Then
             response.Headers["ETag"].ShouldEqual("\"B9D9DC2B50ADFD0867749D4837C63556339080CE\"");

--- a/test/Nancy.Tests/Unit/Sessions/CookieBasedSessionsFixture.cs
+++ b/test/Nancy.Tests/Unit/Sessions/CookieBasedSessionsFixture.cs
@@ -5,12 +5,12 @@ namespace Nancy.Tests.Unit.Sessions
     using System.Linq;
     using System.Reflection;
     using System.Threading;
-    using System.Web;
 
     using FakeItEasy;
 
     using Nancy.Bootstrapper;
     using Nancy.Cryptography;
+    using Nancy.Helpers;
     using Nancy.IO;
     using Nancy.Session;
     using Nancy.Tests.Fakes;

--- a/test/Nancy.Tests/Unit/Sessions/DefaultSessionObjectFormatterFixture.cs
+++ b/test/Nancy.Tests/Unit/Sessions/DefaultSessionObjectFormatterFixture.cs
@@ -64,7 +64,9 @@ namespace Nancy.Tests.Unit.Sessions
             output.ShouldBeNull();
         }
 
+#if !CORE
         [Serializable]
+#endif
         public class Payload : IEquatable<Payload>
         {
             public int IntValue { get;  set; }

--- a/test/Nancy.Tests/Unit/StaticContentConventionBuilderFixture.cs
+++ b/test/Nancy.Tests/Unit/StaticContentConventionBuilderFixture.cs
@@ -4,16 +4,15 @@
     using System.Collections.Generic;
     using System.Globalization;
     using System.IO;
-    using System.Linq;
     using System.Text;
 
     using Nancy.Configuration;
     using Nancy.Conventions;
     using Nancy.Diagnostics;
+    using Nancy.Extensions;
     using Nancy.Responses;
 
     using Xunit;
-    using Xunit.Extensions;
 
     public class StaticContentConventionBuilderFixture
     {
@@ -26,7 +25,12 @@
 
         public StaticContentConventionBuilderFixture()
         {
-            this.directory = Environment.CurrentDirectory;
+            // Under .NET Framework, resources are copied to
+            // bin\Release\net452\win7-x64\Resources (modulo version and architecture), but under .NET Core, they go to
+            // bin\Release\netcoreapp1.0\Resources.
+            // Set our working directory relative the assembly to ensure the tests find the resources.
+            this.directory = new DirectoryInfo(typeof(StaticContentConventionBuilderFixture).GetAssembly().Location)
+                .Parent.FullName;
             this.environment = new DefaultNancyEnvironment();
             this.environment.StaticContent(safepaths:this.directory);
         }
@@ -263,7 +267,7 @@
                 using (var stream = new MemoryStream())
                 {
                     fileResponse.Contents(stream);
-                    return Encoding.UTF8.GetString(stream.GetBuffer(), 0, (int)stream.Length);
+                    return Encoding.UTF8.GetString(stream.ToArray());
                 }
             }
 

--- a/test/Nancy.Tests/Unit/UrlFixture.cs
+++ b/test/Nancy.Tests/Unit/UrlFixture.cs
@@ -235,7 +235,7 @@
             Url result = uri;
 
             // Then
-            result.Scheme.ShouldEqual(Uri.UriSchemeHttp);
+            result.Scheme.ShouldEqual("http");
             result.HostName.ShouldEqual(string.Empty);
             result.Port.ShouldEqual(null);
             result.BasePath.ShouldEqual(string.Empty);

--- a/test/Nancy.Tests/Unit/ViewEngines/ResourceViewLocationProviderFixture.cs
+++ b/test/Nancy.Tests/Unit/ViewEngines/ResourceViewLocationProviderFixture.cs
@@ -8,6 +8,7 @@ namespace Nancy.Tests.Unit.ViewEngines
 
     using FakeItEasy;
 
+    using Nancy.Extensions;
     using Nancy.ViewEngines;
 
     using Xunit;
@@ -25,12 +26,12 @@ namespace Nancy.Tests.Unit.ViewEngines
             this.resourceAssemblyProvider = A.Fake<IResourceAssemblyProvider>();
             this.viewProvider = new ResourceViewLocationProvider(this.reader, this.resourceAssemblyProvider);
 
-            if (!ResourceViewLocationProvider.RootNamespaces.ContainsKey(this.GetType().Assembly))
+            if (!ResourceViewLocationProvider.RootNamespaces.ContainsKey(this.GetType().GetAssembly()))
             {
-                ResourceViewLocationProvider.RootNamespaces.Add(this.GetType().Assembly, "Some.Resource");
+                ResourceViewLocationProvider.RootNamespaces.Add(this.GetType().GetAssembly(), "Some.Resource");
             }
 
-            A.CallTo(() => this.resourceAssemblyProvider.GetAssembliesToScan()).Returns(new[] { this.GetType().Assembly });
+            A.CallTo(() => this.resourceAssemblyProvider.GetAssembliesToScan()).Returns(new[] { this.GetType().GetAssembly() });
         }
 
         [Fact]
@@ -117,7 +118,7 @@ namespace Nancy.Tests.Unit.ViewEngines
             // Given
             var extensions = new[] { "html" };
 
-            ResourceViewLocationProvider.RootNamespaces.Remove(this.GetType().Assembly);
+            ResourceViewLocationProvider.RootNamespaces.Remove(this.GetType().GetAssembly());
 
             var match = new Tuple<string, Func<StreamReader>>(
                 "Some.Resource.View.html",
@@ -138,7 +139,7 @@ namespace Nancy.Tests.Unit.ViewEngines
             // Given
             var extensions = new[] { "html" };
 
-            ResourceViewLocationProvider.RootNamespaces.Remove(this.GetType().Assembly);
+            ResourceViewLocationProvider.RootNamespaces.Remove(this.GetType().GetAssembly());
 
             var match = new Tuple<string, Func<StreamReader>>(
                 "Some.Resource.View.html",
@@ -147,7 +148,7 @@ namespace Nancy.Tests.Unit.ViewEngines
             A.CallTo(() => this.reader.GetResourceStreamMatches(A<Assembly>._, A<IEnumerable<string>>._)).Returns(new[] { match });
 
             var expectedErrorMessage =
-                string.Format("Only one view was found in assembly {0}, but no rootnamespace had been registered.", this.GetType().Assembly.FullName);
+                string.Format("Only one view was found in assembly {0}, but no rootnamespace had been registered.", this.GetType().GetAssembly().FullName);
 
             // When
             var exception = Record.Exception(() => this.viewProvider.GetLocatedViews(extensions).ToList());
@@ -181,8 +182,8 @@ namespace Nancy.Tests.Unit.ViewEngines
             // Given
             A.CallTo(() => this.resourceAssemblyProvider.GetAssembliesToScan()).Returns(new[]
             {
-                typeof(NancyEngine).Assembly,
-                this.GetType().Assembly
+                typeof(NancyEngine).GetAssembly(),
+                this.GetType().GetAssembly()
             });
 
             var extensions = new[] { "html" };
@@ -191,8 +192,8 @@ namespace Nancy.Tests.Unit.ViewEngines
             this.viewProvider.GetLocatedViews(extensions).ToList();
 
             // Then
-            A.CallTo(() => this.reader.GetResourceStreamMatches(this.GetType().Assembly, A<IEnumerable<string>>._)).MustHaveHappened();
-            A.CallTo(() => this.reader.GetResourceStreamMatches(typeof(NancyEngine).Assembly, A<IEnumerable<string>>._)).MustHaveHappened();
+            A.CallTo(() => this.reader.GetResourceStreamMatches(this.GetType().GetAssembly(), A<IEnumerable<string>>._)).MustHaveHappened();
+            A.CallTo(() => this.reader.GetResourceStreamMatches(typeof(NancyEngine).GetAssembly(), A<IEnumerable<string>>._)).MustHaveHappened();
         }
 
         [Fact]
@@ -201,11 +202,11 @@ namespace Nancy.Tests.Unit.ViewEngines
             // Given
             A.CallTo(() => this.resourceAssemblyProvider.GetAssembliesToScan()).Returns(new[]
             {
-                typeof(NancyEngine).Assembly,
-                this.GetType().Assembly
+                typeof(NancyEngine).GetAssembly(),
+                this.GetType().GetAssembly()
             });
 
-            ResourceViewLocationProvider.Ignore.Add(this.GetType().Assembly);
+            ResourceViewLocationProvider.Ignore.Add(this.GetType().GetAssembly());
 
             var extensions = new[] { "html" };
 
@@ -213,8 +214,8 @@ namespace Nancy.Tests.Unit.ViewEngines
             this.viewProvider.GetLocatedViews(extensions).ToList();
 
             // Then
-            A.CallTo(() => this.reader.GetResourceStreamMatches(this.GetType().Assembly, A<IEnumerable<string>>._)).MustNotHaveHappened();
-            A.CallTo(() => this.reader.GetResourceStreamMatches(typeof(NancyEngine).Assembly, A<IEnumerable<string>>._)).MustHaveHappened();
+            A.CallTo(() => this.reader.GetResourceStreamMatches(this.GetType().GetAssembly(), A<IEnumerable<string>>._)).MustNotHaveHappened();
+            A.CallTo(() => this.reader.GetResourceStreamMatches(typeof(NancyEngine).GetAssembly(), A<IEnumerable<string>>._)).MustHaveHappened();
         }
     }
 }

--- a/test/Nancy.Tests/Unit/XmlFormatterExtensionsFixtures.cs
+++ b/test/Nancy.Tests/Unit/XmlFormatterExtensionsFixtures.cs
@@ -58,8 +58,8 @@ namespace Nancy.Tests.Unit
 
                 root.Name.ShouldEqual("Person");
                 root.ChildNodes.Count.ShouldEqual(2);
-                root.SelectSingleNode("//Person/FirstName").InnerText.ShouldEqual("Andy");
-                root.SelectSingleNode("//Person/LastName").InnerText.ShouldEqual("Pike");
+                root["FirstName"].InnerText.ShouldEqual("Andy");
+                root["LastName"].InnerText.ShouldEqual("Pike");
             }
         }
 

--- a/test/Nancy.Tests/project.json
+++ b/test/Nancy.Tests/project.json
@@ -1,7 +1,9 @@
 {
+    "version": "1.4.1.0",
     "dependencies": {
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
-        "FakeItEasy.Analyzer": "2.1.0",
+        "FakeItEasy": "3.0.0-rc001",
+        "FakeItEasy.Analyzer": "3.0.0-rc001",
         "Microsoft.NETCore.Platforms": "1.0.1",
         "Nancy": { "target": "project" },
         "Nancy.Testing": { "target": "project" },
@@ -28,14 +30,27 @@
 
     "frameworks": {
         "net452": {
-            "dependencies": {
-                "FakeItEasy": "2.0.0"
-            },
             "frameworkAssemblies": {
                 "System.Runtime": { "type": "build" },
                 "System.Threading.Tasks": { "type": "build" },
                 "System.Web": { "type": "build" }
+            },
+            "dependencies": {
+                "Microsoft.CodeAnalysis.CSharp": "1.3.2"
             }
+        },
+        "netcoreapp1.0": {
+            "buildOptions": {
+                "define": [ "CORE" ]
+            },
+            "dependencies": {
+                "Microsoft.CodeAnalysis.CSharp": "2.0.0-rc",
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.0.0"
+                }
+            },
+            "imports": [ "netstandard1.6" ]
         }
     },
 

--- a/test/Nancy.Tests/xUnitExtensions/UsingCultureAttribute.cs
+++ b/test/Nancy.Tests/xUnitExtensions/UsingCultureAttribute.cs
@@ -1,0 +1,76 @@
+﻿namespace Nancy.Tests.xUnitExtensions
+{
+    using System;
+    using System.Globalization;
+    using System.Reflection;
+    using System.Threading;
+    using Xunit.Sdk;
+
+    /// <summary>
+    /// Attribute that is applied to a method to indicate that it should be run using a particular
+    /// culture (and UI culture).
+    /// Applies the named culture before running the method and restores the original one after.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public sealed class UsingCultureAttribute : BeforeAfterTestAttribute
+    {
+        private readonly string cultureName;
+
+        private CultureInfo originalCulture;
+        private CultureInfo originalUiCulture;
+
+        /// <summary>
+        /// Create an instance of <see cref="UsingCultureAttribute"/> that will apply the
+        /// name culture during the execution of the decorated method.
+        /// </summary>
+        /// <param name="cultureName">The name of the culture to use.</param>
+        /// <example>
+        ///   <code>
+        ///     [Fact]
+        ///     [UsingCulture("de-DE")]
+        ///     public void Should_Behave_In_Some_Way()
+        ///     …
+        ///   </code>
+        /// </example>
+        public UsingCultureAttribute(string cultureName)
+        {
+            this.cultureName = cultureName;
+        }
+
+        /// <summary>
+        /// This method is called after the test method is executed. It restores the original
+        /// current culture and current UI culture in effect before the test method was run.
+        /// </summary>
+        /// <param name="methodUnderTest">The method under test</param>
+        public override void After(MethodInfo methodUnderTest)
+        {
+#if CORE
+            CultureInfo.CurrentCulture = this.originalCulture;
+            CultureInfo.CurrentUICulture = this.originalUiCulture;
+#else
+            Thread.CurrentThread.CurrentCulture = this.originalCulture;
+            Thread.CurrentThread.CurrentUICulture = this.originalUiCulture;
+#endif
+        }
+
+        /// <summary>
+        /// This method is called before the test method is executed. It switches the current
+        /// culture and current UI culture to the culture chosen when this instance was created.
+        /// </summary>
+        /// <param name="methodUnderTest">The method under test</param>
+        public override void Before(MethodInfo methodUnderTest)
+        {
+#if CORE
+            this.originalCulture = CultureInfo.CurrentCulture;
+            this.originalUiCulture = CultureInfo.CurrentUICulture;
+            CultureInfo.CurrentCulture = new CultureInfo(this.cultureName);
+            CultureInfo.CurrentUICulture = new CultureInfo(this.cultureName);
+#else
+            this.originalCulture = Thread.CurrentThread.CurrentCulture;
+            this.originalUiCulture = Thread.CurrentThread.CurrentUICulture;
+            Thread.CurrentThread.CurrentCulture = new CultureInfo(this.cultureName);
+            Thread.CurrentThread.CurrentUICulture = new CultureInfo(this.cultureName);
+#endif
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description

Supports #2612.

A preliminary attempt to convert Nancy.Tests to target a netcoreapp1.0.
I expect I've done many things wrong, and invite corrections.
I'll highlight what I think are the most egregious violations.

- update FakeItEasy to 3.0.0-alpha001
- add workaround so FakeItEasy gets required Castle.Core-beta002
- poorly patch the build so the project compiles and tests run

- currently
  - ~~`CookieBasedSessionsFixture.Should_load_valid_test_data` fails~~, and
  - ~~`DefaultNancyBootstrapperFixture.Container_should_ignore_specified_assemblies`
    is conditionally compiled out~~
