### PR TITLE
Added MONO_TLS_PROVIDER env variable to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,14 @@ sudo: required
 dist: trusty
 addons:
   apt:
-    packages: 
+    packages:
     - gettext
     - libcurl4-openssl-dev
     - libicu-dev
     - libssl-dev
     - libunwind8
+env:
+    - MONO_TLS_PROVIDER=legacy
 script: ./build.sh --verbosity=diagnostic
 notifications:
   email:


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [X] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [X] I have provided test coverage for my change (where applicable)

### Description
Our Travis builds recently started failing when we went from `4.8.0 (Stable 4.8.0.395/df81fe4 Tue Jan 3 15:47:11 UTC 2017)` to `Mono JIT compiler version 4.8.0 (Stable 4.8.0.425/038ff4a Mon Jan 9 14:42:31 UTC 2017)` (we're grabbing latest published). I was recommended by @akoeplinger to try to add `MONO_TLS_PROVIDER=legacy` to our env variables to see if that resolves it. If this PR builds on Travis then it should be good to merge.