### PR TITLE
Small perfomance improvments for Dictionary

### DIFF
--- a/src/Nancy.Authentication.Forms/FormsAuthentication.cs
+++ b/src/Nancy.Authentication.Forms/FormsAuthentication.cs
@@ -243,12 +243,11 @@ namespace Nancy.Authentication.Forms
         /// <returns>Returns user guid, or Guid.Empty if not present or invalid</returns>
         private static Guid GetAuthenticatedUserFromCookie(NancyContext context, FormsAuthenticationConfiguration configuration)
         {
-            if (!context.Request.Cookies.ContainsKey(formsAuthenticationCookieName))
+            string cookieValueEncrypted;
+            if (!context.Request.Cookies.TryGetValue(formsAuthenticationCookieName, out cookieValueEncrypted))
             {
                 return Guid.Empty;
             }
-
-            var cookieValueEncrypted = context.Request.Cookies[formsAuthenticationCookieName];
 
             if (string.IsNullOrEmpty(cookieValueEncrypted))
             {

--- a/src/Nancy.Hosting.Aspnet/NancyHandler.cs
+++ b/src/Nancy.Hosting.Aspnet/NancyHandler.cs
@@ -97,13 +97,13 @@ namespace Nancy.Hosting.Aspnet
                 return 0;
             }
 
-            if (!incomingHeaders.ContainsKey("Content-Length"))
+            IEnumerable<string> values;
+            if (!incomingHeaders.TryGetValue("Content-Length", out values))
             {
                 return 0;
             }
 
-            var headerValue =
-                incomingHeaders["Content-Length"].SingleOrDefault();
+            var headerValue = values.SingleOrDefault();
 
             if (headerValue == null)
             {

--- a/src/Nancy.Hosting.Self/NancyHost.cs
+++ b/src/Nancy.Hosting.Self/NancyHost.cs
@@ -11,7 +11,6 @@
     using System.Threading.Tasks;
     using Nancy.Bootstrapper;
     using Nancy.Extensions;
-    using Nancy.Helpers;
     using Nancy.IO;
     using System.Threading;
 
@@ -371,8 +370,9 @@
                 buffer = memoryStream.ToArray();
             }
 
-            var contentLength = (nancyResponse.Headers.ContainsKey("Content-Length")) ?
-                Convert.ToInt64(nancyResponse.Headers["Content-Length"]) :
+            string value;
+            var contentLength = nancyResponse.Headers.TryGetValue("Content-Length", out value) ?
+                Convert.ToInt64(value) :
                 buffer.Length;
 
             response.SendChunked = false;
@@ -395,13 +395,13 @@
                 return 0;
             }
 
-            if (!incomingHeaders.ContainsKey("Content-Length"))
+            IEnumerable<string> values;
+            if (!incomingHeaders.TryGetValue("Content-Length", out values))
             {
                 return 0;
             }
 
