### PR TITLE
Upgrade to FakeItEasy 4.6.0

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -36,8 +36,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="4.3.0" />
-    <PackageReference Include="FakeItEasy.Analyzer.CSharp" Version="4.3.0" />
+    <PackageReference Include="FakeItEasy" Version="4.6.0" />
+    <PackageReference Include="FakeItEasy.Analyzer.CSharp" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="xunit" Version="2.4.0-beta.1.build3958" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0-beta.1.build3958" />

--- a/test/Nancy.Authentication.Basic.Tests/BasicAuthenticationFixture.cs
+++ b/test/Nancy.Authentication.Basic.Tests/BasicAuthenticationFixture.cs
@@ -39,9 +39,9 @@
 
             // Then
             A.CallTo(() => pipelines.BeforeRequest.AddItemToStartOfPipeline(A<Func<NancyContext, Response>>.Ignored))
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
             A.CallTo(() => pipelines.AfterRequest.AddItemToEndOfPipeline(A<Action<NancyContext>>.Ignored))
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
         }
 
         [Fact]

--- a/test/Nancy.Authentication.Forms.Tests/FormsAuthenticationFixture.cs
+++ b/test/Nancy.Authentication.Forms.Tests/FormsAuthenticationFixture.cs
@@ -117,9 +117,9 @@ namespace Nancy.Authentication.Forms.Tests
             FormsAuthentication.Enable(pipelines, this.config);
 
             A.CallTo(() => pipelines.BeforeRequest.AddItemToStartOfPipeline(A<Func<NancyContext, Response>>.Ignored))
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
             A.CallTo(() => pipelines.AfterRequest.AddItemToEndOfPipeline(A<Action<NancyContext>>.Ignored))
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -131,7 +131,7 @@ namespace Nancy.Authentication.Forms.Tests
             FormsAuthentication.Enable(pipelines, this.config);
 
             A.CallTo(() => pipelines.BeforeRequest.AddItemToStartOfPipeline(A<Func<NancyContext, Response>>.Ignored))
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
             A.CallTo(() => pipelines.AfterRequest.AddItemToEndOfPipeline(A<Action<NancyContext>>.Ignored))
                 .MustNotHaveHappened();
         }
@@ -272,7 +272,7 @@ namespace Nancy.Authentication.Forms.Tests
             FormsAuthentication.UserLoggedInRedirectResponse(context, userGuid, DateTime.Now.AddDays(1));
 
             A.CallTo(() => mockEncrypter.Encrypt(A<string>.Ignored))
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -288,7 +288,7 @@ namespace Nancy.Authentication.Forms.Tests
 
             // Then
             A.CallTo(() => mockEncrypter.Encrypt(A<string>.Ignored))
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -305,7 +305,7 @@ namespace Nancy.Authentication.Forms.Tests
             FormsAuthentication.UserLoggedInRedirectResponse(context, userGuid, DateTime.Now.AddDays(1));
 
             A.CallTo(() => mockHmac.GenerateHmac(fakeCryptoText))
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -325,7 +325,7 @@ namespace Nancy.Authentication.Forms.Tests
 
             // Then
             A.CallTo(() => mockHmac.GenerateHmac(fakeCryptoText))
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -394,7 +394,7 @@ namespace Nancy.Authentication.Forms.Tests
             fakePipelines.BeforeRequest.Invoke(this.context, new CancellationToken());
 
             A.CallTo(() => mockMapper.GetUserFromIdentifier(this.userGuid, this.context))
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
         }
 
         [Fact]

--- a/test/Nancy.Hosting.Aspnet.Tests/NancyHandlerFixture.cs
+++ b/test/Nancy.Hosting.Aspnet.Tests/NancyHandlerFixture.cs
@@ -107,7 +107,7 @@ namespace Nancy.Hosting.Aspnet.Tests
             await this.handler.ProcessRequest(this.context);
 
             // Then
-            A.CallTo(() => disposable.Dispose()).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => disposable.Dispose()).MustHaveHappenedOnceExactly();
         }
         [Fact]
         public async Task Should_create_request_body_when_content_length_specified()

--- a/test/Nancy.Tests/Unit/Bootstrapper/NancyBootstrapperBaseFixture.cs
+++ b/test/Nancy.Tests/Unit/Bootstrapper/NancyBootstrapperBaseFixture.cs
@@ -116,8 +116,8 @@
             this.bootstrapper.Initialise();
 
             // Then
