### PR TITLE
Nancy Self Host: Connection Control over the HttpListener

### DIFF
--- a/src/Nancy.Hosting.Self/HostConfiguration.cs
+++ b/src/Nancy.Hosting.Self/HostConfiguration.cs
@@ -54,6 +54,16 @@
         /// </summary>
         public bool AllowAuthorityFallback { get; set; }
 
+        /// <summary>
+        /// Gets or sets a property determining how many total connections the NancyHost can maintain simultaneously.
+        /// Higher values mean more conections can be maintained at a slower average response times; while fewer connections will be rejected.
+        /// Lower values will result in fewer conections, yet will be maintained at a faster average response time.
+        /// </summary>
+        public int MaximumConnectionCount { get; set; }
+
+        /// <summary>
+        /// Initializes the default configuration. MaximumConnectionCount is defaulted to 4.
+        /// </summary>
         public HostConfiguration()
         {
             this.RewriteLocalhost = true;
@@ -65,6 +75,7 @@
                     Debug.Write(message);
                 };
             this.EnableClientCertificates = false;
+            this.MaximumConnectionCount = 4;
         }
     }
 }

--- a/src/Nancy.Hosting.Self/HostConfiguration.cs
+++ b/src/Nancy.Hosting.Self/HostConfiguration.cs
@@ -61,21 +61,51 @@
         /// </summary>
         public int MaximumConnectionCount { get; set; }
 
+
         /// <summary>
-        /// Initializes the default configuration. MaximumConnectionCount is defaulted to 4.
+        /// Gets approximate processor thread count by halfing the Logical Core count to 
+        /// account for hyper-threading.
         /// </summary>
+        private static int ProcessorThreadCount
+        {
+            get
+            {
+                // Divide by 2 for hyper-threading, and good defaults.
+                var threadCount = Environment.ProcessorCount >> 1;
+
+                if (threadCount < 1)
+                {
+                    // Ensure thread count is at least 1.
+                    return 1;
+                }
+
+                return threadCount;
+            }
+        }
+
+        /// <summary>
+        /// Initializes the default configuration.
+        /// MaximumConnectionCount by default is half of the Logical Core count.
+        /// </summary>
+        /// <remarks>
+        /// If the system running NancyHost is not using hyper-threading you may want to consider
+        /// supplying your own values for MaximumConnectionCount as the default assumes 
+        /// hyperthreading is being utilized.
+        /// </remarks>
         public HostConfiguration()
         {
             this.RewriteLocalhost = true;
             this.UrlReservations = new UrlReservations();
             this.AllowChunkedEncoding = true;
             this.UnhandledExceptionCallback = e =>
-                {
-                    var message = string.Format("---\n{0}\n---\n", e);
-                    Debug.Write(message);
-                };
+            {
+                var message = string.Format("---\n{0}\n---\n", e);
+                Debug.Write(message);
+            };
             this.EnableClientCertificates = false;
-            this.MaximumConnectionCount = 4;
+            this.MaximumConnectionCount = ProcessorThreadCount;
         }
+
+
     }
 }

--- a/src/Nancy.Hosting.Self/HostConfiguration.cs
+++ b/src/Nancy.Hosting.Self/HostConfiguration.cs
@@ -61,7 +61,6 @@
         /// </summary>
         public int MaximumConnectionCount { get; set; }
 
-
         /// <summary>
         /// Gets approximate processor thread count by halfing the Logical Core count to 
         /// account for hyper-threading.
@@ -98,10 +97,10 @@
             this.UrlReservations = new UrlReservations();
             this.AllowChunkedEncoding = true;
             this.UnhandledExceptionCallback = e =>
-            {
-                var message = string.Format("---\n{0}\n---\n", e);
-                Debug.Write(message);
-            };
+                {
+                    var message = string.Format("---\n{0}\n---\n", e);
+                    Debug.Write(message);
+                };
             this.EnableClientCertificates = false;
             this.MaximumConnectionCount = ProcessorThreadCount;
         }

--- a/src/Nancy.Hosting.Self/NancyHost.cs
+++ b/src/Nancy.Hosting.Self/NancyHost.cs
@@ -143,6 +143,7 @@
                         catch (Exception ex)
                         {
                             this.configuration.UnhandledExceptionCallback.Invoke(ex);
+                            throw;
                         }
                     });
                 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
NancyHost in its original implementation did not allow a way for consumers to have control over the number of connections. This PR aims to provide a slice of control to consumers to allow them to specify the number of accept connections that can be listened for at a given time.

This implementation has been adapted from https://github.com/JamesDunne/aardwolf/blob/master/Aardwolf/HttpAsyncHost.cs#L107 , which outlines a simple semaphore to control the total number of Hot Tasks listening for a request. To allow consumers to specify the number of connections to fit their environment, I added a property to the HostConfiguration.cs, and specify a default value for it (4) in the default constructor. I've used JMeter locally pointing at the Nancy Self Hosting demo with 150 threads. The performance on my machine is anecdotal and doesn't really matter, but in all this change does not appear to degrade existing functionality. In the context of my environment, throughput was around 2,000/s for the original version that was awaiting on this.Process and with the default MaximumConnectionCount of 4 was around 4,000/s. Again, anecdotal and nothing anyone should take to the bank, but I wanted to provide that as some form of comparison.

I originally jumped in to remove an await call on this.Process as it would cause only one request to be processed at a time, however while in here I thought I could add a little extra bit of functionality for consumers. This will let consumers of Nancy.SelfHosting to fine tune their connection accept loop to meet their needs, as opposed to just throwing out hot this.Process task calls indefinitely.

I'm certainly open to changing this up, and really not sure what a "good" default value would be for the MaximumConnectionCount, as most consumers would probably want to set this after performing their own analysis of their needs and their service's performance. 

Let me know your feedback as this functionality may not be helpful (though I think it's a nice feature) for Nancy.SelfHost, but at the minimum we need to take the await off of the this.Process call or I think we'll only be processing  one request at a time when this package is released :)
<!-- Thanks for contributing to Nancy! -->
