### PR TITLE
Virtual methods on assembly catalogs

### DIFF
--- a/src/Nancy/AppDomainAssemblyCatalog.cs
+++ b/src/Nancy/AppDomainAssemblyCatalog.cs
@@ -22,7 +22,7 @@ namespace Nancy
         /// Gets all <see cref="Assembly"/> instances in the catalog.
         /// </summary>
         /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Assembly"/> instances.</returns>
-        public IReadOnlyCollection<Assembly> GetAssemblies()
+        public virtual IReadOnlyCollection<Assembly> GetAssemblies()
         {
             return this.assemblies.Value;
         }

--- a/src/Nancy/DependencyContextAssemblyCatalog.cs
+++ b/src/Nancy/DependencyContextAssemblyCatalog.cs
@@ -38,7 +38,7 @@ namespace Nancy
         /// Gets all <see cref="Assembly"/> instances in the catalog.
         /// </summary>
         /// <returns>An <see cref="IReadOnlyCollection{T}"/> of <see cref="Assembly"/> instances.</returns>
-        public IReadOnlyCollection<Assembly> GetAssemblies()
+        public virtual IReadOnlyCollection<Assembly> GetAssemblies()
         {
             var results = new HashSet<Assembly>
             {


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
Made the `GetAssemblies`-method as `virtual`, on `AppDomainAssemblyCatalog` and `DependencyContextAssemblyCatalog`

Resolves #2722
