### PR TITLE
Grab the SDK version from global.json

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,5 +1,5 @@
 $CakeVersion = "0.19.4"
-$DotNetVersion = "1.0.3";
+$DotNetVersion = select-string -Path .\global.json -Pattern '[\d]\.[\d]\.[\d]' | % {$_.Matches} | % {$_.Value };
 $DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.1/scripts/obtain/dotnet-install.ps1";
 
 # Make sure tools folder exists

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR=$PWD
 TOOLS_DIR=$SCRIPT_DIR/tools
 CAKE_VERSION=0.19.4
 CAKE_DLL=$TOOLS_DIR/Cake.CoreCLR.$CAKE_VERSION/Cake.dll
-DOTNET_VERSION=1.0.3
+DOTNET_VERSION=$(cat global.json | grep -Po '[\d]\.[\d]\.[\d]')
 DOTNET_INSTRALL_URI=https://raw.githubusercontent.com/dotnet/cli/rel/1.0.1/scripts/obtain/dotnet-install.sh
 
 # Make sure the tools folder exist.


### PR DESCRIPTION
This should prevent the build scripts from becoming out of sync with the SDK version (`build.ps1` looks completely changed because line-endings were changes to `CRLF`)