### PR TITLE
Changed date parsing and extracted method

### DIFF
--- a/src/Nancy/Security/Csrf.cs
+++ b/src/Nancy/Security/Csrf.cs
@@ -171,17 +171,17 @@
             return cookieToken;
         }
 
+        private static void AddTokenValue(Dictionary<string, string> dictionary, string key, string value)
+        {
+            if (!string.IsNullOrEmpty(key))
+            {
+                dictionary.Add(key, value);
+            }
+        }
+
         private static CsrfToken ParseToCsrfToken(string cookieTokenString)
         {
             var parsed = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
-            void Add(string key, string value)
-            {
-                if (!string.IsNullOrEmpty(key))
-                {
-                    parsed.Add(key, value);
-                }
-            }
 
             var currentKey = string.Empty;
             var buffer = new StringBuilder();
@@ -197,7 +197,7 @@
                         buffer.Clear();
                         break;
                     case PairDelimiter:
-                        Add(currentKey, buffer.ToString());
+                        AddTokenValue(parsed, currentKey, buffer.ToString());
                         buffer.Clear();
                         break;
                     default:
@@ -206,7 +206,7 @@
                 }
             }
 
-            Add(currentKey, buffer.ToString());
+            AddTokenValue(parsed, currentKey, buffer.ToString());
 
             if (parsed.Keys.Count() != 3)
             {
@@ -217,7 +217,7 @@
             {
                 return new CsrfToken
                 {
-                    CreatedDate = DateTimeOffset.ParseExact(parsed["CreatedDate"], "o", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+                    CreatedDate = DateTimeOffset.ParseExact(parsed["CreatedDate"], "o", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal),
                     Hmac = Convert.FromBase64String(parsed["Hmac"]),
                     RandomBytes = Convert.FromBase64String(parsed["RandomBytes"])
                 };


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [X] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [X] I have provided test coverage for my change (where applicable)

### Description
Removed a C# 7 local method and changed confusing date parsing option for Csrf
