### PR TITLE
Regression: System.NotSupportedException: The stream does not support writing.

### DIFF
--- a/src/Nancy/IO/RequestStream.cs
+++ b/src/Nancy/IO/RequestStream.cs
@@ -500,7 +500,7 @@
                 this.stream.Position = 0;
             }
             this.stream.CopyTo(targetStream, 8196);
-            if (this.stream.CanSeek)
+            if (this.stream.CanWrite)
             {
                 this.stream.Flush();
             }


### PR DESCRIPTION
- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)


This is a duplicate of #1014. It happens when trying to upload a file larger than `RequestStream.DEFAULT_SWITCHOVER_THRESHOLD`.

Stacktrace:
```
System.NotSupportedException: The stream does not support writing.
   at System.Net.Http.StreamContent.ReadOnlyStream.Flush()
   at Nancy.IO.RequestStream.MoveStreamContentsToFileStream()
   at Nancy.IO.RequestStream.MoveStreamOutOfMemoryIfExpectedLengthExceedSwitchLength(Int64 expectedLength)
   at Nancy.IO.RequestStream..ctor(Stream stream, Int64 expectedLength, Int64 thresholdLength, Boolean disableStreamSwitching)
   at Nancy.IO.RequestStream..ctor(Stream stream, Int64 expectedLength, Boolean disableStreamSwitching)
   at Nancy.Owin.NancyMiddleware.<>c__DisplayClass2_1.<<UseNancy>b__1>d.MoveNext()
```