### PR TITLE
Added ctor overload on DependencyContextAssemblyCatalog

### DIFF
--- a/src/Nancy/DependencyContextAssemblyCatalog.cs
+++ b/src/Nancy/DependencyContextAssemblyCatalog.cs
@@ -6,7 +6,7 @@ namespace Nancy
     using System.Linq;
     using System.Reflection;
     using Microsoft.Extensions.DependencyModel;
-    
+
     /// <summary>
     /// Default implementation of the <see cref="IAssemblyCatalog"/> interface, based on
     /// retrieving <see cref="Assembly"/> information from <see cref="DependencyContext"/>.
@@ -17,12 +17,20 @@ namespace Nancy
         private readonly DependencyContext dependencyContext;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DependencyContextAssemblyCatalog"/> class.
+        /// Initializes a new instance of the <see cref="DependencyContextAssemblyCatalog"/> class,
+        /// using <see cref="Assembly.GetEntryAssembly()"/>.
         /// </summary>
         public DependencyContextAssemblyCatalog()
+            : this(Assembly.GetEntryAssembly())
         {
-            var entryAssembly = Assembly.GetEntryAssembly();
-            
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DependencyContextAssemblyCatalog"/> class,
+        /// using <paramref name="entryAssembly"/>.
+        /// </summary>
+        public DependencyContextAssemblyCatalog(Assembly entryAssembly)
+        {
             this.dependencyContext = DependencyContext.Load(entryAssembly);
         }
 
@@ -47,10 +55,10 @@ namespace Nancy
                     }
                 }
             }
-            
+
             return results.ToArray();
         }
-        
+
         private static Assembly SafeLoadAssembly(AssemblyName assemblyName)
         {
             try


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [X] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [X] I have provided test coverage for my change (where applicable)

### Description
Added a ctor overload to `DependencyContextAssemblyCatalog` that enabled you to specify which assembly it should use. Makes scenarios like this https://github.com/NancyFx/Nancy/issues/2692#issuecomment-275901435 a bit easier. Removed a bit of white space as well, because boy-scout 

<!-- Thanks for contributing to Nancy! -->
