### PR TITLE
Fix Link header non-ASCII characters issue

### DIFF
--- a/src/Nancy/Responses/Negotiation/DefaultResponseNegotiator.cs
+++ b/src/Nancy/Responses/Negotiation/DefaultResponseNegotiator.cs
@@ -9,6 +9,7 @@
 
     using Nancy.Conventions;
     using Nancy.Extensions;
+    using Nancy.Helpers;
 
     /// <summary>
     /// The default implementation for a response negotiator.
@@ -82,7 +83,7 @@
             if (routeResult is Response)
             {
                 response = (Response)routeResult;
-                return true; 
+                return true;
             }
 
             var methods = responseType.GetMethods(BindingFlags.Public | BindingFlags.Static);
@@ -364,7 +365,7 @@
         /// <returns>The link header.</returns>
         protected virtual string CreateLinkHeader(Url requestUrl, IEnumerable<KeyValuePair<string, MediaRange>> linkProcessors, string existingLinkHeader)
         {
-            var fileName = Path.GetFileNameWithoutExtension(requestUrl.Path);
+            var fileName = HttpUtility.UrlEncode(Path.GetFileNameWithoutExtension(requestUrl.Path));
             var baseUrl = string.Concat(requestUrl.BasePath, "/", fileName);
             var linkBuilder = new HttpLinkBuilder();
 

--- a/test/Nancy.Tests/Unit/Responses/Negotiation/DefaultResponseNegotiatorFixture.cs
+++ b/test/Nancy.Tests/Unit/Responses/Negotiation/DefaultResponseNegotiatorFixture.cs
@@ -1,0 +1,43 @@
+﻿namespace Nancy.Tests.Unit.Responses.Negotiation
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using Nancy.Responses.Negotiation;
+
+    using Xunit;
+
+    public class DefaultResponseNegotiatorFixture
+    {
+        [Fact]
+        public void Should_encode_URL_in_Link_response_header()
+        {
+            // Given
+            var negotiator = new DefaultResponseNegotiatorWrapper();
+            var requestUrl = new Uri("http://localhost:80/george-å");
+            var range = new MediaRange("application/vnd.nancy");
+            var linkProcessor = new KeyValuePair<string, MediaRange>("nancy", range);
+
+            // When
+            var linkHeader = negotiator.CreateLinkHeaderWrapper(requestUrl, new[] { linkProcessor }, null);
+
+            // Then
+            Assert.DoesNotContain("å", linkHeader, StringComparison.InvariantCultureIgnoreCase);
+            Assert.Contains("%C3%A5", linkHeader, StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        private class DefaultResponseNegotiatorWrapper : DefaultResponseNegotiator
+        {
+            public DefaultResponseNegotiatorWrapper()
+                : base(Enumerable.Empty<IResponseProcessor>(), null)
+            {
+            }
+
+            public string CreateLinkHeaderWrapper(Url requestUrl, IEnumerable<KeyValuePair<string, MediaRange>> linkProcessors, string existingLinkHeader)
+            {
+                return base.CreateLinkHeader(requestUrl, linkProcessors, existingLinkHeader);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix for the #2695.

Added UrlEncode specifically for Link header since when it comes to Owin middleware - it gets already composed header values but we need to encode only the path that was passed in the request.
<!-- Thanks for contributing to Nancy! -->
