### PR TITLE
Updated tests\Directory.Build.props

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -20,7 +20,13 @@
 
   <ItemGroup>
     <ProjectReference Include="../../src/Nancy/Nancy.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(MSBuildProjectName)' != 'Nancy.Tests' and '$(MSBuildProjectName)' != 'Nancy.Tests.Functional' ">
     <ProjectReference Include="../../src/$(ProjectUnderTest)/$(ProjectUnderTest).csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(MSBuildProjectName)' != 'Nancy.Testing.Tests' ">
     <ProjectReference Include="../../src/Nancy.Testing/Nancy.Testing.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
There were some issues with the old implementation, causing weird includes for some tests projects that could cause the compiler to throw a fit
