### PR TITLE
Fail if no projects could be built or tested

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -61,6 +61,12 @@ Task("Compile")
         if (IsRunningOnUnix())
         {
             var srcProjects = GetFiles("./src/**/*.xproj");
+
+            if (srcProjects.Count == 0)
+            {
+                throw new CakeException("Unable to find any projects to build.");
+            }
+
             srcProjects = srcProjects - GetFiles("./**/Nancy.Encryption.MachineKey.xproj");
 
             var testProjects = GetFiles("./test/**/*.xproj");
@@ -292,6 +298,11 @@ Task("Test")
         var projects =
             GetFiles("./test/**/*.xproj") -
             GetFiles("./test/**/Nancy.ViewEngines.Razor.Tests.Models.xproj");
+
+        if (projects.Count == 0)
+        {
+            throw new CakeException("Unable to find any projects to test.");
+        }
 
         if (IsRunningOnUnix())
         {


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [X] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [X] I have provided test coverage for my change (where applicable)

### Description
Previously the build script your succeed even if it could not locate any projects during the `compile` task, or any projects during the `test` task. This could mean that we end up with a false-positive from out CI servers on pull-requests.