### PR TITLE
Updated build scripts to use non-core version of CAKE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: csharp
 os:
   - linux
+  - osx
 
 sudo: required
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 language: csharp
-mono: alpha
+os:
+  - linux
+
 sudo: required
 dist: trusty
-addons:
-  apt:
-    packages:
-    - gettext
-    - libcurl4-openssl-dev
-    - libicu-dev
-    - libssl-dev
-    - libunwind8
-env:
-    - MONO_TLS_PROVIDER=legacy
-script: ./build.sh --verbosity=minimal
+
+mono:
+  - 4.4.2
+
+dotnet: 1.1.4
+
+script:
+  - ./build.sh --verbosity=minimal
+
 notifications:
   email:
     - nancy@nancyfx.org

--- a/build.cake
+++ b/build.cake
@@ -108,6 +108,17 @@ Task("Package-NuGet")
     {
         foreach(var project in GetFiles("./src/**/*.csproj"))
         {
+            Information("Packaging " + project.GetFilename().FullPath);
+
+            var content =
+                System.IO.File.ReadAllText(project.FullPath, Encoding.UTF8);
+
+            if (IsRunningOnUnix() && content.Contains(">" + fullFrameworkTarget + "<"))
+            {
+                Information(project.GetFilename() + " only supports " +fullFrameworkTarget + " and cannot be packaged on *nix. Skipping.");
+                continue;
+            }
+
             DotNetCorePack(project.GetDirectory().FullPath, new DotNetCorePackSettings {
                 Configuration = configuration,
                 OutputDirectory = outputNuGet

--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-$CakeVersion = "0.19.4"
+$CakeVersion = "0.24.0"
 $DotNetVersion = select-string -Path .\global.json -Pattern '[\d]\.[\d]\.[\d]' | % {$_.Matches} | % {$_.Value };
 $DotNetInstallerUri = "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.1/scripts/obtain/dotnet-install.ps1";
 
@@ -43,6 +43,7 @@ if($FoundDotNetCliVersion -ne $DotNetVersion) {
     if (!(Test-Path $InstallPath)) {
         mkdir -Force $InstallPath | Out-Null;
     }
+
     (New-Object System.Net.WebClient).DownloadFile($DotNetInstallerUri, "$InstallPath\dotnet-install.ps1");
     & $InstallPath\dotnet-install.ps1 -Channel preview -Version $DotNetVersion -InstallDir $InstallPath;
 
@@ -68,17 +69,17 @@ Function Unzip
 
 
 # Make sure Cake has been installed.
-$CakePath = Join-Path $ToolPath "Cake.CoreCLR.$CakeVersion/Cake.dll"
+$CakePath = Join-Path $ToolPath "Cake.$CakeVersion/Cake.exe"
 if (!(Test-Path $CakePath)) {
     Write-Host "Installing Cake..."
-     (New-Object System.Net.WebClient).DownloadFile("https://www.nuget.org/api/v2/package/Cake.CoreCLR/$CakeVersion", "$ToolPath\Cake.CoreCLR.zip")
-     Unzip "$ToolPath\Cake.CoreCLR.zip" "$ToolPath/Cake.CoreCLR.$CakeVersion"
-     Remove-Item "$ToolPath\Cake.CoreCLR.zip"
+    (New-Object System.Net.WebClient).DownloadFile("https://www.nuget.org/api/v2/package/Cake/$CakeVersion", "$ToolPath\Cake.zip")
+    Unzip "$ToolPath\Cake.zip" "$ToolPath/Cake.$CakeVersion"
+    Remove-Item "$ToolPath\Cake.zip"
 }
 
 ###########################################################################
 # RUN BUILD SCRIPT
 ###########################################################################
 
-& dotnet "$CakePath" $args
+& "$CakePath" $args
 exit $LASTEXITCODE

--- a/build.sh
+++ b/build.sh
@@ -3,9 +3,9 @@
 # Define directories.
 SCRIPT_DIR=$PWD
 TOOLS_DIR=$SCRIPT_DIR/tools
-CAKE_VERSION=0.19.4
-CAKE_DLL=$TOOLS_DIR/Cake.CoreCLR.$CAKE_VERSION/Cake.dll
-DOTNET_VERSION=$(cat global.json | grep -Po '[\d]\.[\d]\.[\d]')
+CAKE_VERSION=0.24.0
+CAKE_DLL=$TOOLS_DIR/Cake.$CAKE_VERSION/Cake.exe
+DOTNET_VERSION=$(cat global.json | grep -o '[0-9]\.[0-9]\.[0-9]')
 DOTNET_INSTRALL_URI=https://raw.githubusercontent.com/dotnet/cli/rel/1.0.1/scripts/obtain/dotnet-install.sh
 
 # Make sure the tools folder exist.
@@ -28,13 +28,12 @@ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 "$SCRIPT_DIR/.dotnet/dotnet" --info
 
-
 ###########################################################################
 # INSTALL CAKE
 ###########################################################################
 
 if [ ! -f "$CAKE_DLL" ]; then
-    curl -Lsfo "$TOOLS_DIR/Cake.CoreCLR.zip" "https://www.nuget.org/api/v2/package/Cake.CoreCLR/$CAKE_VERSION" && unzip -q "$TOOLS_DIR/Cake.CoreCLR.zip" -d "$TOOLS_DIR/Cake.CoreCLR.$CAKE_VERSION" && rm -f "$TOOLS_DIR/Cake.CoreCLR.zip"
+    curl -Lsfo Cake.zip "https://www.nuget.org/api/v2/package/Cake/$CAKE_VERSION" && unzip -q Cake.zip -d "$TOOLS_DIR/Cake.$CAKE_VERSION" && rm -f Cake.zip
     if [ $? -ne 0 ]; then
         echo "An error occured while installing Cake."
         exit 1
@@ -55,4 +54,4 @@ fi
 export FrameworkPathOverride=$(dirname $(which mono))/../lib/mono/4.5/
 
 # Start Cake
-exec dotnet "$CAKE_DLL" "$@"
+exec mono "$CAKE_DLL" "$@"


### PR DESCRIPTION
Making some preparations to enable us to support `netstandard2`

## Planned changes
- [x] Update `.travis.yml` to build using `dotnet 1.1.4`
- [x] Update `build.ps1` to use the non-core version of CAKE and `0.24.0`
- [x] Update `build.sh` to use the non-core version of CAKE and `0.24.0`
  
  