### PR TITLE
Reenable async analyzer

### DIFF
--- a/Nancy.ruleset
+++ b/Nancy.ruleset
@@ -2,7 +2,7 @@
 <RuleSet Name="Nancy" ToolsVersion="14.0">
   <Include Path="allrules.ruleset" Action="Default" />
   <Rules AnalyzerId="AsyncUsageAnalyzers" RuleNamespace="AsyncUsageAnalyzers">
-    <Rule Id="AvoidAsyncVoid" Action="Error" />
+    <Rule Id="AvoidAsyncVoid" Action="None" />
     <Rule Id="UseAsyncSuffix" Action="None" />
     <Rule Id="UseConfigureAwait" Action="Error" />
   </Rules>

--- a/Nancy.ruleset
+++ b/Nancy.ruleset
@@ -3,6 +3,7 @@
   <Include Path="allrules.ruleset" Action="Default" />
   <Rules AnalyzerId="AsyncUsageAnalyzers" RuleNamespace="AsyncUsageAnalyzers">
     <Rule Id="AvoidAsyncVoid" Action="Error" />
+    <Rule Id="UseAsyncSuffix" Action="None" />
     <Rule Id="UseConfigureAwait" Action="Error" />
   </Rules>
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <Authors>Andreas Håkansson, Steven Robbins and contributors</Authors>
+    <CodeAnalysisRuleSet>..\..\Nancy.ruleset</CodeAnalysisRuleSet>
     <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' == 'net452' ">true</DisableImplicitFrameworkReferences>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageIconUrl>http://nancyfx.org/nancy-nuget.png</PackageIconUrl>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' == 'net452' ">true</DisableImplicitFrameworkReferences>
+    <CodeAnalysisRuleSet>..\..\Nancy.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
I've re-enabled the use of the Async Analyzer in all `/src` projects by adding back `<CodeAnalysisRuleSet>` in `src/Directory.Build.props`. I've also updated `Nancy.ruleset` to disable the warning for the `UseAsyncSuffix` rule