### PR TITLE
Case-insensitive Basic Authentication Scheme

### DIFF
--- a/src/Nancy.Authentication.Basic/BasicAuthentication.cs
+++ b/src/Nancy.Authentication.Basic/BasicAuthentication.cs
@@ -114,7 +114,7 @@
                 return null;
             }
 
-            if (!authorization.StartsWith(SCHEME))
+            if (!authorization.StartsWith(SCHEME, StringComparison.OrdinalIgnoreCase))
             {
                 return null;
             }

--- a/test/Nancy.Authentication.Basic.Tests/BasicAuthenticationFixture.cs
+++ b/test/Nancy.Authentication.Basic.Tests/BasicAuthenticationFixture.cs
@@ -222,6 +222,23 @@
             context.CurrentUser.ShouldBeNull();
         }
 
+        [Theory]
+        [InlineData("Basic")]
+        [InlineData("BASIC")]
+        [InlineData("basic")]
+        public void Pre_request_hook_should_call_user_validator_when_valid_scheme_in_auth_header(string scheme)
+        {
+            // Given
+            var context = CreateContextWithHeader(
+                "Authorization", new[] { scheme + " " + EncodeCredentials("foo", "bar") });
+
+            // When
+            var result = this.hooks.BeforeRequest.Invoke(context, new CancellationToken());
+
+            // Then
+            A.CallTo(() => config.UserValidator.Validate("foo", "bar")).MustHaveHappened();
+        }
+
         [Fact]
         public void Pre_request_hook_should_not_authenticate_when_invalid_encoded_username_in_auth_header()
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
When basic authentication extract credential from headers it returns null where request header authorization does not start with constant case sensitive string **"Basic"** [cref](https://github.com/NancyFx/Nancy/blob/master/src/Nancy.Authentication.Basic/BasicAuthentication.cs#L117). 

According to [RFC2617](https://tools.ietf.org/html/rfc2617#section-1.2) _HTTP provides a simple challenge-response authentication mechanism that MAY be used by a server to challenge a client request and by a client to provide authentication information. It uses an extensible, **case-insensitive** token to identify the authentication scheme..._

<!-- Thanks for contributing to Nancy! -->

  