### PR TITLE
Removed GetAwaiter on Response

### DIFF
--- a/src/Nancy/Response.cs
+++ b/src/Nancy/Response.cs
@@ -37,15 +37,6 @@ namespace Nancy
         }
 
         /// <summary>
-        /// Gets the awaiter.
-        /// </summary>
-        /// <returns><see cref="TaskAwaiter{Response}"/></returns>
-        public TaskAwaiter<Response> GetAwaiter()
-        {
-            return Task.FromResult(this).GetAwaiter();
-        }
-
-        /// <summary>
         /// Gets or sets the type of the content.
         /// </summary>
         /// <value>The type of the content.</value>


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [X] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [X] I have provided test coverage for my change (where applicable)

### Description
Removed the `GetAwaiter` method on `Response`. It was accidentally included when we added the new route syntax. 

Closes #2518