### PR TITLE
Cast a null MediaRange reference to a null string

### DIFF
--- a/src/Nancy/Responses/Negotiation/MediaRange.cs
+++ b/src/Nancy/Responses/Negotiation/MediaRange.cs
@@ -122,6 +122,11 @@ namespace Nancy.Responses.Negotiation
         /// </returns>
         public static implicit operator string(MediaRange mediaRange)
         {
+            if (null == mediaRange)
+            {
+                return null;
+            }
+
             if (mediaRange.Parameters.Any())
             {
                 return string.Concat(mediaRange.Type, "/", mediaRange.Subtype, ";", mediaRange.Parameters);

--- a/test/Nancy.Tests/Unit/Responses/Negotiation/MediaRangeFixture.cs
+++ b/test/Nancy.Tests/Unit/Responses/Negotiation/MediaRangeFixture.cs
@@ -83,5 +83,18 @@
             // Then
             range.ToString().ShouldEqual("application/vnd.nancy;a=1;b=2");
         }
+
+        [Fact]
+        public void Should_cast_to_null_string()
+        {
+            // Given
+            MediaRange range = null;
+
+            // When
+            string cast = (string)range;
+
+            // Then
+            Assert.Null(cast);
+        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
When trying to compare a null `MediaRange` to a `string`, the implicit cast to `string` was throwing a `NullReferenceException`. Fix the operator so that a null `MediaRange` is cast to a null `string`.

Resolves #2769 