-            var headerValue =
-                incomingHeaders["Content-Length"].SingleOrDefault();
+            var headerValue = values.SingleOrDefault();
 
             if (headerValue == null)
             {

--- a/src/Nancy.Metadata.Modules/MetadataModule.cs
+++ b/src/Nancy.Metadata.Modules/MetadataModule.cs
@@ -44,9 +44,10 @@
         /// <returns>An instance of <see cref="MetadataType"/> if one exists, otherwise null.</returns>
         public object GetMetadata(RouteDescription description)
         {
-            if (this.metadata.ContainsKey(description.Name))
+            Func<RouteDescription, TMetadata> func;
+            if (this.metadata.TryGetValue(description.Name, out func))
             {
-                return this.metadata[description.Name].Invoke(description);
+                return func.Invoke(description);
             }
 
             return null;

--- a/src/Nancy.Owin/AppBuilderExtensions.cs
+++ b/src/Nancy.Owin/AppBuilderExtensions.cs
@@ -44,12 +44,13 @@ namespace Owin
 
         private static void HookDisposal(IAppBuilder builder, NancyOptions nancyOptions)
         {
-            if (!builder.Properties.ContainsKey(AppDisposingKey))
+            object value;
+            if (!builder.Properties.TryGetValue(AppDisposingKey, out value))
             {
                 return;
             }
 
-            var appDisposing = builder.Properties[AppDisposingKey] as CancellationToken?;
+            var appDisposing = value as CancellationToken?;
 
             if (appDisposing.HasValue)
             {

--- a/src/Nancy.Testing/ConfigurableBootstrapper.cs
+++ b/src/Nancy.Testing/ConfigurableBootstrapper.cs
@@ -2102,7 +2102,8 @@ namespace Nancy.Testing
             /// <returns>The <see cref="INancyModule"/> instance</returns>
             public INancyModule GetModule(Type moduleType, NancyContext context)
             {
-                return this.moduleInstances.ContainsKey(moduleType.FullName) ? this.moduleInstances[moduleType.FullName] : null;
+                INancyModule module;
+                return this.moduleInstances.TryGetValue(moduleType.FullName, out module) ? module : null;
             }
 
             /// <summary>

--- a/src/Nancy.Testing/NancyContextExtensions.cs
+++ b/src/Nancy.Testing/NancyContextExtensions.cs
@@ -20,9 +20,10 @@ namespace Nancy.Testing
             // We only really want to generate this once, so we'll stick it in the context
             // This isn't ideal, but we don't want to hide the guts of the context from the
             // tests this will have to do.
-            if (context.Items.ContainsKey(key))
+            object value;
+            if (context.Items.TryGetValue(key, out value))
             {
-                return (T)context.Items[key];
+                return (T)value;
             }
 
             T data = getData.Invoke();

--- a/src/Nancy.Testing/TestingViewBrowserResponseExtensions.cs
+++ b/src/Nancy.Testing/TestingViewBrowserResponseExtensions.cs
@@ -53,12 +53,13 @@
 
         private static string GetContextValue(BrowserResponse response, string key)
         {
-            if (!response.Context.Items.ContainsKey(key))
+            object val;
+            if (!response.Context.Items.TryGetValue(key, out val))
             {
                 return string.Empty;
             }
 
-            var value = (string)response.Context.Items[key];
+            var value = (string)val;
             return string.IsNullOrEmpty(value) ? string.Empty : value;
         }
     }

--- a/src/Nancy.ViewEngines.Razor/CSharp/CSharpClrTypeResolver.cs
+++ b/src/Nancy.ViewEngines.Razor/CSharp/CSharpClrTypeResolver.cs
@@ -2,7 +2,6 @@ namespace Nancy.ViewEngines.Razor.CSharp
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Web.Razor.Tokenizer.Symbols;
 
     /// <summary>
@@ -83,8 +82,8 @@ namespace Nancy.ViewEngines.Razor.CSharp
                 {"bool", typeof (bool)},
                 {"object", typeof (object)},
             };
-
-            return (primitives.ContainsKey(typeName) ? primitives[typeName] : null);
+            Type type;
+            return primitives.TryGetValue(typeName, out type) ? type : null;
         }
     }
 }

--- a/src/Nancy/Diagnostics/DiagnosticsHook.cs
+++ b/src/Nancy/Diagnostics/DiagnosticsHook.cs
@@ -228,12 +228,12 @@ namespace Nancy.Diagnostics
                 return ProcessLogin(context, diagnosticsConfiguration, serializer);
             }
 
-            if (!context.Request.Cookies.ContainsKey(diagnosticsConfiguration.CookieName))
+            string encryptedValue;
+            if (!context.Request.Cookies.TryGetValue(diagnosticsConfiguration.CookieName, out encryptedValue))
             {
                 return null;
             }
 
-            var encryptedValue = context.Request.Cookies[diagnosticsConfiguration.CookieName];
             var hmacStringLength = Base64Helpers.GetBase64Length(diagnosticsConfiguration.CryptographyConfiguration.HmacProvider.HmacLength);
             var encryptedSession = encryptedValue.Substring(hmacStringLength);
             var hmacString = encryptedValue.Substring(0, hmacStringLength);

