### PR TITLE
Enable CSRF cookie to has secure flag enabled

### DIFF
--- a/src/Nancy/Security/Csrf.cs
+++ b/src/Nancy/Security/Csrf.cs
@@ -26,8 +26,8 @@
         /// <remarks>This is disabled by default.</remarks>
         /// <param name="pipelines">The application pipelines.</param>
         /// <param name="cryptographyConfiguration">The cryptography configuration. This is <see langword="null" /> by default.</param>
-        /// <param name="csrfCookieSecureFlag">Set the CSRF cookie secure flag. This is <see langword="false"/> by default</param>
-        public static void Enable(IPipelines pipelines, CryptographyConfiguration cryptographyConfiguration = null, bool csrfCookieSecureFlag = false)
+        /// <param name="useSecureCookie">Set the CSRF cookie secure flag. This is <see langword="false"/> by default</param>
+        public static void Enable(IPipelines pipelines, CryptographyConfiguration cryptographyConfiguration = null, bool useSecureCookie = false)
         {
             cryptographyConfiguration = cryptographyConfiguration ?? CsrfApplicationStartup.CryptographyConfiguration;
 
@@ -45,7 +45,7 @@
                         context.Response.Cookies.Add(new NancyCookie(
                             CsrfToken.DEFAULT_CSRF_KEY,
                             (string)context.Items[CsrfToken.DEFAULT_CSRF_KEY],
-                            httpOnly:true, secure: csrfCookieSecureFlag));
+                            httpOnly:true, secure: useSecureCookie));
 
                         return;
                     }
@@ -65,7 +65,7 @@
                     var tokenString = GenerateTokenString(cryptographyConfiguration);
 
                     context.Items[CsrfToken.DEFAULT_CSRF_KEY] = tokenString;
-                    context.Response.Cookies.Add(new NancyCookie(CsrfToken.DEFAULT_CSRF_KEY, tokenString, httpOnly: true, secure: csrfCookieSecureFlag));
+                    context.Response.Cookies.Add(new NancyCookie(CsrfToken.DEFAULT_CSRF_KEY, tokenString, httpOnly: true, secure: useSecureCookie));
                 });
 
             pipelines.AfterRequest.AddItemToEndOfPipeline(postHook);

--- a/src/Nancy/Security/Csrf.cs
+++ b/src/Nancy/Security/Csrf.cs
@@ -45,7 +45,7 @@
                         context.Response.Cookies.Add(new NancyCookie(
                             CsrfToken.DEFAULT_CSRF_KEY,
                             (string)context.Items[CsrfToken.DEFAULT_CSRF_KEY],
-                            httpOnly:true, secure: useSecureCookie));
+                            true, useSecureCookie));
 
                         return;
                     }
@@ -65,7 +65,7 @@
                     var tokenString = GenerateTokenString(cryptographyConfiguration);
 
                     context.Items[CsrfToken.DEFAULT_CSRF_KEY] = tokenString;
-                    context.Response.Cookies.Add(new NancyCookie(CsrfToken.DEFAULT_CSRF_KEY, tokenString, httpOnly: true, secure: useSecureCookie));
+                    context.Response.Cookies.Add(new NancyCookie(CsrfToken.DEFAULT_CSRF_KEY, tokenString, true, useSecureCookie));
                 });
 
             pipelines.AfterRequest.AddItemToEndOfPipeline(postHook);

--- a/src/Nancy/Security/Csrf.cs
+++ b/src/Nancy/Security/Csrf.cs
@@ -26,7 +26,8 @@
         /// <remarks>This is disabled by default.</remarks>
         /// <param name="pipelines">The application pipelines.</param>
         /// <param name="cryptographyConfiguration">The cryptography configuration. This is <see langword="null" /> by default.</param>
-        public static void Enable(IPipelines pipelines, CryptographyConfiguration cryptographyConfiguration = null)
+        /// <param name="csrfCookieSecureFlag">Set the CSRF cookie secure flag. This is <see langword="false"/> by default</param>
+        public static void Enable(IPipelines pipelines, CryptographyConfiguration cryptographyConfiguration = null, bool csrfCookieSecureFlag = false)
         {
             cryptographyConfiguration = cryptographyConfiguration ?? CsrfApplicationStartup.CryptographyConfiguration;
 
@@ -44,7 +45,7 @@
                         context.Response.Cookies.Add(new NancyCookie(
                             CsrfToken.DEFAULT_CSRF_KEY,
                             (string)context.Items[CsrfToken.DEFAULT_CSRF_KEY],
-                            true));
+                            httpOnly:true, secure: csrfCookieSecureFlag));
 
                         return;
                     }
@@ -64,7 +65,7 @@
                     var tokenString = GenerateTokenString(cryptographyConfiguration);
 
                     context.Items[CsrfToken.DEFAULT_CSRF_KEY] = tokenString;
-                    context.Response.Cookies.Add(new NancyCookie(CsrfToken.DEFAULT_CSRF_KEY, tokenString, true));
+                    context.Response.Cookies.Add(new NancyCookie(CsrfToken.DEFAULT_CSRF_KEY, tokenString, httpOnly: true, secure: csrfCookieSecureFlag));
                 });
 
             pipelines.AfterRequest.AddItemToEndOfPipeline(postHook);


### PR DESCRIPTION
### Prerequisites

- [:fire: ] I have written a descriptive pull-request title
- [:fire: ] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [:fire: even used this. and feel unclean ] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [-] I have provided test coverage for my change (where applicable)

### Description
Adds optional bool to signature of Csrf.Enable(this.pipelines) to set the csrf cookies secure flag.
I've set it to false by default to avoid unintended activation. 
Resolves #2649
