### PR TITLE
Fix memory leak when serving static content

### DIFF
--- a/src/Nancy/NancyEngine.cs
+++ b/src/Nancy/NancyEngine.cs
@@ -115,9 +115,16 @@
             var staticContentResponse = this.staticContentProvider.GetContent(context);
             if (staticContentResponse != null)
             {
-                context.Response = staticContentResponse;
-                tcs.SetResult(context);
-                return tcs.Task;
+                try
+                {
+                    context.Response = staticContentResponse;
+                    tcs.SetResult(context);
+                    return tcs.Task;
+                }
+                finally
+                {
+                    cts.Dispose();
+                }
             }
 
             var pipelines = this.RequestPipelinesFactory.Invoke(context);
@@ -147,7 +154,14 @@
                 },
                 errorTask =>
                 {
-		            tcs.SetException(errorTask.Exception);
+                    try
+                    {
+                        tcs.SetException(errorTask.Exception);
+                    }
+                    finally
+                    {
+                        cts.Dispose();
+                    }
                 },
                 true);
 


### PR DESCRIPTION
### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [ ] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Added calls to dispose the `CancellationTokenSource` when the engine returns static content and on errors. Potentially fixes the memory leaks described in #2605 without reverting the fix in #2150

<!-- Thanks for contributing to Nancy! -->