--- a/src/Nancy/Extensions/ModelValidationErrorExtensions.cs
+++ b/src/Nancy/Extensions/ModelValidationErrorExtensions.cs
@@ -18,12 +18,14 @@
         /// <returns>A reference to the <see cref="ModelValidationResult.Errors"/> property.</returns>
         public static IDictionary<string, IList<ModelValidationError>> Add(this IDictionary<string, IList<ModelValidationError>> errors, string name, string errorMessage)
         {
-            if (!errors.ContainsKey(name))
+            IList<ModelValidationError> value;
+            if (!errors.TryGetValue(name, out value))
             {
-                errors[name] = new List<ModelValidationError>();
+                value = new List<ModelValidationError>();
+                errors[name] = value;
             }
 
-            errors[name].Add(new ModelValidationError(name, errorMessage));
+            value.Add(new ModelValidationError(name, errorMessage));
 
             return errors;
         }

--- a/src/Nancy/Helpers/HttpEncoder.cs
+++ b/src/Nancy/Helpers/HttpEncoder.cs
@@ -479,8 +479,9 @@ namespace Nancy.Helpers
                     if (c == ';')
                     {
                         string key = entity.ToString();
-                        if (key.Length > 1 && Entities.ContainsKey(key.Substring(1, key.Length - 2)))
-                            key = Entities[key.Substring(1, key.Length - 2)].ToString();
+                        char value;
+                        if (key.Length > 1 && Entities.TryGetValue(key.Substring(1, key.Length - 2), out value))
+                            key = value.ToString();
 
                         output.Append(key);
                         state = 0;

--- a/src/Nancy/Json/Simple/SimpleJson.cs
+++ b/src/Nancy/Json/Simple/SimpleJson.cs
@@ -259,7 +259,8 @@ namespace Nancy.Json.Simple
         /// </returns>
         public bool Contains(KeyValuePair<string, object> item)
         {
-            return this._members.ContainsKey(item.Key) && this._members[item.Key] == item.Value;
+            object value;
+            return this._members.TryGetValue(item.Key, out value) && value == item.Value;
         }
 
         /// <summary>

--- a/src/Nancy/Json/SimpleJson.cs
+++ b/src/Nancy/Json/SimpleJson.cs
@@ -264,7 +264,8 @@ namespace Nancy
         /// </returns>
         public bool Contains(KeyValuePair<string, object> item)
         {
-            return _members.ContainsKey(item.Key) && _members[item.Key] == item.Value;
+            object value;
+            return _members.TryGetValue(item.Key, out value) && value == item.Value;
         }
 
         /// <summary>

--- a/src/Nancy/ModelBinding/DefaultBinder.cs
+++ b/src/Nancy/ModelBinding/DefaultBinder.cs
@@ -475,14 +475,14 @@ namespace Nancy.ModelBinding
                                            .Distinct()
                                            .Select((k, i) => new KeyValuePair<int, int>(i, k))
                                            .ToDictionary(k => k.Key, v => v.Value);
-
-                if (indexindexes.ContainsKey(index))
+                int indexValue;
+                if (indexindexes.TryGetValue(index, out indexValue))
                 {
                     var propertyValue =
                         context.RequestData.Where(c =>
                         {
                             var indexId = IsMatch(c.Key);
-                            return c.Key.StartsWith(propertyName, StringComparison.OrdinalIgnoreCase) && indexId != -1 && indexId == indexindexes[index];
+                            return c.Key.StartsWith(propertyName, StringComparison.OrdinalIgnoreCase) && indexId != -1 && indexId == indexValue;
                         })
                         .Select(k => k.Value)
                         .FirstOrDefault();
@@ -492,7 +492,9 @@ namespace Nancy.ModelBinding
 
                 return string.Empty;
             }
-            return context.RequestData.ContainsKey(propertyName) ? context.RequestData[propertyName] : string.Empty;
+
+            string value;
+            return context.RequestData.TryGetValue(propertyName, out value) ? value : string.Empty;
         }
 
         private object DeserializeRequestBody(BindingContext context)