-            A.CallTo(() => startupMock.Initialize(A<IPipelines>._)).MustHaveHappened(Repeated.Exactly.Once);
-            A.CallTo(() => startupMock2.Initialize(A<IPipelines>._)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => startupMock.Initialize(A<IPipelines>._)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => startupMock2.Initialize(A<IPipelines>._)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -214,7 +214,7 @@
 
             this.bootstrapper.Initialise();
 
-            A.CallTo(() => fakeDiagnostics.Initialize(A<IPipelines>._)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => fakeDiagnostics.Initialize(A<IPipelines>._)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -259,8 +259,8 @@
             uninitialiedBootstrapper.GetRequestPipelines(new NancyContext());
 
             // Then
-            A.CallTo(() => startupMock.Initialize(A<IPipelines>._, A<NancyContext>._)).MustHaveHappened(Repeated.Exactly.Once);
-            A.CallTo(() => startupMock2.Initialize(A<IPipelines>._, A<NancyContext>._)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => startupMock.Initialize(A<IPipelines>._, A<NancyContext>._)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => startupMock2.Initialize(A<IPipelines>._, A<NancyContext>._)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]

--- a/test/Nancy.Tests/Unit/Bootstrapper/NancyBootstrapperWithRequestContainerBaseFixture.cs
+++ b/test/Nancy.Tests/Unit/Bootstrapper/NancyBootstrapperWithRequestContainerBaseFixture.cs
@@ -134,8 +134,8 @@
             this.bootstrapper.GetRequestPipelines(new NancyContext());
 
             // Then
-            A.CallTo(() => startupMock.Initialize(A<IPipelines>._, A<NancyContext>._)).MustHaveHappened(Repeated.Exactly.Once);
-            A.CallTo(() => startupMock2.Initialize(A<IPipelines>._, A<NancyContext>._)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => startupMock.Initialize(A<IPipelines>._, A<NancyContext>._)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => startupMock2.Initialize(A<IPipelines>._, A<NancyContext>._)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]

--- a/test/Nancy.Tests/Unit/Configuration/DefaultNancyEnvironmentConfiguratorFixture.cs
+++ b/test/Nancy.Tests/Unit/Configuration/DefaultNancyEnvironmentConfiguratorFixture.cs
@@ -34,7 +34,7 @@
             this.configurator.ConfigureEnvironment(env => { });
 
             // Then
-            A.CallTo(() => this.factory.CreateEnvironment()).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => this.factory.CreateEnvironment()).MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -86,7 +86,7 @@
             // Then
             foreach (var provider in providers)
             {
-                A.CallTo(() => provider.GetDefaultConfiguration()).MustHaveHappened(Repeated.Exactly.Once);
+                A.CallTo(() => provider.GetDefaultConfiguration()).MustHaveHappenedOnceExactly();
             }
         }
 

--- a/test/Nancy.Tests/Unit/ModelBinding/DefaultBinderFixture.cs
+++ b/test/Nancy.Tests/Unit/ModelBinding/DefaultBinderFixture.cs
@@ -135,7 +135,7 @@ namespace Nancy.Tests.Unit.ModelBinding
 
             // Then
             A.CallTo(() => deserializer.Deserialize(null, null, null)).WithAnyArguments()
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -170,7 +170,7 @@ namespace Nancy.Tests.Unit.ModelBinding
 
             // Then
             A.CallTo(() => deserializer.CanDeserialize(A<MediaRange>.That.Matches(x => x.Matches("application/xml")), A<BindingContext>._))
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -187,7 +187,7 @@ namespace Nancy.Tests.Unit.ModelBinding
 
             // Then
             A.CallTo(() => deserializer.CanDeserialize(A<MediaRange>.That.Matches(x => x.Matches("application/xml")), A<BindingContext>.That.Not.IsNull()))
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -273,7 +273,7 @@ namespace Nancy.Tests.Unit.ModelBinding
 
             // Then
             A.CallTo(() => typeConverter.CanConvertTo(null, null)).WithAnyArguments()
-                .MustHaveHappened(Repeated.Exactly.Times(2));
+                .MustHaveHappenedTwiceExactly();
         }
 
         [Fact]
