### PR TITLE
Use a better error message when picking a fluent validator is ambiguous

### DIFF
--- a/src/Nancy.Validation.FluentValidation/FluentValidationValidatorFactory.cs
+++ b/src/Nancy.Validation.FluentValidation/FluentValidationValidatorFactory.cs
@@ -51,9 +51,12 @@
             if (available.Length > 1)
             {
                 var names = string.Join(", ", available.Select(v => v.GetType().Name));
-                var message =
-                    $"Ambiguous choice between multiple validators for type {type.Name}. "
-                    + $"The validators available are: {names}";
+                var message = string.Concat(
+                    "Ambiguous choice between multiple validators for type ",
+					type.Name,
+					". The validators available are: ",
+					names);
+
                 throw new InvalidOperationException(message);
             }
 

--- a/src/Nancy.Validation.FluentValidation/FluentValidationValidatorFactory.cs
+++ b/src/Nancy.Validation.FluentValidation/FluentValidationValidatorFactory.cs
@@ -45,9 +45,19 @@
         {
             var fullType =
                 CreateValidatorType(type);
+            var available = this.validators
+                .Where(validator => fullType.GetTypeInfo().IsAssignableFrom(validator.GetType()))
+                .ToArray();
+            if (available.Length > 1)
+            {
+                var names = string.Join(", ", available.Select(v => v.GetType().Name));
+                var message =
+                    $"Ambiguous choice between multiple validators for type {type.Name}. "
+                    + $"The validators available are: {names}";
+                throw new InvalidOperationException(message);
+            }
 
-            return this.validators
-                .SingleOrDefault(validator => fullType.GetTypeInfo().IsAssignableFrom(validator.GetType()));
+            return available.FirstOrDefault();
         }
 
         private static Type CreateValidatorType(Type type)

--- a/src/Nancy.Validation.FluentValidation/FluentValidationValidatorFactory.cs
+++ b/src/Nancy.Validation.FluentValidation/FluentValidationValidatorFactory.cs
@@ -48,6 +48,7 @@
             var available = this.validators
                 .Where(validator => fullType.GetTypeInfo().IsAssignableFrom(validator.GetType()))
                 .ToArray();
+
             if (available.Length > 1)
             {
                 var names = string.Join(", ", available.Select(v => v.GetType().Name));


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)
  _could not find a test project for `Nancy.Validation.FluentValidation`_

### Description

When more than one fluent validator exists for a given type, `FluentValidationValidatorFactory` throws an `InvalidOperationException`.

This commit doesn't change that behavior, but does make it friendlier to debug by listing the matching validator types.