--- a/src/Nancy/Owin/NancyMiddleware.cs
+++ b/src/Nancy/Owin/NancyMiddleware.cs
@@ -143,8 +143,9 @@
                 if (nancyResponse.Cookies != null && nancyResponse.Cookies.Count != 0)
                 {
                     const string setCookieHeaderKey = "Set-Cookie";
-                    string[] setCookieHeader = owinResponseHeaders.ContainsKey(setCookieHeaderKey)
-                                                    ? owinResponseHeaders[setCookieHeaderKey]
+                    string[] cookieHeader;
+                    string[] setCookieHeader = owinResponseHeaders.TryGetValue(setCookieHeaderKey, out cookieHeader)
+                                                    ? cookieHeader
                                                     : ArrayCache.Empty<string>();
                     owinResponseHeaders[setCookieHeaderKey] = setCookieHeader
                         .Concat(nancyResponse.Cookies.Select(cookie => cookie.ToString()))

--- a/src/Nancy/RequestHeaders.cs
+++ b/src/Nancy/RequestHeaders.cs
@@ -6,7 +6,6 @@ namespace Nancy
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
-    using System.Reflection;
     using Nancy.Cookies;
     using Nancy.Responses.Negotiation;
 
@@ -274,8 +273,9 @@ namespace Nancy
         {
             get
             {
-                return (this.headers.ContainsKey(name)) ?
-                    this.headers[name] :
+                IEnumerable<string> value;
+                return this.headers.TryGetValue(name, out value) ?
+                    value :
                     Enumerable.Empty<string>();
             }
         }

--- a/src/Nancy/Response.cs
+++ b/src/Nancy/Response.cs
@@ -5,7 +5,6 @@ namespace Nancy
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
-    using System.Runtime.CompilerServices;
     using System.Threading.Tasks;
     using Nancy.Cookies;
     using Nancy.Helpers;
@@ -43,7 +42,11 @@ namespace Nancy
         /// <remarks>The default value is <c>text/html</c>.</remarks>
         public string ContentType
         {
-            get { return Headers.ContainsKey("content-type") ? Headers["content-type"] : this.contentType; }
+            get
+            {
+                string value;
+                return Headers.TryGetValue("content-type", out value) ? value : this.contentType;
+            }
             set { this.contentType = value; }
         }
 

--- a/src/Nancy/Responses/Negotiation/DefaultResponseNegotiator.cs
+++ b/src/Nancy/Responses/Negotiation/DefaultResponseNegotiator.cs
@@ -1,7 +1,6 @@
 ﻿namespace Nancy.Responses.Negotiation
 {
     using System;
-    using System.CodeDom.Compiler;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
@@ -390,9 +389,10 @@
         /// <param name="response">The response.</param>
         private static void AddContentTypeHeader(NegotiationContext negotiationContext, Response response)
         {
-            if (negotiationContext.Headers.ContainsKey("Content-Type"))
+            string contentType;
+            if (negotiationContext.Headers.TryGetValue("Content-Type", out contentType))
             {
-                response.ContentType = negotiationContext.Headers["Content-Type"];
+                response.ContentType = contentType;
                 negotiationContext.Headers.Remove("Content-Type");
             }
         }

--- a/src/Nancy/Responses/Negotiation/MediaRangeParameters.cs
+++ b/src/Nancy/Responses/Negotiation/MediaRangeParameters.cs
@@ -85,7 +85,8 @@
         {
             get
             {
-                return (this.parameters.ContainsKey(name)) ? this.parameters[name] : null;
+                string value;
+                return this.parameters.TryGetValue(name, out value) ? value : null;
             }
         }
 

--- a/src/Nancy/Routing/DefaultRouteCacheProvider.cs
+++ b/src/Nancy/Routing/DefaultRouteCacheProvider.cs
@@ -79,12 +79,14 @@
 
                 foreach (var entry in this.cacheProvider.GetCache().Values.SelectMany(t => t.Select(t1 => t1.Item2)))
                 {
-                    if (!result.ContainsKey(entry.Method))
+                    IList<object> value;
+                    if (!result.TryGetValue(entry.Method, out value))
                     {
-                        result[entry.Method] = new List<object>();
+                        value = new List<object>();
+                        result[entry.Method] = value;
                     }
 
-                    result[entry.Method].Add(new { Name = entry.Name, Path = entry.Path });
+                    value.Add(new { Name = entry.Name, Path = entry.Path });
                 }
 
                 return result;

--- a/src/Nancy/Routing/RouteCache.cs
+++ b/src/Nancy/Routing/RouteCache.cs
@@ -93,12 +93,14 @@
 
         private void AddRoutesToCache(IEnumerable<RouteDescription> routes, Type moduleType)
         {
-            if (!this.ContainsKey(moduleType))
+            List<Tuple<int, RouteDescription>> routeDescriptions;
+            if (!this.TryGetValue(moduleType, out routeDescriptions))
             {
-                this[moduleType] = new List<Tuple<int, RouteDescription>>();
+                routeDescriptions = new List<Tuple<int, RouteDescription>>();
+                this[moduleType] = routeDescriptions;
             }
 
-            this[moduleType].AddRange(routes.Select((r, i) => new Tuple<int, RouteDescription>(i, r)));
+            routeDescriptions.AddRange(routes.Select((r, i) => new Tuple<int, RouteDescription>(i, r)));
         }
     }
 }

