### PR TITLE
Build script cleanup

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -196,23 +196,24 @@ Task("Package-NuGet")
 });
 
 Task("Publish-NuGet")
-  .Description("Pushes the nuget packages in the nuget folder to a NuGet source. Also publishes the packages into the feeds.")
-  .Does(() =>
+    .Description("Pushes the nuget packages in the nuget folder to a NuGet source. Also publishes the packages into the feeds.")
+    .Does(() =>
 {
-  // Make sure we have an API key.
-  if(string.IsNullOrWhiteSpace(apiKey)){
-    throw new CakeException("No NuGet API key provided.");
-  }
+    if(string.IsNullOrWhiteSpace(apiKey)){
+        throw new CakeException("No NuGet API key provided.");
+    }
 
-  // Upload every package to the provided NuGet source (defaults to nuget.org).
-  var packages = GetFiles(outputNuGet.Path.FullPath + "/*" + version + ".nupkg");
-  foreach(var package in packages)
-  {
-    NuGetPush(package, new NuGetPushSettings {
-      Source = source,
-      ApiKey = apiKey
-    });
-  }
+    var packages =
+        GetFiles(outputNuGet.Path.FullPath + "/*.nupkg") -
+        GetFiles(outputNuGet.Path.FullPath + "/*.symbols.nupkg");
+
+    foreach(var package in packages)
+    {
+        NuGetPush(package, new NuGetPushSettings {
+            Source = source,
+            ApiKey = apiKey
+        });
+    }
 });
 
 ///////////////////////////////////////////////////////////////
@@ -319,7 +320,6 @@ public void UpdateProjectJsonVersion(string version, FilePathCollection filePath
         System.IO.File.WriteAllText(file.FullPath, project, Encoding.UTF8);
     }
 }
-
 
 Task("Default")
     .IsDependentOn("Test")

--- a/build.cake
+++ b/build.cake
@@ -229,8 +229,8 @@ Task("Tag")
 Task("Prepare-Release")
   .Does(() =>
 {
-  // Update version.
-  UpdateProjectJsonVersion(version, projectJsonFiles);
+    // Update version.
+    UpdateProjectJsonVersion(version, projectJsonFiles);
 
     // Add
     foreach (var file in projectJsonFiles)
@@ -292,36 +292,42 @@ Task("Prepare-Release")
 Task("Update-Version")
   .Does(() =>
 {
-  if(string.IsNullOrWhiteSpace(version)) {
-    throw new CakeException("No version specified!");
-  }
+    if(string.IsNullOrWhiteSpace(version)) {
+        throw new CakeException("No version specified!");
+    }
 
-  UpdateProjectJsonVersion(version, projectJsonFiles);
+    UpdateProjectJsonVersion(version, projectJsonFiles);
 });
 
 ///////////////////////////////////////////////////////////////
 
 public void UpdateProjectJsonVersion(string version, FilePathCollection filePaths)
 {
-  Verbose(logAction => logAction("Setting version to {0}", version));
-  foreach (var file in filePaths)
-  {
-    var project = System.IO.File.ReadAllText(file.FullPath, Encoding.UTF8);
+    Verbose(logAction => logAction("Setting version to {0}", version));
 
-    project = System.Text.RegularExpressions.Regex.Replace(project, "(\"version\":\\s*)\".+\"", "$1\"" + version + "\"");
+    foreach (var file in filePaths)
+    {
+        var project =
+            System.IO.File.ReadAllText(file.FullPath, Encoding.UTF8);
 
-    System.IO.File.WriteAllText(file.FullPath, project, Encoding.UTF8);
-  }
+        var projectVersion =
+            new System.Text.RegularExpressions.Regex("(\"version\":\\s*)\".+\"");
+
+        project =
+            projectVersion.Replace(project, "$1\"" + version + "\"", 1);
+
+        System.IO.File.WriteAllText(file.FullPath, project, Encoding.UTF8);
+    }
 }
 
 
 Task("Default")
-  .IsDependentOn("Test")
-  .IsDependentOn("Update-Version")
-  .IsDependentOn("Package-NuGet");
+    .IsDependentOn("Test")
+    .IsDependentOn("Update-Version")
+    .IsDependentOn("Package-NuGet");
 
 Task("Mono")
-  .IsDependentOn("Test");
+    .IsDependentOn("Test");
 
 ///////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
- Updated the way that the `UpdateProjectJsonVersion`, in `build.cake` updates the version number. It will now only update the first occurrence (which should always be the project one)
- Updated the `Publish-NuGet` task so that it filters out `*.symbols.nupkg`
- Some other white-space / indentation tweaks