### PR TITLE
Changed AppVeyor and Travis verbosity to minimal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
     - libunwind8
 env:
     - MONO_TLS_PROVIDER=legacy
-script: ./build.sh --verbosity=diagnostic
+script: ./build.sh --verbosity=minimal
 notifications:
   email:
     - nancy@nancyfx.org

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
 - set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
 
 build_script:
-- ps: .\build.ps1 -verbosity=normal
+- ps: .\build.ps1 -verbosity=minimal
 
 artifacts:
 - path: build\nuget\*.nupkg


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
Part of our continued effort to reduce CI build output down to the essentials. Currently we run AppVeyor with `normal` and Travis with `diagnostic` verbosity. This pull-request changes both to run using `minimal`

<!-- Thanks for contributing to Nancy! -->
