### PR TITLE
Added now mandatory configurations

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,12 +2,14 @@
   <PropertyGroup>
     <Authors>Andreas Håkansson, Steven Robbins and contributors</Authors>
     <CodeAnalysisRuleSet>..\..\Nancy.ruleset</CodeAnalysisRuleSet>
+    <Configurations>Debug;Release</Configurations>
     <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' == 'net452' ">true</DisableImplicitFrameworkReferences>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageIconUrl>http://nancyfx.org/nancy-nuget.png</PackageIconUrl>
     <PackageLicenseUrl>https://github.com/NancyFx/Nancy/blob/master/license.txt</PackageLicenseUrl>
     <PackageProjectUrl>http://nancyfx.org</PackageProjectUrl>
     <PackageTags>Nancy</PackageTags>
+    <Platforms>AnyCPU</Platforms>
     <Version>2.0.0-clinteastwood</Version>
   </PropertyGroup>
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,7 +1,9 @@
 <Project>
   <PropertyGroup>
-    <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' == 'net452' ">true</DisableImplicitFrameworkReferences>
     <CodeAnalysisRuleSet>..\..\Nancy.ruleset</CodeAnalysisRuleSet>
+    <Configurations>Debug;Release</Configurations>
+    <DisableImplicitFrameworkReferences Condition=" '$(TargetFramework)' == 'net452' ">true</DisableImplicitFrameworkReferences>
+    <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [X] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [X] I have provided test coverage for my change (where applicable)

### Description
Due to a breaking change between Visual Studio `15.2` -> `15.3` we now have to specify `Configurations` and `Platforms` in our `*.csproj` files. I've added both to our two `Directory.Build.props` files. More information about the breaking change can be found as https://github.com/dotnet/project-system/blob/master/docs/configurations.md (was found thanks to this bug report https://github.com/dotnet/project-system/issues/2604)