@@ -292,7 +292,7 @@ namespace Nancy.Tests.Unit.ModelBinding
 
             // Then
             A.CallTo(() => typeConverter.Convert(null, null, null)).WithAnyArguments()
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -414,7 +414,7 @@ namespace Nancy.Tests.Unit.ModelBinding
 
             // Then
             A.CallTo(() => deserializer.CanDeserialize(A<MediaRange>.That.Matches(x => x.Matches("application/xml")), A<BindingContext>.That.Not.IsNull()))
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -431,7 +431,7 @@ namespace Nancy.Tests.Unit.ModelBinding
 
             // Then
             A.CallTo(() => this.passthroughNameConverter.Convert(null)).WithAnyArguments()
-                .MustHaveHappened(Repeated.Exactly.Times(2));
+                .MustHaveHappenedTwiceExactly();
         }
 
         [Fact]
@@ -490,7 +490,7 @@ namespace Nancy.Tests.Unit.ModelBinding
 
             // Then
             A.CallTo(() => deserializer.Deserialize(null, null, null)).WithAnyArguments()
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -510,7 +510,7 @@ namespace Nancy.Tests.Unit.ModelBinding
 
             // Then
             A.CallTo(() => typeConverter.Convert(null, null, null)).WithAnyArguments()
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -533,7 +533,7 @@ namespace Nancy.Tests.Unit.ModelBinding
 
             // Then
             A.CallTo(() => userDeserializer.Deserialize(null, null, null)).WithAnyArguments()
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
             A.CallTo(() => defaultDeserializer.Deserialize(null, null, null)).WithAnyArguments()
                 .MustNotHaveHappened();
         }
@@ -558,7 +558,7 @@ namespace Nancy.Tests.Unit.ModelBinding
 
             // Then
             A.CallTo(() => userTypeConverter.Convert(null, null, null)).WithAnyArguments()
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
             A.CallTo(() => defaultTypeConverter.Convert(null, null, null)).WithAnyArguments()
                 .MustNotHaveHappened();
         }

--- a/test/Nancy.Tests/Unit/ModelBinding/DefaultConverters/CollectionConverterFixture.cs
+++ b/test/Nancy.Tests/Unit/ModelBinding/DefaultConverters/CollectionConverterFixture.cs
@@ -49,7 +49,7 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultConverters
             converter.Convert(input, typeof(string[]), mockContext);
 
             A.CallTo(() => this.mockStringTypeConverter.Convert(null, null, null)).WithAnyArguments()
-                .MustHaveHappened(Repeated.Exactly.Times(3));
+                .MustHaveHappened(3, Times.Exactly);
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultConverters
             converter.Convert(input, typeof(List<string>), mockContext);
 
             A.CallTo(() => this.mockStringTypeConverter.Convert(null, null, null)).WithAnyArguments()
-                .MustHaveHappened(Repeated.Exactly.Times(3));
+                .MustHaveHappened(3, Times.Exactly);
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace Nancy.Tests.Unit.ModelBinding.DefaultConverters
             converter.Convert(input, typeof(IEnumerable<string>), mockContext);
 
             A.CallTo(() => this.mockStringTypeConverter.Convert(null, null, null)).WithAnyArguments()
-                .MustHaveHappened(Repeated.Exactly.Times(3));
+                .MustHaveHappened(3, Times.Exactly);
         }
     }
 }

--- a/test/Nancy.Tests/Unit/ModelBinding/DynamicModelBinderAdapterFixture.cs
+++ b/test/Nancy.Tests/Unit/ModelBinding/DynamicModelBinderAdapterFixture.cs
@@ -56,7 +56,7 @@ namespace Nancy.Tests.Unit.ModelBinding
             Model result = adapter;
 
             // Then
