### PR TITLE
Disable parallel test runs for Nancy.Tests

### DIFF
--- a/test/Nancy.Tests/Properties/AssemblyInfo.cs
+++ b/test/Nancy.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
Several fixtures manipulate (and possibly more depend on) the static field
StaticConfiguration.CaseSensitive, causing interference.

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
Disable test run parallelization for Nancy.Tests. 
I noticed intermittent test failures in this module (even on master, on Windows) during my work on #2634. After further investigation performed as described in #2702, helped along with comments from @xt0rted  and @jchannon, I see that both `Nancy.Tests.Unit.RequestFixture` and `Nancy.Tests.Unit.Routing.DefaultRouteResolverFixture`
` set `StaticConfiguration.CaseSensitive`. I figured this to be a primary cause of the failures.

I ran `dotnet test -c Release` in Nancy.Tests repeatedly on Windows on the master branch, then disabled test parallelization and repeated.

Here's what I found:
With parallelization enabled (as `master` has it), tests failed after various numbers of runs:
7, 3, 6, 1, 2, 2, 2, 3, 1, 2, 1, 3, 1, 1, 1, 8, 11, 4, 2, 1, 2, 1, 1, 12, 7, 3, 1, 1, 7, 1, 8, 15, 10, 1, 4, 3, 3, 1 , 2, 1, 1, 2, 1, 2, 1, 4, 14, 3, 14, 10, 3, 1, 1, 2, 3, 3, 1, 4, 5, 6, 1, 9, 7, 4, 12, 7, 1, 5, 3, 1, 6, 9, 6, 1, 6, 2, 2, 1, 1, 2, 2, 2, 6, 2, 1 , 5, 11, 4, 4, 2, 1, 3, 7, 3, 3, 6, 2, 10, 1, 1, 26, 2, 1, 7, 4, 10, 2, 1, 12, 2, 1, 1, 7, 1, 1, 4, 1, 7, 6, 2, 4, 1, 1, 4, 3, 2, 2, 1, 3, 1, 2, 3, 1, 2, 5, 2, 7, 7, 2, 6, 6, 1, 1, 1, 2, 4, 3, 6, 4, 2, 13, 1, 8, 2, 2, 10, 8, 1, 6, 5, 3, 6, 2, 1, 5, 1, 2, 1, 10, 9, 4, 3, 5, 6, 2, 9, 3, 1, 2 , 17, 1, 9, 3, 4, 5, 5, 1, 2, 5, 1, 4, 2, 1, 1, 1, 1, 8, 2, 2, 1, 5, 8, 2, 2, 2, 3, 3, 2, 2, 1, 1, 3, 4, 3, 3, 1, 3, 1, 2, 1, 1, 3, 3, 1

With parallelization disabled, the tests did not fail once in over 200 runs.

Here's a picture:

![image](https://cloud.githubusercontent.com/assets/3275797/22788172/d553617e-eeac-11e6-9b87-deae09bb2abb.png)

It's possible that a more sophisticated fix could be found, but in the interim, I propose disabling parallel test execution.