--- a/src/Nancy/Routing/RouteMetadata.cs
+++ b/src/Nancy/Routing/RouteMetadata.cs
@@ -40,11 +40,10 @@ namespace Nancy.Routing
         /// <returns>The metadata instance if available, otherwise <see langword="null"/>.</returns>
         public TMetadata Retrieve<TMetadata>()
         {
-            var key =
-                typeof(TMetadata);
-
-            return (this.Raw.ContainsKey(key)) ?
-                (TMetadata)this.Raw[key] :
+            var key = typeof(TMetadata);
+            object value;
+            return this.Raw.TryGetValue(key, out value) ?
+                (TMetadata)value :
                 default(TMetadata);
         }
     }

--- a/src/Nancy/Security/Csrf.cs
+++ b/src/Nancy/Security/Csrf.cs
@@ -9,7 +9,6 @@
     using Nancy.Bootstrapper;
     using Nancy.Cookies;
     using Nancy.Cryptography;
-    using Nancy.Helpers;
 
     /// <summary>
     /// Csrf protection methods
@@ -40,19 +39,20 @@
                         return;
                     }
 
-                    if (context.Items.ContainsKey(CsrfToken.DEFAULT_CSRF_KEY))
+                    object value;
+                    if (context.Items.TryGetValue(CsrfToken.DEFAULT_CSRF_KEY, out value))
                     {
                         context.Response.Cookies.Add(new NancyCookie(
                             CsrfToken.DEFAULT_CSRF_KEY,
-                            (string)context.Items[CsrfToken.DEFAULT_CSRF_KEY],
+                            (string)value,
                             true, useSecureCookie));
 
                         return;
                     }
 
