### PR TITLE
Changed restore verbosity to minimal

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -220,7 +220,12 @@ Task("Restore-NuGet-Packages")
     .Description("Restores NuGet packages for all projects")
     .Does(() =>
     {
-        DotNetCoreRestore();
+        DotNetCoreRestore(new DotNetCoreRestoreSettings {
+            ArgumentCustomization = args => {
+                args.Append("--verbosity minimal");
+                return args;
+            }
+        });
     });
 
 Task("Tag")


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
Reduces the verbosity of ´dotnet restore` to `minimal`. This change will only be visible if you are running a later release of the CLI tooling because of a bug that was recently fixed https://github.com/dotnet/cli/pull/6627

<!-- Thanks for contributing to Nancy! -->
