### PR TITLE
Fixed build warnings in src/Nancy

### DIFF
--- a/src/Nancy.MSBuild/Nancy.csproj
+++ b/src/Nancy.MSBuild/Nancy.csproj
@@ -978,9 +978,6 @@
     <Compile Include="..\Nancy\Localization\ResourceBasedTextResource.cs">
       <Link>Localization\ResourceBasedTextResource.cs</Link>
     </Compile>
-    <Compile Include="..\Nancy\ViewEngines\DefaultViewRenderer.cs">
-      <Link>ViewEngines\DefaultViewRenderer.cs</Link>
-    </Compile>
     <Compile Include="..\Nancy\ViewEngines\DefaultViewCache.cs">
       <Link>ViewEngines\DefaultViewCache.cs</Link>
     </Compile>
@@ -1280,9 +1277,6 @@
     </Compile>
     <Compile Include="..\Nancy\ViewEngines\IViewFactory.cs">
       <Link>ViewEngines\IViewFactory.cs</Link>
-    </Compile>
-    <Compile Include="..\Nancy\ViewEngines\IViewRenderer.cs">
-      <Link>ViewEngines\IViewRenderer.cs</Link>
     </Compile>
     <Compile Include="..\Nancy\ViewEngines\IViewResolver.cs">
       <Link>ViewEngines\IViewResolver.cs</Link>

--- a/src/Nancy/AfterPipeline.cs
+++ b/src/Nancy/AfterPipeline.cs
@@ -5,17 +5,14 @@ namespace Nancy
     using System.Threading.Tasks;
     using Nancy.Helpers;
 
-
     /// <summary>
     /// Intercepts the request after the appropriate route handler has completed its operation.
-    /// The After hooks does not have any return value because one has already been produced by the appropriate route. 
+    /// The After hooks does not have any return value because one has already been produced by the appropriate route.
     /// Instead you get the option to modify (or completely replace) the existing response by accessing the Response property of the NancyContext that is passed in.
     /// </summary>
