### PR TITLE
Fix test execution that relies on code compilation

### DIFF
--- a/src/Nancy.ViewEngines.Razor/Nancy.ViewEngines.Razor.csproj
+++ b/src/Nancy.ViewEngines.Razor/Nancy.ViewEngines.Razor.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="1.0.3" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -37,7 +37,7 @@
   <ItemGroup>
     <PackageReference Include="FakeItEasy" Version="4.0.0" />
     <PackageReference Include="FakeItEasy.Analyzer.CSharp" Version="4.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
   </ItemGroup>

--- a/test/Nancy.Tests/Nancy.Tests.csproj
+++ b/test/Nancy.Tests/Nancy.Tests.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="1.3.2" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
For some reason tests, that rely on code compilation (such as the Razor tests and one of the bootstrapper tests) fail on my machine without these fixes.

## Changes

- Added explicit package reference to `System.Collections.Immutable` version `1.2.0` in `Nancy.Tests` and `Nancy.ViewEngines.Razor.Tests`
- Updated `Microsoft.NET.Test.Sdk` to version `15.5.0` since they did some fixes in `15.3.0` worth having

> ℹ️  Ideally I'd like @khellang and @jchannon to try and run the tests, on their machines before we merge this. Not sure if the problem is only on my machine, or if it's a general problem. The tests do appear to function on our CI servers and I'm not sure why.
