### PR TITLE
Removed use of object serializer for Csrf cookie generation

### DIFF
--- a/src/Nancy/Security/Csrf.cs
+++ b/src/Nancy/Security/Csrf.cs
@@ -1,7 +1,10 @@
 ﻿namespace Nancy.Security
 {
     using System;
+    using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
+    using System.Text;
 
     using Nancy.Bootstrapper;
     using Nancy.Cookies;
@@ -14,15 +17,15 @@
     public static class Csrf
     {
         private const string CsrfHookName = "CsrfPostHook";
-
-
+        private const char ValueDelimiter = '#';
+        private const char PairDelimiter = '|';
 
         /// <summary>
         /// Enables Csrf token generation.
-        /// This is disabled by default.
         /// </summary>
+        /// <remarks>This is disabled by default.</remarks>
         /// <param name="pipelines">The application pipelines.</param>
-        /// <param name="cryptographyConfiguration">The cryptography configuration. This is <c>null</c> by default.</param>
+        /// <param name="cryptographyConfiguration">The cryptography configuration. This is <see langword="null" /> by default.</param>
         public static void Enable(IPipelines pipelines, CryptographyConfiguration cryptographyConfiguration = null)
         {
             cryptographyConfiguration = cryptographyConfiguration ?? CsrfApplicationStartup.CryptographyConfiguration;
@@ -38,16 +41,18 @@
 
                     if (context.Items.ContainsKey(CsrfToken.DEFAULT_CSRF_KEY))
                     {
-                        context.Response.Cookies.Add(new NancyCookie(CsrfToken.DEFAULT_CSRF_KEY,
-                                                                     (string)context.Items[CsrfToken.DEFAULT_CSRF_KEY],
-                                                                     true));
+                        context.Response.Cookies.Add(new NancyCookie(
+                            CsrfToken.DEFAULT_CSRF_KEY,
+                            (string)context.Items[CsrfToken.DEFAULT_CSRF_KEY],
+                            true));
+
                         return;
                     }
 
                     if (context.Request.Cookies.ContainsKey(CsrfToken.DEFAULT_CSRF_KEY))
                     {
                         var cookieValue = context.Request.Cookies[CsrfToken.DEFAULT_CSRF_KEY];
-                        var cookieToken = CsrfApplicationStartup.ObjectSerializer.Deserialize(cookieValue) as CsrfToken;
+                        var cookieToken = ParseToCsrfToken(cookieValue);
 
                         if (CsrfApplicationStartup.TokenValidator.CookieTokenStillValid(cookieToken))
                         {
@@ -96,13 +101,21 @@
             cryptographyConfiguration = cryptographyConfiguration ?? CsrfApplicationStartup.CryptographyConfiguration;
             var token = new CsrfToken
             {
-                CreatedDate = DateTimeOffset.Now,
+                CreatedDate = DateTimeOffset.Now
             };
 
             token.CreateRandomBytes();
             token.CreateHmac(cryptographyConfiguration.HmacProvider);
-            var tokenString = CsrfApplicationStartup.ObjectSerializer.Serialize(token);
-            return tokenString;
+
+            var builder = new StringBuilder();
+
+            builder.AppendFormat("RandomBytes{0}{1}", ValueDelimiter, Convert.ToBase64String(token.RandomBytes));
+            builder.Append(PairDelimiter);
+            builder.AppendFormat("Hmac{0}{1}", ValueDelimiter, Convert.ToBase64String(token.Hmac));
+            builder.Append(PairDelimiter);
+            builder.AppendFormat("CreatedDate{0}{1}", ValueDelimiter, token.CreatedDate.ToString("o", CultureInfo.InvariantCulture));
+
+            return builder.ToString();
         }
 
         /// <summary>
@@ -139,7 +152,7 @@
             var providedTokenString = request.Form[CsrfToken.DEFAULT_CSRF_KEY].Value ?? request.Headers[CsrfToken.DEFAULT_CSRF_KEY].FirstOrDefault();
             if (providedTokenString != null)
             {
-                providedToken = CsrfApplicationStartup.ObjectSerializer.Deserialize(providedTokenString) as CsrfToken;
+                providedToken = ParseToCsrfToken(providedTokenString);
             }
 
             return providedToken;
@@ -152,10 +165,67 @@
             string cookieTokenString;
             if (request.Cookies.TryGetValue(CsrfToken.DEFAULT_CSRF_KEY, out cookieTokenString))
             {
-                cookieToken = CsrfApplicationStartup.ObjectSerializer.Deserialize(cookieTokenString) as CsrfToken;
+                cookieToken = ParseToCsrfToken(cookieTokenString);
             }
 
             return cookieToken;
+        }
+
+        private static CsrfToken ParseToCsrfToken(string cookieTokenString)
+        {
+            var parsed = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            void Add(string key, string value)
+            {
+                if (!string.IsNullOrEmpty(key))
+                {
+                    parsed.Add(key, value);
+                }
+            }
+
+            var currentKey = string.Empty;
+            var buffer = new StringBuilder();
+
+            for (var index = 0; index < cookieTokenString.Length; index++)
+            {
+                var currentCharacter = cookieTokenString[index];
+
+                switch (currentCharacter)
+                {
+                    case ValueDelimiter:
+                        currentKey = buffer.ToString();
+                        buffer.Clear();
+                        break;
+                    case PairDelimiter:
+                        Add(currentKey, buffer.ToString());
+                        buffer.Clear();
+                        break;
+                    default:
+                        buffer.Append(currentCharacter);
+                        break;
+                }
+            }
+
+            Add(currentKey, buffer.ToString());
+
+            if (parsed.Keys.Count() != 3)
+            {
+                return null;
+            }
+
+            try
+            {
+                return new CsrfToken
+                {
+                    CreatedDate = DateTimeOffset.ParseExact(parsed["CreatedDate"], "o", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+                    Hmac = Convert.FromBase64String(parsed["Hmac"]),
+                    RandomBytes = Convert.FromBase64String(parsed["RandomBytes"])
+                };
+            }
+            catch
+            {
+                return null;
+            }
         }
     }
 }

--- a/src/Nancy/Security/CsrfApplicationStartup.cs
+++ b/src/Nancy/Security/CsrfApplicationStartup.cs
@@ -10,15 +10,13 @@
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CsrfApplicationStartup"/> class, using the
-        /// provided <paramref name="cryptographyConfiguration"/>, <paramref name="objectSerializer"/> and <paramref name="tokenValidator"/>.
+        /// provided <paramref name="cryptographyConfiguration"/> and <paramref name="tokenValidator"/>.
         /// </summary>
         /// <param name="cryptographyConfiguration">The cryptographic configuration to use.</param>
-        /// <param name="objectSerializer">The serializer that should be used.</param>
         /// <param name="tokenValidator">The token validator that should be used.</param>
-        public CsrfApplicationStartup(CryptographyConfiguration cryptographyConfiguration, IObjectSerializer objectSerializer, ICsrfTokenValidator tokenValidator)
+        public CsrfApplicationStartup(CryptographyConfiguration cryptographyConfiguration, ICsrfTokenValidator tokenValidator)
         {
             CryptographyConfiguration = cryptographyConfiguration;
-            ObjectSerializer = objectSerializer;
             TokenValidator = tokenValidator;
         }
 
@@ -26,11 +24,6 @@
         /// Gets the configured crypto config
         /// </summary>
         internal static CryptographyConfiguration CryptographyConfiguration { get; private set; }
-
-        /// <summary>
-        /// Gets the configured object serialiser
-        /// </summary>
-        internal static IObjectSerializer ObjectSerializer { get; private set; }
 
         /// <summary>
         /// Gets the configured token validator

--- a/test/Nancy.Tests/Unit/Security/CsrfFixture.cs
+++ b/test/Nancy.Tests/Unit/Security/CsrfFixture.cs
@@ -18,17 +18,14 @@
         private readonly FakeRequest optionsRequest;
         private readonly Response response;
         private readonly CryptographyConfiguration cryptographyConfiguration;
-        private readonly DefaultObjectSerializer objectSerializer;
 
         public CsrfFixture()
         {
             this.pipelines = new MockPipelines();
 
             this.cryptographyConfiguration = CryptographyConfiguration.Default;
-            this.objectSerializer = new DefaultObjectSerializer();
             var csrfStartup = new CsrfApplicationStartup(
                 this.cryptographyConfiguration,
-                this.objectSerializer,
                 new DefaultCsrfTokenValidator(this.cryptographyConfiguration));
 
             csrfStartup.Initialize(this.pipelines);
@@ -44,11 +41,14 @@
         [Fact]
         public void Should_create_cookie_in_response_if_token_exists_in_context()
         {
+            // Given
             var context = new NancyContext { Request = this.request, Response = this.response };
             context.Items[CsrfToken.DEFAULT_CSRF_KEY] = "TestingToken";
 
+            // When
             this.pipelines.AfterRequest.Invoke(context, new CancellationToken());
 
+            // Then
             this.response.Cookies.Any(c => c.Name == CsrfToken.DEFAULT_CSRF_KEY).ShouldBeTrue();
             this.response.Cookies.FirstOrDefault(c => c.Name == CsrfToken.DEFAULT_CSRF_KEY).Value.ShouldEqual("TestingToken");
         }
@@ -56,18 +56,23 @@
         [Fact]
         public void Should_copy_request_cookie_to_context_but_not_response_if_it_exists_and_context_does_not_contain_token()
         {
+            // Given
             this.request.Cookies.Add(CsrfToken.DEFAULT_CSRF_KEY, "ValidToken");
             var fakeValidator = A.Fake<ICsrfTokenValidator>();
+
             A.CallTo(() => fakeValidator.CookieTokenStillValid(A<CsrfToken>.Ignored)).Returns(true);
+
             var csrfStartup = new CsrfApplicationStartup(
                 this.cryptographyConfiguration,
-                this.objectSerializer,
                 fakeValidator);
+
             csrfStartup.Initialize(this.pipelines);
             var context = new NancyContext { Request = this.request, Response = this.response };
 
+            // When
             this.pipelines.AfterRequest.Invoke(context, new CancellationToken());
 
+            // Then
             this.response.Cookies.Any(c => c.Name == CsrfToken.DEFAULT_CSRF_KEY).ShouldBeFalse();
             context.Items.ContainsKey(CsrfToken.DEFAULT_CSRF_KEY).ShouldBeTrue();
             context.Items[CsrfToken.DEFAULT_CSRF_KEY].ShouldEqual("ValidToken");
@@ -76,20 +81,24 @@
         [Fact]
         public void Should_not_generate_a_new_token_on_an_options_request_and_not_add_a_cookie()
         {
+            // Given
             this.optionsRequest.Cookies.Add(CsrfToken.DEFAULT_CSRF_KEY, "ValidToken");
 
             var fakeValidator = A.Fake<ICsrfTokenValidator>();
             A.CallTo(() => fakeValidator.CookieTokenStillValid(A<CsrfToken>.Ignored)).Returns(true);
+
             var csrfStartup = new CsrfApplicationStartup(
                 this.cryptographyConfiguration,
-                this.objectSerializer,
                 fakeValidator);
+
             csrfStartup.Initialize(this.pipelines);
             var context = new NancyContext { Request = this.optionsRequest, Response = this.response };
             context.Items[CsrfToken.DEFAULT_CSRF_KEY] = "ValidToken";
 
+            // When
             this.pipelines.AfterRequest.Invoke(context, new CancellationToken());
 
+            // Then
             this.response.Cookies.Any(c => c.Name == CsrfToken.DEFAULT_CSRF_KEY).ShouldBeFalse();
             context.Items.ContainsKey(CsrfToken.DEFAULT_CSRF_KEY).ShouldBeTrue();
             context.Items[CsrfToken.DEFAULT_CSRF_KEY].ShouldEqual("ValidToken");
@@ -98,18 +107,23 @@
         [Fact]
         public void Should_regenerage_token_if_invalid()
         {
+            // Given
             this.request.Cookies.Add(CsrfToken.DEFAULT_CSRF_KEY, "InvalidToken");
             var fakeValidator = A.Fake<ICsrfTokenValidator>();
+
             A.CallTo(() => fakeValidator.CookieTokenStillValid(A<CsrfToken>.Ignored)).Returns(false);
+
             var csrfStartup = new CsrfApplicationStartup(
                 this.cryptographyConfiguration,
-                this.objectSerializer,
                 fakeValidator);
+
             csrfStartup.Initialize(this.pipelines);
             var context = new NancyContext { Request = this.request, Response = this.response };
 
+            // When
             this.pipelines.AfterRequest.Invoke(context, new CancellationToken());
 
+            // Then
             this.response.Cookies.Any(c => c.Name == CsrfToken.DEFAULT_CSRF_KEY).ShouldBeTrue();
             context.Items.ContainsKey(CsrfToken.DEFAULT_CSRF_KEY).ShouldBeTrue();
             context.Items[CsrfToken.DEFAULT_CSRF_KEY].ShouldNotEqual("InvalidToken");
@@ -118,18 +132,22 @@
         [Fact]
         public void Should_http_decode_cookie_token_when_copied_to_the_context()
         {
+            // Given
             var fakeValidator = A.Fake<ICsrfTokenValidator>();
             A.CallTo(() => fakeValidator.CookieTokenStillValid(A<CsrfToken>.Ignored)).Returns(true);
+
             var csrfStartup = new CsrfApplicationStartup(
                 this.cryptographyConfiguration,
-                this.objectSerializer,
                 fakeValidator);
+
             csrfStartup.Initialize(this.pipelines);
             this.request.Cookies.Add(CsrfToken.DEFAULT_CSRF_KEY, "Testing Token");
             var context = new NancyContext { Request = this.request, Response = this.response };
 
+            // When
             this.pipelines.AfterRequest.Invoke(context, new CancellationToken());
 
+            // Then
             this.response.Cookies.Any(c => c.Name == CsrfToken.DEFAULT_CSRF_KEY).ShouldBeFalse();
             context.Items.ContainsKey(CsrfToken.DEFAULT_CSRF_KEY).ShouldBeTrue();
             context.Items[CsrfToken.DEFAULT_CSRF_KEY].ShouldEqual("Testing Token");
@@ -138,10 +156,13 @@
         [Fact]
         public void Should_create_a_new_token_if_one_doesnt_exist_in_request_or_context()
         {
+            // Given
             var context = new NancyContext { Request = this.request, Response = this.response };
 
+            // When
             this.pipelines.AfterRequest.Invoke(context, new CancellationToken());
 
+            // Then
             this.response.Cookies.Any(c => c.Name == CsrfToken.DEFAULT_CSRF_KEY).ShouldBeTrue();
             context.Items.ContainsKey(CsrfToken.DEFAULT_CSRF_KEY).ShouldBeTrue();
             var cookieValue = this.response.Cookies.FirstOrDefault(c => c.Name == CsrfToken.DEFAULT_CSRF_KEY).Value;
@@ -153,12 +174,16 @@
         [Fact]
         public void Should_be_able_to_disable_csrf()
         {
+            // Given
             var context = new NancyContext { Request = this.request, Response = this.response };
             context.Items[CsrfToken.DEFAULT_CSRF_KEY] = "TestingToken";
 
             Csrf.Disable(this.pipelines);
+
+            // When
             this.pipelines.AfterRequest.Invoke(context, new CancellationToken());
 
+            // Then
             this.response.Cookies.Any(c => c.Name == CsrfToken.DEFAULT_CSRF_KEY).ShouldBeFalse();
         }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
Removed the need to use (de)serialization when writing/reading the `CsrfToken` information from the Crsf cookie. The implementation use a forward-only string reader to parse the content.

<!-- Thanks for contributing to Nancy! -->