-    /// <seealso cref="Nancy.AsyncNamedPipelineBase{System.Func{Nancy.NancyContext, System.Threading.CancellationToken, System.Threading.Tasks.Task}, System.Action{Nancy.NancyContext}}" />
+    /// <seealso cref="AsyncNamedPipelineBase{TAsyncDelegate,TSyncDelegate}" />
     public class AfterPipeline : AsyncNamedPipelineBase<Func<NancyContext, CancellationToken, Task>, Action<NancyContext>>
     {
-        private static readonly Task completeTask = TaskHelpers.CompletedTask;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="AfterPipeline"/> class.
         /// </summary>

--- a/src/Nancy/AsyncNamedPipelineBase.cs
+++ b/src/Nancy/AsyncNamedPipelineBase.cs
@@ -17,7 +17,7 @@
         protected readonly List<PipelineItem<TAsyncDelegate>> pipelineItems;
 
         /// <summary>
-        /// Creates a new instance of <see cref="AsyncNamedPipelineBase"/>
+        /// Creates a new instance of <see cref="AsyncNamedPipelineBase{TAsyncDelegate,TSyncDelegate}"/>
         /// </summary>
         protected AsyncNamedPipelineBase()
         {
@@ -25,7 +25,7 @@
         }
 
         /// <summary>
-        /// Creates a new instance of <see cref="AsyncNamedPipelineBase"/> with size
+        /// Creates a new instance of <see cref="AsyncNamedPipelineBase{TAsyncDelegate,TSyncDelegate}"/> with size
         /// </summary>
         /// <param name="capacity">Number of delegates in pipeline</param>
         protected AsyncNamedPipelineBase(int capacity)
@@ -229,7 +229,7 @@
         public virtual void InsertBefore(string name, PipelineItem<TAsyncDelegate> item)
         {
             var existingIndex =
-                this.pipelineItems.FindIndex(i => String.Equals(name, i.Name, StringComparison.Ordinal));
+                this.pipelineItems.FindIndex(i => string.Equals(name, i.Name, StringComparison.Ordinal));
 
             if (existingIndex == -1)
             {
@@ -281,7 +281,7 @@
         public virtual void InsertAfter(string name, PipelineItem<TAsyncDelegate> item)
         {
             var existingIndex =
-                this.pipelineItems.FindIndex(i => String.Equals(name, i.Name, StringComparison.Ordinal));
+                this.pipelineItems.FindIndex(i => string.Equals(name, i.Name, StringComparison.Ordinal));
 
             if (existingIndex == -1)
             {
@@ -324,7 +324,7 @@
             }
 
             var existingIndex =
-                this.pipelineItems.FindIndex(i => String.Equals(name, i.Name, StringComparison.Ordinal));
+                this.pipelineItems.FindIndex(i => string.Equals(name, i.Name, StringComparison.Ordinal));
 
             if (existingIndex != -1)
             {

--- a/src/Nancy/BeforePipeline.cs
+++ b/src/Nancy/BeforePipeline.cs
@@ -7,10 +7,10 @@
 
     /// <summary>
     /// Intercepts the request before it is passed to the appropriate route handler.
-    /// This gives you a couple of possibilities such as modifying parts of the request 
+    /// This gives you a couple of possibilities such as modifying parts of the request
     /// or even prematurely aborting the request by returning a response that will be sent back to the caller.
     /// </summary>
-    /// <seealso cref="AsyncNamedPipelineBase" />
+    /// <seealso cref="AsyncNamedPipelineBase{TAsyncDelegate,TSyncDelegate}" />
     public class BeforePipeline : AsyncNamedPipelineBase<Func<NancyContext, CancellationToken, Task<Response>>, Func<NancyContext, Response>>
     {
 
@@ -31,7 +31,7 @@
         }
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="BeforePipeline"/> to <see cref="Func{NancyContext, CancellationToken, Task{Response}}"/>.
+        /// Performs an implicit conversion from <see cref="BeforePipeline"/> to <see cref="Func{TNancyContext, TCancellationToken, TTaskResponse}"/>.
         /// </summary>
         /// <param name="pipeline">The <see cref="BeforePipeline"/>.</param>
         /// <returns>
@@ -44,9 +44,9 @@
 
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="Func{NancyContext, CancellationToken, Task{Response}}"/> to <see cref="BeforePipeline"/>.
+        /// Performs an implicit conversion from <see cref="Func{TNancyContext, TCancellationToken, TTaskResponse}"/> to <see cref="BeforePipeline"/>.
         /// </summary>
-        /// <param name="func">A <see cref="Func{NancyContext, CancellationToken, Task{Response}}"/>.</param>
+        /// <param name="func">A <see cref="Func{TNancyContext, TCancellationToken, TTaskResponse}"/>.</param>
         /// <returns>
         /// A new <see cref="BeforePipeline"/> instance with <paramref name="func"/>.
         /// </returns>
@@ -61,7 +61,7 @@
         /// Appends a new function to the <see cref="BeforePipeline"/>.
         /// </summary>
         /// <param name="pipeline">The <see cref="BeforePipeline"/> instance.</param>
-        /// <param name="func">A <see cref="Func{NancyContext, CancellationToken, Task{Response}}"/></param>
+        /// <param name="func">A <see cref="Func{TNancyContext, TCancellationToken, TTaskResponse}"/></param>
         /// <returns>
         /// <paramref name="pipeline"/> with <paramref name="func"/> added
         /// </returns>
@@ -112,7 +112,7 @@
         /// <param name="context">The <see cref="NancyContext"/> instance.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> instance.</param>
         /// <returns>
-        /// A <see cref="Response"/> instance or <see langword="null" /> 
+        /// A <see cref="Response"/> instance or <see langword="null" />
         /// </returns>
         public async Task<Response> Invoke(NancyContext context, CancellationToken cancellationToken)
         {

--- a/src/Nancy/Conventions/CultureConventions.cs
+++ b/src/Nancy/Conventions/CultureConventions.cs
@@ -9,7 +9,7 @@
     /// <summary>
     /// Collection class for static culture conventions
     /// </summary>
-    /// <seealso cref="System.Collections.Generic.IEnumerable{System.Func{Nancy.NancyContext, Nancy.GlobalizationConfiguration, System.Globalization.CultureInfo}}" />
+    /// <seealso cref="Func{TContext, TGlobalizationConfiguration, TResult}" />
     public class CultureConventions : IEnumerable<Func<NancyContext, GlobalizationConfiguration, CultureInfo>>
     {
         private readonly IEnumerable<Func<NancyContext, GlobalizationConfiguration, CultureInfo>> conventions;
@@ -33,12 +33,12 @@
         /// </returns>
         public IEnumerator<Func<NancyContext, GlobalizationConfiguration, CultureInfo>> GetEnumerator()
         {
-            return conventions.GetEnumerator();
+            return this.conventions.GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetEnumerator();
+            return this.GetEnumerator();
         }
     }
 }

--- a/src/Nancy/Diagnostics/DiagnosticsHook.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsHook.cs
@@ -176,7 +176,6 @@ namespace Nancy.Diagnostics
             if (ctx.Response == null)
             {
                 var routeResult = resolveResult.Route.Invoke(resolveResult.Parameters, CancellationToken);
-                routeResult.Wait();
 
                 ctx.Response = (Response)routeResult.Result;
             }

--- a/src/Nancy/DynamicDictionary.cs
+++ b/src/Nancy/DynamicDictionary.cs
@@ -81,7 +81,7 @@
         /// <param name="binder">Provides information about the object that called the dynamic operation. The binder.Name property provides the name of the member on which the dynamic operation is performed. For example, for the Console.WriteLine(sampleObject.SampleProperty) statement, where sampleObject is an instance of the class derived from the <see cref="T:System.Dynamic.DynamicObject"/> class, binder.Name returns "SampleProperty". The binder.IgnoreCase property specifies whether the member name is case-sensitive.</param><param name="result">The result of the get operation. For example, if the method is called for a property, you can assign the property value to <paramref name="result"/>.</param>
         public override bool TryGetMember(GetMemberBinder binder, out object result)
         {
-            if (!dictionary.TryGetValue(binder.Name, out result))
+            if (!this.dictionary.TryGetValue(binder.Name, out result))
             {
                 result = new DynamicDictionaryValue(null, this.globalizationConfiguration);
             }
@@ -95,7 +95,7 @@
         /// <returns>A <see cref="IEnumerable{T}"/> that contains dynamic member names.</returns>
         public override IEnumerable<string> GetDynamicMemberNames()
         {
-            return dictionary.Keys;
+            return this.dictionary.Keys;
         }
 
         /// <summary>
@@ -104,7 +104,7 @@
         /// <returns>A <see cref="IEnumerable{T}"/> that contains dynamic member names.</returns>
         public IEnumerator<string> GetEnumerator()
         {
-            return dictionary.Keys.GetEnumerator();
+            return this.dictionary.Keys.GetEnumerator();
         }
 
         /// <summary>
@@ -113,7 +113,7 @@
         /// <returns>A <see cref="IEnumerator"/> that contains dynamic member names.</returns>
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return dictionary.Keys.GetEnumerator();
+            return this.dictionary.Keys.GetEnumerator();
         }
 
         /// <summary>
@@ -127,7 +127,7 @@
                 name = GetNeutralKey(name);
 
                 dynamic member;
-                if (!dictionary.TryGetValue(name, out member))
+                if (!this.dictionary.TryGetValue(name, out member))
                 {
                     member = new DynamicDictionaryValue(null, this.globalizationConfiguration);
                 }
@@ -138,7 +138,7 @@
             {
                 name = GetNeutralKey(name);
 
-                dictionary[name] = value is DynamicDictionaryValue ? value : new DynamicDictionaryValue(value, this.globalizationConfiguration);
+                this.dictionary[name] = value is DynamicDictionaryValue ? value : new DynamicDictionaryValue(value, this.globalizationConfiguration);
             }
         }
 
@@ -192,7 +192,7 @@
         /// <returns> A hash code for this <see cref="DynamicDictionary"/>, suitable for use in hashing algorithms and data structures like a hash table.</returns>
         public override int GetHashCode()
         {
-            return (dictionary != null ? dictionary.GetHashCode() : 0);
+            return (this.dictionary != null ? this.dictionary.GetHashCode() : 0);
         }
 
         /// <summary>
@@ -353,7 +353,7 @@
         {
             var data = new Dictionary<string, object>();
 
-            foreach (var item in dictionary)
+            foreach (var item in this.dictionary)
             {
                 var newKey = item.Key;
                 var newValue = ((DynamicDictionaryValue)item.Value).Value;

--- a/src/Nancy/DynamicDictionaryValue.cs
+++ b/src/Nancy/DynamicDictionaryValue.cs
@@ -196,7 +196,7 @@
         /// <summary>
         /// Determines whether the specified <see cref="object"/> is equal to the current <see cref="object"/>.
         /// </summary>
-        /// <returns><see langword="true"/> if the specified <see cref="object"/> is equal to the current <see cref="DynamicDictionaryValue"/>; otherwise, <see langword="false/>.</returns>
+        /// <returns><see langword="true"/> if the specified <see cref="object"/> is equal to the current <see cref="DynamicDictionaryValue"/>; otherwise, <see langword="false"/>.</returns>
         /// <param name="compareValue">The <see cref="object"/> to compare with the current <see cref="DynamicDictionaryValue"/>.</param>
         public override bool Equals(object compareValue)
         {
@@ -294,7 +294,7 @@
             else if (binderType.GetTypeInfo().IsEnum)
             {
                 // handles enum to enum assignments
-                if (value.GetType().GetTypeInfo().IsEnum)
+                if (this.value.GetType().GetTypeInfo().IsEnum)
                 {
                     if (binderType == this.value.GetType())
                     {
@@ -337,9 +337,9 @@
                 }
 
 #if !NETSTANDARD1_6
-                result = Convert.ChangeType(value, typeCode);
+                result = Convert.ChangeType(this.value, typeCode);
 #else
-                result = Convert.ChangeType(value, binderType);
+                result = Convert.ChangeType(this.value, binderType);
 #endif
 
                 return true;
@@ -360,7 +360,7 @@
 
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="DynamicDictionaryValue"/> to <see cref="System.Nullable{System.Boolean}"/>.
+        /// Performs an implicit conversion from <see cref="DynamicDictionaryValue"/> to <see cref="Nullable{T}"/>.
         /// </summary>
         /// <param name="dynamicValue">The <see cref="DynamicDictionaryValue"/> instance</param>
         /// <returns>
@@ -423,7 +423,7 @@
 
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="DynamicDictionaryValue"/> to <see cref="System.Nullable{System.Int32}"/>.
+        /// Performs an implicit conversion from <see cref="DynamicDictionaryValue"/> to <see cref="Nullable{T}"/>.
         /// </summary>
         /// <param name="dynamicValue">The <see cref="DynamicDictionaryValue"/> instance</param>
         /// <returns>
@@ -629,7 +629,7 @@
 
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="DynamicDictionaryValue"/> to <see cref="System.Nullable{System.Single}"/>.
+        /// Performs an implicit conversion from <see cref="DynamicDictionaryValue"/> to <see cref="Nullable{T}"/>.
         /// </summary>
         /// <param name="dynamicValue">The <see cref="DynamicDictionaryValue"/> instance</param>
         /// <returns>
@@ -672,7 +672,7 @@
 
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="DynamicDictionaryValue"/> to <see cref="System.Nullable{System.Decimal}"/>.
+        /// Performs an implicit conversion from <see cref="DynamicDictionaryValue"/> to <see cref="Nullable{T}"/>.
         /// </summary>
         /// <param name="dynamicValue">The <see cref="DynamicDictionaryValue"/> instance</param>
         /// <returns>
@@ -715,7 +715,7 @@
 
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="DynamicDictionaryValue"/> to <see cref="System.Nullable{System.Double}"/>.
+        /// Performs an implicit conversion from <see cref="DynamicDictionaryValue"/> to <see cref="Nullable{T}"/>.
         /// </summary>
         /// <param name="dynamicValue">The <see cref="DynamicDictionaryValue"/> instance</param>
         /// <returns>
@@ -765,8 +765,12 @@
         /// <filterpriority>2</filterpriority>
         public TypeCode GetTypeCode()
         {
-            if (value == null) return TypeCode.Empty;
-            return value.GetType().GetTypeCode();
+            if (this.value == null)
+            {
+                return TypeCode.Empty;
+            }
+
+            return this.value.GetType().GetTypeCode();
         }
 
         /// <summary>
@@ -778,7 +782,7 @@
         /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
         public bool ToBoolean(IFormatProvider provider)
         {
-            return Convert.ToBoolean(value, provider);
+            return Convert.ToBoolean(this.value, provider);
         }
 
         /// <summary>
@@ -790,7 +794,7 @@
         /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
         public char ToChar(IFormatProvider provider)
         {
-            return Convert.ToChar(value, provider);
+            return Convert.ToChar(this.value, provider);
         }
 
         /// <summary>
@@ -802,7 +806,7 @@
         /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
         public sbyte ToSByte(IFormatProvider provider)
         {
-            return Convert.ToSByte(value, provider);
+            return Convert.ToSByte(this.value, provider);
         }
 
         /// <summary>
@@ -814,7 +818,7 @@
         /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
         public byte ToByte(IFormatProvider provider)
         {
-            return Convert.ToByte(value, provider);
+            return Convert.ToByte(this.value, provider);
         }
 
         /// <summary>
@@ -826,7 +830,7 @@
         /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
         public short ToInt16(IFormatProvider provider)
         {
-            return Convert.ToInt16(value, provider);
+            return Convert.ToInt16(this.value, provider);
         }
 
         /// <summary>
@@ -838,7 +842,7 @@
         /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
         public ushort ToUInt16(IFormatProvider provider)
         {
-            return Convert.ToUInt16(value, provider);
+            return Convert.ToUInt16(this.value, provider);
         }
 
         /// <summary>
@@ -850,7 +854,7 @@
         /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
         public int ToInt32(IFormatProvider provider)
         {
-            return Convert.ToInt32(value, provider);
+            return Convert.ToInt32(this.value, provider);
         }
 
         /// <summary>
@@ -862,7 +866,7 @@
         /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
         public uint ToUInt32(IFormatProvider provider)
         {
-            return Convert.ToUInt32(value, provider);
+            return Convert.ToUInt32(this.value, provider);
         }
 
         /// <summary>
@@ -874,7 +878,7 @@
         /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
         public long ToInt64(IFormatProvider provider)
         {
-            return Convert.ToInt64(value, provider);
+            return Convert.ToInt64(this.value, provider);
         }
 
         /// <summary>
@@ -886,7 +890,7 @@
         /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
         public ulong ToUInt64(IFormatProvider provider)
         {
-            return Convert.ToUInt64(value, provider);
+            return Convert.ToUInt64(this.value, provider);
         }
 
         /// <summary>
@@ -898,7 +902,7 @@
         /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
         public float ToSingle(IFormatProvider provider)
         {
-            return Convert.ToSingle(value, provider);
+            return Convert.ToSingle(this.value, provider);
         }
 
         /// <summary>
@@ -910,7 +914,7 @@
         /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
         public double ToDouble(IFormatProvider provider)
         {
-            return Convert.ToDouble(value, provider);
+            return Convert.ToDouble(this.value, provider);
         }
 
         /// <summary>
@@ -922,7 +926,7 @@
         /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
         public decimal ToDecimal(IFormatProvider provider)
         {
-            return Convert.ToDecimal(value, provider);
+            return Convert.ToDecimal(this.value, provider);
         }
 
         /// <summary>
@@ -934,7 +938,7 @@
         /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
         public DateTime ToDateTime(IFormatProvider provider)
         {
-            return Convert.ToDateTime(value, provider);
+            return Convert.ToDateTime(this.value, provider);
         }
 
         /// <summary>
@@ -946,7 +950,7 @@
         /// <param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
         public string ToString(IFormatProvider provider)
         {
-            return Convert.ToString(value, provider);
+            return Convert.ToString(this.value, provider);
         }
 
         /// <summary>
@@ -958,7 +962,7 @@
         /// <param name="conversionType">The <see cref="T:System.Type"/> to which the value of this instance is converted. </param><param name="provider">An <see cref="T:System.IFormatProvider"/> interface implementation that supplies culture-specific formatting information. </param><filterpriority>2</filterpriority>
         public object ToType(Type conversionType, IFormatProvider provider)
         {
-            return Convert.ChangeType(value, conversionType, provider);
+            return Convert.ChangeType(this.value, conversionType, provider);
         }
 
 #endregion

--- a/src/Nancy/Json/Json.cs
+++ b/src/Nancy/Json/Json.cs
@@ -30,6 +30,9 @@ namespace Nancy.Json
 {
     using System;
 
+    /// <summary>
+    /// JSON Helper Class.
+    /// </summary>
     public static class Json
     {
         private const StringComparison ComparisonType = StringComparison.OrdinalIgnoreCase;

--- a/src/Nancy/Json/Simple/NancySerializationStrategy.cs
+++ b/src/Nancy/Json/Simple/NancySerializationStrategy.cs
@@ -136,6 +136,11 @@
             return genericTypeConverter.Deserialize(values, type);
         }
 
+        /// <summary>
+        /// Serializes an <see cref="Enum"/>.
+        /// </summary>
+        /// <param name="p">The enum value to serialize.</param>
+        /// <returns>The serialized value.</returns>
         protected override object SerializeEnum(Enum p)
         {
             if (this.serializeEnumToString)

--- a/src/Nancy/NancyEngine.cs
+++ b/src/Nancy/NancyEngine.cs
@@ -264,7 +264,7 @@
             {
                 handler.Handle(context.Response.StatusCode, context);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 if (defaultHandler == null)
                 {

--- a/src/Nancy/PipelineItem.cs
+++ b/src/Nancy/PipelineItem.cs
@@ -36,7 +36,7 @@
 
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="TDelegate"/> to <see cref="PipelineItem{TDelegate}"/>.
+        /// Performs an implicit conversion from <typeparamref name="TDelegate"/> cref="TDelegate"/> to <see cref="PipelineItem{TDelegate}"/>.
         /// </summary>
         /// <param name="action">The action.</param>
         /// <returns>
@@ -48,7 +48,7 @@
         }
 
         /// <summary>
-        /// Performs an implicit conversion from <see cref="PipelineItem{TDelegate}"/> to <see cref="TDelegate"/>.
+        /// Performs an implicit conversion from <see cref="PipelineItem{TDelegate}"/> to <typeparamref name="TDelegate"/>.
         /// </summary>
         /// <param name="pipelineItem">The pipeline item.</param>
         /// <returns>

--- a/test/Nancy.Tests.MSBuild/Nancy.Tests.csproj
+++ b/test/Nancy.Tests.MSBuild/Nancy.Tests.csproj
@@ -75,7 +75,8 @@
     <OutputPath>bin\MonoRelease\</OutputPath>
     <DefineConstants>TRACE;MONO</DefineConstants>
     <Optimize>true</Optimize>
-    <DebugType></DebugType>
+    <DebugType>
+    </DebugType>
     <PlatformTarget>anycpu</PlatformTarget>
     <CodeAnalysisLogFile>bin\Release\Nancy.Tests.dll.CodeAnalysisLog.xml</CodeAnalysisLogFile>
     <CodeAnalysisUseTypeNameInSuppression>true</CodeAnalysisUseTypeNameInSuppression>
@@ -602,9 +603,6 @@
     </Compile>
     <Compile Include="..\Nancy.Tests\Fakes\FakeViewEngine.cs">
       <Link>Fakes\FakeViewEngine.cs</Link>
-    </Compile>
-    <Compile Include="..\Nancy.Tests\Unit\ViewEngines\DefaultViewRendererFixture.cs">
-      <Link>Unit\ViewEngines\DefaultViewRendererFixture.cs</Link>
     </Compile>
     <Compile Include="..\Nancy.Tests\Unit\ViewEngines\FileSystemViewLocationProviderFixture.cs">
       <Link>Unit\ViewEngines\FileSystemViewLocationProviderFixture.cs</Link>


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [X] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [X] I have provided test coverage for my change (where applicable)

### Description
Fixed build warnings. The following was changed

- Fixed invalid XML comments
- Added missing XML comments
- Added a couple of missing `this.`
- Changes a couple of `String` to `string`
- Wrapped a single line `if`-statement in curly-braces

The one code change that went in was in [DiagnosticsHook](https://github.com/NancyFx/Nancy/pull/2667/files#diff-5f26f534f32bbe24db978e4c188e3206R191) where we don't really do async handling and we were calling on a method that returns `Task`. I've changed that to `Wait()` on the task 