### PR TITLE
DefaultFileSystemReader: if directory does not exist, return empty list of file names.

### DIFF
--- a/src/Nancy/ViewEngines/DefaultFileSystemReader.cs
+++ b/src/Nancy/ViewEngines/DefaultFileSystemReader.cs
@@ -69,7 +69,9 @@
 
         private static IEnumerable<string> GetFilenames(string path, string extension)
         {
-            return Directory.GetFiles(path, string.Concat("*.", extension), SearchOption.AllDirectories);
+            return !Directory.Exists(path) 
+                ? Enumerable.Empty<string>()
+                : Directory.GetFiles(path, string.Concat("*.", extension), SearchOption.AllDirectories);
         }
     }
 }


### PR DESCRIPTION
DefaultFileSystemReader: if directory does not exist, return empty list of file names of file names. This fixes a cryptic TinyIoC exception that is thrown if the root path provider points to a path, or calculates a path that does not exist.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description

If the path does not exist (root path provider), it will result on a TinyIoC activation exception and not a useful one at that. 

![image](https://cloud.githubusercontent.com/assets/57436/21893886/4972d2e6-d8dd-11e6-9edb-7938975eb3aa.png)

![image](https://cloud.githubusercontent.com/assets/57436/21893889/4eea2378-d8dd-11e6-96a0-d6d847c22381.png)

This prevents that exception from being thrown. The user will be subsequently get a different but more user friendly error later:

```
System.Exception: System.Exception : ConfigurableBootstrapper Exception
---- Nancy.RequestExecutionException : Oh noes!
-------- Nancy.ViewEngines.ViewNotFoundException : Unable to locate view 'doublequotedpartial'
Currently available view engine extensions: sshtml,html,htm
...
```