### PR TITLE
Inside Nancy.Diagnostics couldn't cast object to Response

### DIFF
--- a/src/Nancy/Diagnostics/DefaultDiagnostics.cs
+++ b/src/Nancy/Diagnostics/DefaultDiagnostics.cs
@@ -4,6 +4,7 @@
 
     using Nancy.Bootstrapper;
     using Nancy.Configuration;
+    using Nancy.Conventions;
     using Nancy.Culture;
     using Nancy.Localization;
     using Nancy.ModelBinding;
@@ -29,8 +30,8 @@
         private readonly ITextResource textResource;
         private readonly INancyEnvironment environment;
         private readonly ITypeCatalog typeCatalog;
-
         private readonly IAssemblyCatalog assemblyCatalog;
+        private readonly AcceptHeaderCoercionConventions acceptHeaderCoercionConventions;
 
         /// <summary>
         /// Creates a new instance of the <see cref="DefaultDiagnostics"/> class.
@@ -49,6 +50,7 @@
         /// <param name="environment"></param>
         /// <param name="typeCatalog"></param>
         /// <param name="assemblyCatalog"></param>
+        /// <param name="acceptHeaderCoercionConventions"></param>
         public DefaultDiagnostics(
             IEnumerable<IDiagnosticsProvider> diagnosticProviders,
             IRootPathProvider rootPathProvider,
@@ -63,7 +65,8 @@
             ITextResource textResource,
             INancyEnvironment environment,
             ITypeCatalog typeCatalog,
-            IAssemblyCatalog assemblyCatalog)
+            IAssemblyCatalog assemblyCatalog,
+            AcceptHeaderCoercionConventions acceptHeaderCoercionConventions)
         {
             this.diagnosticProviders = diagnosticProviders;
             this.rootPathProvider = rootPathProvider;
@@ -79,6 +82,7 @@
             this.environment = environment;
             this.typeCatalog = typeCatalog;
             this.assemblyCatalog = assemblyCatalog;
+            this.acceptHeaderCoercionConventions = acceptHeaderCoercionConventions;
         }
 
         /// <summary>
@@ -102,7 +106,8 @@
                 this.textResource,
                 this.environment,
                 this.typeCatalog,
-                this.assemblyCatalog);
+                this.assemblyCatalog,
+                this.acceptHeaderCoercionConventions);
         }
     }
 }

--- a/test/Nancy.Tests/Unit/Diagnostics/CustomInteractiveDiagnosticsFixture.cs
+++ b/test/Nancy.Tests/Unit/Diagnostics/CustomInteractiveDiagnosticsFixture.cs
@@ -6,6 +6,7 @@
     using System.Threading.Tasks;
     using Nancy.Bootstrapper;
     using Nancy.Configuration;
+    using Nancy.Conventions;
     using Nancy.Cryptography;
     using Nancy.Culture;
     using Nancy.Diagnostics;
@@ -45,6 +46,7 @@
             private readonly INancyEnvironment environment;
             private readonly ITypeCatalog typeCatalog;
             private readonly IAssemblyCatalog assemblyCatalog;
+            private readonly AcceptHeaderCoercionConventions acceptHeaderCoercionConventions;
 
             public FakeDiagnostics(
                 IRootPathProvider rootPathProvider,
@@ -59,7 +61,8 @@
                 ITextResource textResource,
                 INancyEnvironment environment,
                 ITypeCatalog typeCatalog,
-                IAssemblyCatalog assemblyCatalog)
+                IAssemblyCatalog assemblyCatalog,
+                AcceptHeaderCoercionConventions acceptHeaderCoercionConventions)
             {
                 this.diagnosticProviders = (new IDiagnosticsProvider[] { new FakeDiagnosticsProvider() }).ToArray();
                 this.rootPathProvider = rootPathProvider;
@@ -75,6 +78,7 @@
                 this.environment = environment;
                 this.typeCatalog = typeCatalog;
                 this.assemblyCatalog = assemblyCatalog;
+                this.acceptHeaderCoercionConventions = acceptHeaderCoercionConventions;
             }
 
             public void Initialize(IPipelines pipelines)
@@ -94,7 +98,8 @@
                     this.textResource,
                     this.environment,
                     this.typeCatalog,
-                    this.assemblyCatalog);
+                    this.assemblyCatalog,
+                    this.acceptHeaderCoercionConventions);
             }
         }
 

--- a/test/Nancy.Tests/Unit/Diagnostics/DiagnosticsHookFixture.cs
+++ b/test/Nancy.Tests/Unit/Diagnostics/DiagnosticsHookFixture.cs
@@ -296,7 +296,7 @@
         [Fact]
         public async Task Should_return_diagnostic_example()
         {
-            // Given no custom interactive diagnostic providers
+            // Given
             var bootstrapper = new ConfigurableBootstrapper(with =>
             {
                 with.Configure(env =>
@@ -313,13 +313,13 @@
 
             var browser = new Browser(bootstrapper);
 
-            // When querying the list of interactive providers
+            // When
             var result = await browser.Get(DiagnosticsConfiguration.Default.Path + "/interactive/providers/", with =>
                 {
                     with.Cookie(DiagsCookieName, this.GetSessionCookieValue("password"));
                 });
 
-            // Then we should see the fake testing provider and not the Nancy provided testing example
+            // Then
             result.Body.AsString().ShouldNotContain("Fake testing provider");
             result.Body.AsString().ShouldContain("Testing Diagnostic Provider");
         }
@@ -327,7 +327,7 @@
         [Fact]
         public async Task Should_return_ok_for_post_settings()
         {
-            // Given no custom interactive diagnostic providers
+            // Given
             var bootstrapper = new ConfigurableBootstrapper(with =>
             {
                 with.Configure(env =>
@@ -342,7 +342,8 @@
                 with.Diagnostics<DefaultDiagnostics>();
             });
             var browser = new Browser(bootstrapper);
-            // When querying the list of interactive providers
+            
+            // When
             var result = await browser.Post(DiagnosticsConfiguration.Default.Path + "/settings", with =>
             {
                 with.Cookie(DiagsCookieName, this.GetSessionCookieValue("password"));

--- a/test/Nancy.Tests/Unit/Diagnostics/DiagnosticsHookFixture.cs
+++ b/test/Nancy.Tests/Unit/Diagnostics/DiagnosticsHookFixture.cs
@@ -349,6 +349,8 @@
                 with.Cookie(DiagsCookieName, this.GetSessionCookieValue("password"));
                 with.JsonBody(new SettingsModel { Name = "CaseSensitive", Value = true });
             });
+            
+            // Then
             result.StatusCode.ShouldEqual(HttpStatusCode.OK);
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
Inside `DiagnosticsHook.ExecuteDiagnostics` object cannot be cast to Response (line 178)
Fixed for use `DefaultRouteInvoker` for invoke `Route` and get `Nancy,Response`.
Test included

<!-- Thanks for contributing to Nancy! -->
