### PR TITLE
Ignore If-Modified-Since when If-None-Match is set

### DIFF
--- a/src/Nancy/Helpers/CacheHelpers.cs
+++ b/src/Nancy/Helpers/CacheHelpers.cs
@@ -24,12 +24,13 @@
             }
 
             var requestEtag = context.Request.Headers.IfNoneMatch.FirstOrDefault();
-            var requestDate = context.Request.Headers.IfModifiedSince;
 
-            if (requestEtag != null && !string.IsNullOrEmpty(etag) && requestEtag.Equals(etag, StringComparison.Ordinal))
+            if (requestEtag != null && !string.IsNullOrEmpty(etag))
             {
-                return true;
+                return requestEtag.Equals(etag, StringComparison.Ordinal);
             }
+
+            var requestDate = context.Request.Headers.IfModifiedSince;
 
             if (requestDate.HasValue && lastModified.HasValue && ((int)(lastModified.Value - requestDate.Value).TotalSeconds) <= 0)
             {


### PR DESCRIPTION
From RFC 7232:
>A recipient MUST ignore If-Modified-Since if the request contains an
>   If-None-Match header field; the condition in If-None-Match is
>   considered to be a more accurate replacement for the condition in
>   If-Modified-Since, and the two are only combined for the sake of
>   interoperating with older intermediaries that might not implement
>   If-None-Match.
