### PR TITLE
Url encode `ApplicationPath` to correctly compare with already encoded `Uri.AbsolutePath`

### DIFF
--- a/src/Nancy.Hosting.Aspnet.Tests/NancyHandlerFixture.cs
+++ b/src/Nancy.Hosting.Aspnet.Tests/NancyHandlerFixture.cs
@@ -110,6 +110,27 @@ namespace Nancy.Hosting.Aspnet.Tests
             A.CallTo(() => disposable.Dispose()).MustHaveHappened(Repeated.Exactly.Once);
         }
 
+        [Fact]
+        public async Task Should_contain_correct_path_when_uri_contains_space()
+        {
+            var nancyContext = new NancyContext() { Response = new Response() };
+            A.CallTo(() => this.request.HttpMethod).Returns("GET");
+            A.CallTo(() => this.request.ApplicationPath).Returns("/web root");
+            A.CallTo(() => this.request.Url).Returns(new Uri("http://ihatedummydata.com/web root/api/"));
+            A.CallTo(() => this.engine.HandleRequest(
+                                        A<Request>.Ignored,
+                                        A<Func<NancyContext, NancyContext>>.Ignored,
+                                        A<CancellationToken>.Ignored))
+                                      .Returns(Task.FromResult(nancyContext));
+
+            await this.handler.ProcessRequest(this.context);
+
+            A.CallTo(() => this.engine.HandleRequest(A<Request>
+                .That
+                .Matches(x => x.Url.Path == "/api/"), A<Func<NancyContext, NancyContext>>.Ignored, A<CancellationToken>.Ignored))
+                .MustHaveHappened();
+        }
+
         private void SetupRequestProcess(NancyContext nancyContext)
         {
             A.CallTo(() => this.request.AppRelativeCurrentExecutionFilePath).Returns("~/about");

--- a/src/Nancy.Hosting.Aspnet/NancyHandler.cs
+++ b/src/Nancy.Hosting.Aspnet/NancyHandler.cs
@@ -73,7 +73,7 @@ namespace Nancy.Hosting.Aspnet
             var expectedRequestLength =
                 GetExpectedRequestLength(incomingHeaders);
 
-            var basePath = context.Request.ApplicationPath.TrimEnd('/');
+            var basePath = HttpUtility.UrlEncode(context.Request.ApplicationPath).TrimEnd('/');
 
             var path = context.Request.Url.AbsolutePath.Substring(basePath.Length);
             path = string.IsNullOrWhiteSpace(path) ? "/" : path;


### PR DESCRIPTION
### Prerequisites

- [X] I have written a descriptive pull-request title
- [X] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [X] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [X] I have provided test coverage for my change (where applicable)

### Description
The `CreateNancyRequest` method of the `NancyHandler` class in `Nancy.Hosting.Aspnet` namespace is using the [`HttpRequest.ApplicationPath`](https://docs.microsoft.com/en-us/dotnet/api/system.web.httprequest.applicationpath?view=netframework-4.7.1) to get the `basePath` of the request and uses [`Uri.AbsolutePath`](https://docs.microsoft.com/en-us/dotnet/api/system.uri.absolutepath?view=netframework-4.7.1#System_Uri_AbsolutePath) to get the whole path. Then the `basePath` is stripped from the path and this is where the problem occurs.
It seems like `ApplicationPath` is already unescaped, while `AbsolutePath` is not.

So if we have a url `http://ihatedummydata.com/web root/api/` then the `AbsolutePath` = `/web%20root/api/`. However if the `ApplicationPath` is the `/web root` part, then `ApplicationPath` = `/web root` and not `/web%20root`.

So if we use the `ApplicationPath` length (9 in this case) as `startIndex` in a `Substring` operation on the `AbsolutePath` we would get `ot/api/`, instead of the expected `/api/`.

The suggested solution is to url encode `ApplicationPath`.

<!-- Thanks for contributing to Nancy! -->