### PR TITLE
Fixes Diagnostics Info Module for Bootstrappers Without Default constructors

### DIFF
--- a/src/Nancy/Bootstrapper/NancyBootstrapperLocator.cs
+++ b/src/Nancy/Bootstrapper/NancyBootstrapperLocator.cs
@@ -41,12 +41,15 @@
             }
         }
 
-        private static IReadOnlyCollection<Type> GetAvailableBootstrapperTypes()
+        private static ITypeCatalog GetDefaultTypeCatalog()
         {
             var assemblies = GetAssemblyCatalog();
 
-            var types = new DefaultTypeCatalog(assemblies);
+            return new DefaultTypeCatalog(assemblies);
+        }
 
+        private static IReadOnlyCollection<Type> GetAvailableBootstrapperTypes(ITypeCatalog types)
+        {
             return types.GetTypesAssignableTo<INancyBootstrapper>(TypeResolveStrategies.ExcludeNancy);
         }
 
@@ -79,9 +82,14 @@
         }
 #endif
 
-        private static Type GetBootstrapperType()
+        internal static Type GetBootstrapperType()
         {
-            var customBootstrappers = GetAvailableBootstrapperTypes();
+            return GetBootstrapperType(GetDefaultTypeCatalog());
+        }
+
+        internal static Type GetBootstrapperType(ITypeCatalog typeCatalog)
+        {
+            var customBootstrappers = GetAvailableBootstrapperTypes(typeCatalog);
 
             if (!customBootstrappers.Any())
             {

--- a/src/Nancy/Bootstrapper/NancyBootstrapperLocator.cs
+++ b/src/Nancy/Bootstrapper/NancyBootstrapperLocator.cs
@@ -43,9 +43,9 @@
 
         private static ITypeCatalog GetDefaultTypeCatalog()
         {
-            var assemblies = GetAssemblyCatalog();
+            var assemblyCatalog = GetAssemblyCatalog();
 
-            return new DefaultTypeCatalog(assemblies);
+            return new DefaultTypeCatalog(assemblyCatalog);
         }
 
         private static IReadOnlyCollection<Type> GetAvailableBootstrapperTypes(ITypeCatalog types)

--- a/src/Nancy/Diagnostics/Modules/InfoModule.cs
+++ b/src/Nancy/Diagnostics/Modules/InfoModule.cs
@@ -52,7 +52,7 @@
                 data.Nancy.RootPath = rootPathProvider.GetRootPath();
                 data.Nancy.Hosting = GetHosting();
                 data.Nancy.BootstrapperContainer = GetBootstrapperContainer();
-                data.Nancy.LocatedBootstrapper = NancyBootstrapperLocator.Bootstrapper.GetType().ToString();
+                data.Nancy.LocatedBootstrapper = NancyBootstrapperLocator.GetBootstrapperType().ToString();
                 data.Nancy.LoadedViewEngines = GetViewEngines();
 
                 data.Configuration = new Dictionary<string, object>();

--- a/test/Nancy.Tests/Unit/Bootstrapper/BootstrapperLocatorFixture.cs
+++ b/test/Nancy.Tests/Unit/Bootstrapper/BootstrapperLocatorFixture.cs
@@ -81,6 +81,50 @@
 
         }
 
+        public class TestTypeCatalog : ITypeCatalog
+        {
+            private readonly IReadOnlyCollection<Type> types;
+
+            public TestTypeCatalog(IReadOnlyCollection<Type> types)
+            {
+                this.types = types;
+            }
+
+            public IReadOnlyCollection<Type> GetTypesAssignableTo(Type type, TypeResolveStrategy strategy)
+            {
+                return types;
+            }
+        }
+
+        [Fact]
+        public void Should_throw_exception_when_multiple_bootstrappers_are_located()
+        {
+            // Given
+            var list = new List<Type> { typeof(MyFirstBootstwapper), typeof(AnotherFirstBootstwapper) };
+            var typeCatalog = new TestTypeCatalog(list);
+
+            // When
+            var result = Record.Exception(() => NancyBootstrapperLocator.GetBootstrapperType(typeCatalog));
+
+            // Then
+            result.ShouldNotBeNull();
+            result.GetType().ShouldEqual(typeof(BootstrapperException));
+        }
+
+        [Fact]
+        public void Should_resolve_bootstrapper_type_from_unique_type()
+        {
+            // Given
+            var list = new List<Type> {typeof (MyFirstBootstwapper)};
+            var typeCatalog = new TestTypeCatalog(list);
+
+            // When
+            var bootstrapperType = NancyBootstrapperLocator.GetBootstrapperType(typeCatalog);
+
+            // Then
+            bootstrapperType.ShouldEqual(typeof(MyFirstBootstwapper));
+        }
+
         [Fact]
         public void Should_automatically_resolve_the_most_derived_bootstrapper()
         {


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [X] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [X] I have provided test coverage for my change (where applicable)

### Description
As described in #2352 (and I believe the culprit behind #2423 as well) the diagnostic's info module fails when the bootstrappers lack a parameterless/default constructor. This is because the info module initializes a bootstrapper through `NancyBootstrapperLocator`. However the module only does that to report the bootstrapper name. `NancyBoostrapperLocator` already had `GetBootstrapperType` but it was `private`; this PR makes it `internal` and it overloads it so that tests can be written against it.
