### PR TITLE
 Ensure DefaultStatusCodeHandlerResult can be XML serialized

### DIFF
--- a/src/Nancy/ErrorHandling/DefaultStatusCodeHandler.cs
+++ b/src/Nancy/ErrorHandling/DefaultStatusCodeHandler.cs
@@ -158,7 +158,7 @@ namespace Nancy.ErrorHandling
             }
         }
 
-        internal class DefaultStatusCodeHandlerResult
+        public class DefaultStatusCodeHandlerResult
         {
             public HttpStatusCode StatusCode { get; set; }
 

--- a/src/Nancy/ErrorHandling/DefaultStatusCodeHandler.cs
+++ b/src/Nancy/ErrorHandling/DefaultStatusCodeHandler.cs
@@ -91,7 +91,13 @@ namespace Nancy.ErrorHandling
                 ? DisplayErrorTracesFalseMessage
                 : string.Concat("<pre>", context.GetExceptionDetails().Replace("<", "&gt;").Replace(">", "&lt;"), "</pre>");
 
-            var result = new DefaultStatusCodeHandlerResult(statusCode, this.errorMessages[statusCode], details);
+            var result = new DefaultStatusCodeHandlerResult
+            {
+                Details = details,
+                Message = this.errorMessages[statusCode],
+                StatusCode = statusCode
+            };
+            
             try
             {
                 context.Response = this.responseNegotiator.NegotiateResponse(result, context);
@@ -154,18 +160,11 @@ namespace Nancy.ErrorHandling
 
         internal class DefaultStatusCodeHandlerResult
         {
-            public DefaultStatusCodeHandlerResult(HttpStatusCode statusCode, string message, string details)
-            {
-                this.StatusCode = statusCode;
-                this.Message = message;
-                this.Details = details;
-            }
+            public HttpStatusCode StatusCode { get; set; }
 
-            public HttpStatusCode StatusCode { get; private set; }
+            public string Message { get; set; }
 
-            public string Message { get; private set; }
-
-            public string Details { get; private set; }
+            public string Details { get; set; }
         }
     }
 }

--- a/test/Nancy.Tests/Unit/ErrorHandling/DefaultStatusCodeHandlerFixture.cs
+++ b/test/Nancy.Tests/Unit/ErrorHandling/DefaultStatusCodeHandlerFixture.cs
@@ -212,5 +212,36 @@ namespace Nancy.Tests.Unit.ErrorHandling
             // Then
             Assert.Null(context.NegotiationContext.ViewName);
         }
+
+        [Fact]
+        public void Should_be_xml_serializable()
+        {
+            // Given
+            var environment = new DefaultNancyEnvironment();
+            environment.AddValue(Xml.XmlConfiguration.Default);
+            environment.Tracing(
+                enabled: true,
+                displayErrorTraces: true);
+            var serializer = new Nancy.Responses.DefaultXmlSerializer(environment);
+            var model = new DefaultStatusCodeHandler.DefaultStatusCodeHandlerResult()
+            {
+                StatusCode = HttpStatusCode.NotFound,
+                Message =  "not found",
+                Details = "not found details"
+            };
+
+            // When
+            var xml = new System.Xml.XmlDocument();
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize("application/xml", model, stream);
+
+                stream.Position = 0;
+                xml.Load(stream);
+            }
+
+            // Then
+            Assert.Equal("DefaultStatusCodeHandlerResult", xml.DocumentElement.Name);
+        }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description

Modify DefaultStatusCodeHandlerResult so that it can be handled by DefaultXmlSerializer.
Resolves #2817
