### PR TITLE
Remove unnecessary usings from Program & HomeModule for Kestrel Sample

### DIFF
--- a/samples/Nancy.Demo.Hosting.Kestrel/HomeModule.cs
+++ b/samples/Nancy.Demo.Hosting.Kestrel/HomeModule.cs
@@ -1,7 +1,6 @@
 ﻿namespace Nancy.Demo.Hosting.Kestrel
 {
     using ModelBinding;
-    using System.Threading.Tasks;
 
     public class HomeModule : NancyModule
     {

--- a/samples/Nancy.Demo.Hosting.Kestrel/Program.cs
+++ b/samples/Nancy.Demo.Hosting.Kestrel/Program.cs
@@ -1,7 +1,6 @@
 namespace Nancy.Demo.Hosting.Kestrel
 {
     using System.IO;
-    using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     
     public class Program


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [ ] I have provided test coverage for my change (where applicable)

### Description

This PR is a very simple update to the `Nancy.Demo.Hosting.Kestrel` samples, with guidance as per @thecodejunkie.  Here I made very simple changes: In `Program.cs` I removed the unneeded `using Microsoft.AspNetCore.Builder;` and in `HomeModule.cs` the erroneous `using System.Threading.Tasks;` was removed.