-                    if (context.Request.Cookies.ContainsKey(CsrfToken.DEFAULT_CSRF_KEY))
+                    string cookieValue;
+                    if (context.Request.Cookies.TryGetValue(CsrfToken.DEFAULT_CSRF_KEY, out cookieValue))
                     {
-                        var cookieValue = context.Request.Cookies[CsrfToken.DEFAULT_CSRF_KEY];
                         var cookieToken = ParseToCsrfToken(cookieValue);
 
                         if (CsrfApplicationStartup.TokenValidator.CookieTokenStillValid(cookieToken))

--- a/src/Nancy/Session/CookieBasedSessions.cs
+++ b/src/Nancy/Session/CookieBasedSessions.cs
@@ -166,10 +166,10 @@ namespace Nancy.Session
             var cookieName = this.currentConfiguration.CookieName;
             var hmacProvider = this.currentConfiguration.CryptographyConfiguration.HmacProvider;
             var encryptionProvider = this.currentConfiguration.CryptographyConfiguration.EncryptionProvider;
-
-            if (request.Cookies.ContainsKey(cookieName))
+            string cookieValue;
+            if (request.Cookies.TryGetValue(cookieName, out cookieValue))
             {
-                var cookieData = HttpUtility.UrlDecode(request.Cookies[cookieName]);
+                var cookieData = HttpUtility.UrlDecode(cookieValue);
                 var hmacLength = Base64Helpers.GetBase64Length(hmacProvider.HmacLength);
                 if (cookieData.Length < hmacLength)
                 {

--- a/src/Nancy/Session/Session.cs
+++ b/src/Nancy/Session/Session.cs
@@ -64,7 +64,11 @@ namespace Nancy.Session
         /// <returns>The value, or null or the key didn't exist</returns>
         public object this[string key]
         {
-            get { return dictionary.ContainsKey(key) ? dictionary[key] : null; }
+            get
+            {
+                object value;
+                return dictionary.TryGetValue(key, out value) ? value : null;
+            }
             set
             {
                 var existingValue = this[key] ?? new Object();

--- a/src/Nancy/TinyIoc/TinyIoC.cs
+++ b/src/Nancy/TinyIoc/TinyIoC.cs
@@ -3889,8 +3889,9 @@ namespace Nancy.TinyIoc
 
                 try
                 {
-                    args[parameterIndex] = parameters.ContainsKey(currentParam.Name) ?
-                                            parameters[currentParam.Name] :
+                    object value;
+                    args[parameterIndex] = parameters.TryGetValue(currentParam.Name, out value) ?
+                                            value :
                                             ResolveInternal(
                                                 new TypeRegistration(currentParam.ParameterType),
                                                 NamedParameterOverloads.Default,

--- a/src/Nancy/Validation/ModelValidationDescriptor.cs
+++ b/src/Nancy/Validation/ModelValidationDescriptor.cs
@@ -54,12 +54,14 @@
             {
                 foreach (var name in rule.MemberNames)
                 {
-                    if (!results.ContainsKey(name))
+                    IList<ModelValidationRule> list;
+                    if (!results.TryGetValue(name, out list))
                     {
-                        results.Add(name, new List<ModelValidationRule>());
+                        list = new List<ModelValidationRule>();
+                        results.Add(name, list);
                     }
 
-                    results[name].Add(rule);
+                    list.Add(rule);
                 }
             }
 

--- a/src/Nancy/Validation/ModelValidationResult.cs
+++ b/src/Nancy/Validation/ModelValidationResult.cs
@@ -77,24 +77,27 @@
 
             foreach (var result in results)
             {
+                IList<ModelValidationError> value;
                 foreach (var name in result.MemberNames)
                 {
-                    if (!output.ContainsKey(name))
+                    if (!output.TryGetValue(name, out value))
                     {
-                        output.Add(name, new List<ModelValidationError>());
+                        value = new List<ModelValidationError>();
+                        output.Add(name, value);
                     }
 
-                    output[name].Add(result);
+                    value.Add(result);
                 }
                 
                 if (!result.MemberNames.Any() && !string.IsNullOrEmpty(result.ErrorMessage))
                 {
-                    if (!output.ContainsKey(string.Empty))
+                    if (!output.TryGetValue(string.Empty, out value))
                     {
-                        output.Add(string.Empty, new List<ModelValidationError>());
+                        value = new List<ModelValidationError>();
+                        output.Add(string.Empty, value);
                     }
 
-                    output[string.Empty].Add(result);
+                    value.Add(result);
                 }
             }
 

--- a/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngine.cs
+++ b/src/Nancy/ViewEngines/SuperSimpleViewEngine/SuperSimpleViewEngine.cs
@@ -714,8 +714,8 @@ namespace Nancy.ViewEngines.SuperSimpleViewEngine
                 m =>
                 {
                     var sectionName = m.Groups["SectionName"].Value;
-
-                    return sections.ContainsKey(sectionName) ? sections[sectionName] : string.Empty;
+                    string sectionValue;
+                    return sections.TryGetValue(sectionName, out sectionValue) ? sectionValue : string.Empty;
                 });
 
             return result;


### PR DESCRIPTION
Use TryGetValue instead of ContainsKey and Getter for Dictionary to prevent double calculation of HashCode.