-            A.CallTo(() => fakeLocator.GetBinderForType(typeof(Model), A<NancyContext>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => fakeLocator.GetBinderForType(typeof(Model), A<NancyContext>.Ignored)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace Nancy.Tests.Unit.ModelBinding
             Model result = adapter;
 
             // Then
-            A.CallTo(() => fakeLocator.GetBinderForType(A<Type>.Ignored, context)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => fakeLocator.GetBinderForType(A<Type>.Ignored, context)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -96,7 +96,7 @@ namespace Nancy.Tests.Unit.ModelBinding
             var result = (Model)adapter;
 
             // Then
-            A.CallTo(() => fakeLocator.GetBinderForType(typeof(Model), A<NancyContext>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => fakeLocator.GetBinderForType(typeof(Model), A<NancyContext>.Ignored)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]

--- a/test/Nancy.Tests/Unit/NancyContextFixture.cs
+++ b/test/Nancy.Tests/Unit/NancyContextFixture.cs
@@ -55,7 +55,7 @@ namespace Nancy.Tests.Unit
             this.context.Dispose();
 
             // Then
-            A.CallTo(() => disposable.Dispose()).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => disposable.Dispose()).MustHaveHappenedOnceExactly();
         }
 
         [Fact]

--- a/test/Nancy.Tests/Unit/NancyEngineFixture.cs
+++ b/test/Nancy.Tests/Unit/NancyEngineFixture.cs
@@ -129,7 +129,7 @@ namespace Nancy.Tests.Unit
             this.engine.HandleRequest(request);
 
             // Then
-            A.CallTo(() => this.contextFactory.Create(request)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => this.contextFactory.Create(request)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -309,7 +309,7 @@ namespace Nancy.Tests.Unit
             await this.engine.HandleRequest(request);
 
             // Then
-            A.CallTo(() => this.statusCodeHandler.HandlesStatusCode(A<HttpStatusCode>.Ignored, A<NancyContext>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => this.statusCodeHandler.HandlesStatusCode(A<HttpStatusCode>.Ignored, A<NancyContext>.Ignored)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -336,7 +336,7 @@ namespace Nancy.Tests.Unit
             await this.engine.HandleRequest(request);
 
             // Then
-            A.CallTo(() => this.statusCodeHandler.Handle(A<HttpStatusCode>.Ignored, A<NancyContext>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => this.statusCodeHandler.Handle(A<HttpStatusCode>.Ignored, A<NancyContext>.Ignored)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]

--- a/test/Nancy.Tests/Unit/NancyMiddlewareFixture.cs
+++ b/test/Nancy.Tests/Unit/NancyMiddlewareFixture.cs
@@ -71,7 +71,7 @@ namespace Nancy.Tests.Unit
                     A<Request>.Ignored,
                     A<Func<NancyContext, NancyContext>>.Ignored,
                     (CancellationToken)this.environment["owin.CallCancelled"]))
-             .MustHaveHappened(Repeated.Exactly.Once);
+             .MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -155,7 +155,7 @@ namespace Nancy.Tests.Unit
             this.host.Invoke(environment);
 
             // Then
-            A.CallTo(() => mockDisposable.Dispose()).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => mockDisposable.Dispose()).MustHaveHappenedOnceExactly();
         }
 
         [Fact]

--- a/test/Nancy.Tests/Unit/Routing/DefaultRequestDispatcherFixture.cs
+++ b/test/Nancy.Tests/Unit/Routing/DefaultRequestDispatcherFixture.cs
@@ -326,7 +326,7 @@ namespace Nancy.Tests.Unit.Routing
             await this.requestDispatcher.Dispatch(context, new CancellationToken());
 
             // Then
-            A.CallTo(() => this.routeResolver.Resolve(context)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => this.routeResolver.Resolve(context)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -637,7 +637,7 @@ namespace Nancy.Tests.Unit.Routing
             await this.requestDispatcher.Dispatch(context, new CancellationToken());
 
             // Then
-            A.CallTo(() => this.routeInvoker.Invoke(resolvedRoute.Route, A<CancellationToken>._, A<DynamicDictionary>._, A<NancyContext>._)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => this.routeInvoker.Invoke(resolvedRoute.Route, A<CancellationToken>._, A<DynamicDictionary>._, A<NancyContext>._)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -678,7 +678,7 @@ namespace Nancy.Tests.Unit.Routing
             await this.requestDispatcher.Dispatch(context, new CancellationToken());
 
             // Then
-            A.CallTo(() => this.routeResolver.Resolve(A<NancyContext>._)).MustHaveHappened(Repeated.Exactly.Twice);
+            A.CallTo(() => this.routeResolver.Resolve(A<NancyContext>._)).MustHaveHappenedTwiceExactly();
         }
 
         [Fact]
@@ -706,7 +706,7 @@ namespace Nancy.Tests.Unit.Routing
             await this.requestDispatcher.Dispatch(context, new CancellationToken());
 
             // Then
-            A.CallTo(() => this.routeInvoker.Invoke(A<Route>._, A<CancellationToken>._, parameters, A<NancyContext>._)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => this.routeInvoker.Invoke(A<Route>._, A<CancellationToken>._, parameters, A<NancyContext>._)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -732,7 +732,7 @@ namespace Nancy.Tests.Unit.Routing
             await this.requestDispatcher.Dispatch(context, new CancellationToken());
 
             // Then
-            A.CallTo(() => this.routeInvoker.Invoke(A<Route>._, A<CancellationToken>._, A<DynamicDictionary>._, context)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => this.routeInvoker.Invoke(A<Route>._, A<CancellationToken>._, A<DynamicDictionary>._, context)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]

--- a/test/Nancy.Tests/Unit/Security/ModuleSecurityFixture.cs
+++ b/test/Nancy.Tests/Unit/Security/ModuleSecurityFixture.cs
@@ -23,7 +23,7 @@ namespace Nancy.Tests.Unit.Security
 
             module.RequiresAuthentication();
 
-            A.CallTo(() => module.Before.AddItemToEndOfPipeline(A<Func<NancyContext, Response>>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => module.Before.AddItemToEndOfPipeline(A<Func<NancyContext, Response>>.Ignored)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -33,7 +33,7 @@ namespace Nancy.Tests.Unit.Security
 
             module.RequiresClaims(_ => true);
 
-            A.CallTo(() => module.Before.AddItemToEndOfPipeline(A<Func<NancyContext, Response>>.Ignored)).MustHaveHappened(Repeated.Exactly.Twice);
+            A.CallTo(() => module.Before.AddItemToEndOfPipeline(A<Func<NancyContext, Response>>.Ignored)).MustHaveHappenedTwiceExactly();
         }
 
         [Fact]

--- a/test/Nancy.Tests/Unit/Sessions/CookieBasedSessionsFixture.cs
+++ b/test/Nancy.Tests/Unit/Sessions/CookieBasedSessionsFixture.cs
@@ -239,7 +239,7 @@ namespace Nancy.Tests.Unit.Sessions
 
             store.Load(request);
 
-            A.CallTo(() => fakeFormatter.Deserialize("value1")).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => fakeFormatter.Deserialize("value1")).MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -253,7 +253,7 @@ namespace Nancy.Tests.Unit.Sessions
 
             store.Save(session, response);
 
-            A.CallTo(() => fakeFormatter.Serialize("value1")).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => fakeFormatter.Serialize("value1")).MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -272,7 +272,7 @@ namespace Nancy.Tests.Unit.Sessions
 
             beforePipeline.Invoke(nancyContext, new CancellationToken());
 
-            A.CallTo(() => fakeFormatter.Deserialize(A<string>.Ignored)).MustHaveHappened(Repeated.Exactly.Once);
+            A.CallTo(() => fakeFormatter.Deserialize(A<string>.Ignored)).MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -323,7 +323,7 @@ namespace Nancy.Tests.Unit.Sessions
             cookieStore.Save(session, response);
 
             A.CallTo(() => this.fakeEncryptionProvider.Encrypt(A<string>.Ignored))
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -339,7 +339,7 @@ namespace Nancy.Tests.Unit.Sessions
             cookieStore.Save(session, response);
 
             A.CallTo(() => this.fakeHmacProvider.GenerateHmac(A<string>.Ignored))
-                .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappenedOnceExactly();
         }
 
         [Fact]

--- a/test/Nancy.Tests/Unit/ViewEngines/DefaultViewFactoryFixture.cs
+++ b/test/Nancy.Tests/Unit/ViewEngines/DefaultViewFactoryFixture.cs
@@ -120,7 +120,7 @@ namespace Nancy.Tests.Unit.ViewEngines
             factory.RenderView("view.html", new object(), this.viewLocationContext);
 
             // Then
-            A.CallTo(() => this.renderContextFactory.GetRenderContext(A<ViewLocationContext>.Ignored)).MustHaveHappened(Repeated.NoMoreThan.Once);
+            A.CallTo(() => this.renderContextFactory.GetRenderContext(A<ViewLocationContext>.Ignored)).MustHaveHappenedOnceOrLess();
         }
 
         [Fact]


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
In [FakeItEasy 4.4.0](https://github.com/FakeItEasy/FakeItEasy/releases/tag/4.4.0), we introduced a new API for asserting the number of times a call was made. We intend to replace the old `Repeated` mechanism with it, obsoleting the old way in 5.0.0, and removing it in 6.0.0. Rather than have you be surprised by this, I thought I'd convert all your assertions now.
The Analyzer we released with [FakeItEasy 4.5.0](https://github.com/FakeItEasy/FakeItEasy/releases/tag/4.5.0) detects usages of the old system and warns against them. It also contains a code fix provider to fix 'em all at once, so this was practically no work.

<!-- Thanks for contributing to Nancy! -->
