### PR TITLE
Included app/web.config.transform files in nuget packages

### DIFF
--- a/src/Nancy.Hosting.Aspnet/project.json
+++ b/src/Nancy.Hosting.Aspnet/project.json
@@ -7,16 +7,21 @@
         "tags": [ "Nancy", "Host" ],
         "projectUrl": "http://nancyfx.org",
         "licenseUrl": "https://github.com/NancyFx/Nancy/blob/master/license.txt",
-        "iconUrl": "http://nancyfx.org/nancy-nuget.png"
+        "iconUrl": "http://nancyfx.org/nancy-nuget.png",
+        "files": {
+            "mappings": {
+                "content/web.config.transform": "./web.config.transform"
+            }
+        }
     },
-    
+
     "buildOptions": {
         "xmlDoc": true
     },
 
     "dependencies": {
-      "AsyncUsageAnalyzers": "1.0.0-alpha003",
-      "Nancy": { "target": "project" }
+        "AsyncUsageAnalyzers": "1.0.0-alpha003",
+        "Nancy": { "target": "project" }
     },
 
     "frameworks": {

--- a/src/Nancy.ViewEngines.Razor/project.json
+++ b/src/Nancy.ViewEngines.Razor/project.json
@@ -7,14 +7,20 @@
         "tags": [ "Nancy", "View Engine", "Razor" ],
         "projectUrl": "http://nancyfx.org",
         "licenseUrl": "https://github.com/NancyFx/Nancy/blob/master/license.txt",
-        "iconUrl": "http://nancyfx.org/nancy-nuget.png"
+        "iconUrl": "http://nancyfx.org/nancy-nuget.png",
+        "files": {
+            "mappings": {
+                "content/app.config.transform": "./app.config.transform",
+                "content/web.config.transform": "./web.config.transform"
+            }
+        }
     },
 
     "dependencies": {
         "Nancy": { "target": "project" },
         "Microsoft.AspNet.Razor": "2.0.30506.0",
-      "Microsoft.CodeAnalysis.CSharp": "1.1.0-rc1-20151109-01",
-      "AsyncUsageAnalyzers": "1.0.0-alpha003"
+        "Microsoft.CodeAnalysis.CSharp": "1.1.0-rc1-20151109-01",
+        "AsyncUsageAnalyzers": "1.0.0-alpha003"
     },
 
     "buildOptions": {


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [X] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [X] I have provided test coverage for my change (where applicable)

### Description
We were not including `web.config.transform` in the NuGet packages for `Nancy.Hosting.Aspnet` and `Nancy.ViewEngines.Razor`. They were missing in the `packOptions` in the `project.json` definitions.