### PR TITLE
Fix for ViewNotFound error on netcoreapp

### DIFF
--- a/src/Nancy/DefaultRootPathProvider.cs
+++ b/src/Nancy/DefaultRootPathProvider.cs
@@ -14,7 +14,7 @@
         public string GetRootPath()
         {
 #if CORE
-            return Microsoft.Extensions.PlatformAbstractions.PlatformServices.Default.Application.ApplicationBasePath;
+            return System.IO.Directory.GetCurrentDirectory();
 #else
             return AppDomain.CurrentDomain.BaseDirectory;
 #endif


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
When using Nancy with a view engine on netcoreapp , the default root path points to the debug folder which then requires views to be copied to output.
This however has a limitation because updates to views need to be copied.
<!-- Thanks for contributing to Nancy! -->
