### PR TITLE
Added route return type to RouteDescription

### DIFF
--- a/src/Nancy/Routing/Route.cs
+++ b/src/Nancy/Routing/Route.cs
@@ -13,7 +13,7 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Route"/> type, with the specified <see cref="RouteDescription"/>.
         /// </summary>
-        /// <param name="description"></param>
+        /// <param name="description">An <see cref="RouteDescription"/> instance.</param>
         protected Route(RouteDescription description)
         {
             this.Description = description;
@@ -26,8 +26,9 @@
         /// <param name="method">The HTTP method that the route is declared for.</param>
         /// <param name="path">The path that the route is declared for.</param>
         /// <param name="condition">A condition that needs to be satisfied inorder for the route to be eligible for invocation.</param>
-        protected Route(string name, string method, string path, Func<NancyContext, bool> condition)
-            : this(new RouteDescription(name, method, path, condition))
+        /// <param name="returnType">The <see cref="Type"/> of the value returned by the route.</param>
+        protected Route(string name, string method, string path, Func<NancyContext, bool> condition, Type returnType)
+            : this(new RouteDescription(name, method, path, condition, returnType))
         {
         }
 
@@ -72,7 +73,7 @@
         /// <param name="condition">A condition that needs to be satisfied inorder for the route to be eligible for invocation.</param>
         /// <param name="action">The action that should take place when the route is invoked.</param>
         public Route(string name, string method, string path, Func<NancyContext, bool> condition, Func<object, CancellationToken, Task<T>> action)
-            : this(new RouteDescription(name, method, path, condition), action)
+            : this(new RouteDescription(name, method, path, condition, typeof(T)), action)
         {
         }
 

--- a/src/Nancy/Routing/RouteDescription.cs
+++ b/src/Nancy/Routing/RouteDescription.cs
@@ -19,7 +19,8 @@ namespace Nancy.Routing
         /// <param name="method">The request method of the route.</param>
         /// <param name="path">The path that the route will be invoked for.</param>
         /// <param name="condition">The condition that has to be fulfilled for the route to be a valid match.</param>
-        public RouteDescription(string name, string method, string path, Func<NancyContext, bool> condition)
+        /// <param name="returnType">The <see cref="Type"/> of the value returned by the route.</param>
+        public RouteDescription(string name, string method, string path, Func<NancyContext, bool> condition, Type returnType)
         {
             if (string.IsNullOrEmpty(method))
             {
@@ -35,6 +36,7 @@ namespace Nancy.Routing
             this.Method = method;
             this.Path = path;
             this.Condition = condition;
+            this.ReturnType = returnType;
         }
 
         /// <summary>
@@ -77,6 +79,12 @@ namespace Nancy.Routing
         /// </summary>
         /// <value>An <see cref="IEnumerable{T}"/>, containing the segments for the route.</value>
         public IEnumerable<string> Segments { get; set; }
+
+        /// <summary>
+        /// Gets the <see cref="Type"/> of the value returned by the route.
+        /// </summary>
+        /// <value>A <see cref="Type"/> instance.</value>
+        public Type ReturnType { get; private set; }
 
         private string DebuggerDisplay
         {

--- a/test/Nancy.Metadata.Modules.Tests/MetadataModuleFixture.cs
+++ b/test/Nancy.Metadata.Modules.Tests/MetadataModuleFixture.cs
@@ -13,7 +13,7 @@
 
         public MetadataModuleFixture()
         {
-            this.route = new RouteDescription("NamedDescription", "GET", "/things", ctx => true);
+            this.route = new RouteDescription("NamedDescription", "GET", "/things", ctx => true, typeof(object));
             this.metadataModule = new FakeNancyMetadataModule();
         }
 

--- a/test/Nancy.Metadata.Modules.Tests/MetadataModuleRouteMetadataProviderFixture.cs
+++ b/test/Nancy.Metadata.Modules.Tests/MetadataModuleRouteMetadataProviderFixture.cs
@@ -20,7 +20,7 @@
         {
             this.resolver = A.Fake<IMetadataModuleResolver>();
             this.module = A.Fake<INancyModule>();
-            this.route = new RouteDescription("NamedDescription", "GET", "/things", ctx => true);
+            this.route = new RouteDescription("NamedDescription", "GET", "/things", ctx => true, typeof(object));
             this.metadataModule = new FakeNancyMetadataModule();
             this.metadataModule.Describe[this.route.Name] = desc => { return Metadata; };
 

--- a/test/Nancy.Tests/Fakes/FakeRouteCache.cs
+++ b/test/Nancy.Tests/Fakes/FakeRouteCache.cs
@@ -48,14 +48,14 @@
 
             public FakeRouteCacheConfigurator AddGetRoute(string path, Type moduleType)
             {
-                this.AddRoutesToCache(new[] { new RouteDescription(string.Empty, "GET", path, null) }, moduleType);
+                this.AddRoutesToCache(new[] { new RouteDescription(string.Empty, "GET", path, null, typeof(object)) }, moduleType);
 
                 return this;
             }
 
             public FakeRouteCacheConfigurator AddGetRoute(string path, Type moduleType, Func<NancyContext, bool> condition)
             {
-                this.AddRoutesToCache(new[] { new RouteDescription(string.Empty, "GET", path, condition) }, moduleType);
+                this.AddRoutesToCache(new[] { new RouteDescription(string.Empty, "GET", path, condition, typeof(object)) }, moduleType);
 
                 return this;
             }

--- a/test/Nancy.Tests/Unit/Routing/RouteDescriptionFixture.cs
+++ b/test/Nancy.Tests/Unit/Routing/RouteDescriptionFixture.cs
@@ -1,9 +1,7 @@
 ﻿namespace Nancy.Tests.Unit.Routing
 {
     using System;
-
     using Nancy.Routing;
-
     using Xunit;
 
     public class RouteDescriptionFixture
@@ -13,7 +11,7 @@
         {
             //Given, When
             var exception =
-                Record.Exception(() => new RouteDescription(string.Empty, null, "/", null));
+                Record.Exception(() => new RouteDescription(string.Empty, null, "/", null, typeof(object)));
 
             // Then
             exception.ShouldBeOfType<ArgumentException>();
@@ -24,7 +22,7 @@
         {
             //Given, When
             var exception =
-                Record.Exception(() => new RouteDescription(string.Empty, "", "/", null));
+                Record.Exception(() => new RouteDescription(string.Empty, "", "/", null, typeof(object)));
 
             // Then
             exception.ShouldBeOfType<ArgumentException>();
@@ -35,7 +33,7 @@
         {
             //Given, When
             var exception =
-                Record.Exception(() => new RouteDescription(string.Empty, "GET", null, null));
+                Record.Exception(() => new RouteDescription(string.Empty, "GET", null, null, typeof(object)));
 
             // Then
             exception.ShouldBeOfType<ArgumentException>();
@@ -46,10 +44,24 @@
         {
             //Given, When
             var exception =
-                Record.Exception(() => new RouteDescription(string.Empty, "GET", "", null));
+                Record.Exception(() => new RouteDescription(string.Empty, "GET", "", null, typeof(object)));
 
             // Then
             exception.ShouldBeOfType<ArgumentException>();
+        }
+
+        [Theory]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(string))]
+        public void Should_set_return_type_property(Type returnType)
+        {
+            // Given, When
+            var description =
+                new RouteDescription(string.Empty, "GET", "/", null, returnType);
+
+            // Then
+            description.ReturnType.ShouldEqual(returnType);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [X] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [X] I have provided test coverage for my change (where applicable)

### Description
Updated `Route` and `RouteDescription` to handle information about the return type of a defined route. We never added this after upgrading the route syntax to support `<T>`. Now the information will be persisted in the `ReturnType` property of `RouteDescription`. 
