### PR TITLE
Add IsNullOrWhiteSpace check to the DeserializeObject method

### DIFF
--- a/src/Nancy/Json/Simple/SimpleJson.cs
+++ b/src/Nancy/Json/Simple/SimpleJson.cs
@@ -530,6 +530,11 @@ namespace Nancy.Json.Simple
         /// <returns>An IList&lt;object>, a IDictionary&lt;string,object>, a double, a string, null, true, or false</returns>
         public static object DeserializeObject(string json)
         {
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return null;
+            }
+
             object obj;
             if (TryDeserializeObject(json, out obj))
                 return obj;

--- a/test/Nancy.Tests/Unit/Json/SimpleJsonFixture.cs
+++ b/test/Nancy.Tests/Unit/Json/SimpleJsonFixture.cs
@@ -9,41 +9,41 @@
         [Fact]
         public void String_dictionary_values_are_Json_serialized_as_strings()
         {
-            //Given
+            // Given
             dynamic value = "42";
             var input = new DynamicDictionaryValue(value);
 
-            //When
+            // When
             var actual = SimpleJson.SerializeObject(input, new NancySerializationStrategy(), false);
 
-            //Then
+            // Then
             actual.ShouldEqual(@"""42""");
         }
 
         [Fact]
         public void Integer_dictionary_values_are_Json_serialized_as_integers()
         {
-            //Given
+            // Given
             dynamic value = 42;
             var input = new DynamicDictionaryValue(value);
 
-            //When
+            // When
             var actual = SimpleJson.SerializeObject(input, new NancySerializationStrategy(), false);
 
-            //Then
+            // Then
             actual.ShouldEqual(@"42");
         }
 
         [Fact]
         public void Should_serialize_enum_to_string()
         {
-            //Given
+            // Given
             var model = new ModelTest { EnumModel = TestEnum.Freddy };
 
-            //When
+            // When
             var result = SimpleJson.SerializeObject(model, new NancySerializationStrategy(false, true), false);
 
-            //Then
+            // Then
             result.ShouldEqual("{\"enumModel\":\"Freddy\"}");
         }
 
@@ -52,8 +52,10 @@
         {
             // Given
             var json = "42";
+
             // When
             var result = SimpleJson.DeserializeObject(json, typeof(ulong), DateTimeStyles.None);
+
             // Then
             result.ShouldEqual(42ul);
         }
@@ -63,8 +65,10 @@
         {
             // Given
             var json = "42";
+
             // When
             var result = SimpleJson.DeserializeObject(json, typeof(ushort), DateTimeStyles.None);
+
             // Then
             result.ShouldEqual((ushort)42);
         }
@@ -132,6 +136,45 @@
 
             // Then
             result.SomeNullableInt.ShouldEqual(null);
+        }
+
+        [Fact]
+        public void Should_deserialize_null_string_to_null_object()
+        {
+            // Given
+            const string json = null;
+
+            // When
+            var result = SimpleJson.DeserializeObject(json);
+
+            // Then
+            result.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Should_deserialize_empty_string_to_null_object()
+        {
+            // Given
+            var json = string.Empty;
+
+            // When
+            var result = SimpleJson.DeserializeObject(json);
+
+            // Then
+            result.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Should_deserialize_white_space_to_null_object()
+        {
+            // Given
+            const string json = " \t\r\n ";
+
+            // When
+            var result = SimpleJson.DeserializeObject(json);
+
+            // Then
+            result.ShouldBeNull();
         }
 
         public class ModelTest


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
Adds an `IsNullOrWhiteSpace` check to the `SimpleJson.DeserializeObject()` method so `null`, empty, and white space strings all return a `null` object instead of throwing an exception.

Fixes #2741 
  