### PR TITLE
Add netcoreapp1.0 target to Nancy.Authentication.Basic.Tests

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -66,7 +66,6 @@ Task("Compile")
             var testProjects = GetFiles("./test/**/*.xproj");
 
             var dotnetTestProjects = testProjects
-                                 - GetFiles("test/**/Nancy.Authentication.Basic.Tests.xproj")
                                  - GetFiles("test/**/Nancy.Authentication.Forms.Tests.xproj")
                                  - GetFiles("test/**/Nancy.Embedded.Tests.xproj")
                                  - GetFiles("test/**/Nancy.Encryption.MachineKey.Tests.xproj")
@@ -308,7 +307,6 @@ Task("Test")
 
             var testProjects = GetFiles("./test/**/*.xproj");
             var dotnetTestProjects = testProjects
-                                 - GetFiles("test/**/Nancy.Authentication.Basic.Tests.xproj")
                                  - GetFiles("test/**/Nancy.Authentication.Forms.Tests.xproj")
                                  - GetFiles("test/**/Nancy.Embedded.Tests.xproj")
                                  - GetFiles("test/**/Nancy.Encryption.MachineKey.Tests.xproj")

--- a/test/Nancy.Authentication.Basic.Tests/project.json
+++ b/test/Nancy.Authentication.Basic.Tests/project.json
@@ -1,7 +1,8 @@
 {
     "dependencies": {
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
-        "FakeItEasy.Analyzer": "2.1.0",
+        "FakeItEasy": "3.0.0",
+        "FakeItEasy.Analyzer": "3.0.0",
         "Microsoft.NETCore.Platforms": "1.0.1",
         "Nancy": { "target": "project" },
         "Nancy.Authentication.Basic": { "target": "project" },
@@ -17,12 +18,17 @@
 
     "frameworks": {
         "net452": {
-            "dependencies": {
-                "FakeItEasy": "2.0.0"
-            },
             "frameworkAssemblies": {
                 "System.Runtime": { "type": "build" },
                 "System.Threading.Tasks": { "type": "build" }
+            }
+        },
+        "netcoreapp1.0": {
+            "dependencies": {
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.0.0"
+                }
             }
         }
     },

--- a/test/Nancy.Tests/project.json
+++ b/test/Nancy.Tests/project.json
@@ -2,8 +2,8 @@
     "version": "1.4.1.0",
     "dependencies": {
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
-        "FakeItEasy": "3.0.0-rc001",
-        "FakeItEasy.Analyzer": "3.0.0-rc001",
+        "FakeItEasy": "3.0.0",
+        "FakeItEasy.Analyzer": "3.0.0",
         "Microsoft.NETCore.Platforms": "1.0.1",
         "Nancy": { "target": "project" },
         "Nancy.Testing": { "target": "project" },
@@ -49,8 +49,7 @@
                     "type": "platform",
                     "version": "1.0.0"
                 }
-            },
-            "imports": [ "netstandard1.6" ]
+            }
         }
     },
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Adds netcoreapp1.0 target to  Nancy.Authentication.Basic.Tests, and runs it on Windows and Unix

Supports #2612.
<!-- Thanks for contributing to Nancy! -->