### PR TITLE
Updated README.md with a grammatical fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Compile, run and enjoy the simple, elegant design!
 ## Features
 
 * Built from the bottom up, not simply a DSL on top of an existing framework. Removing limitations and feature hacks of an underlying framework, as well as the need to reference more assemblies than you need. _keep it light_
-* Run anywhere. Nancy is not built on any specific hosting technology can be run anywhere. Out of the box, Nancy supports running on ASP.NET/IIS, WCF, Self-hosting and any [OWIN](http://owin.org)
+* Run anywhere. Nancy is not built on any specific hosting technology, meaning it can be run anywhere. Out of the box, Nancy supports running on ASP.NET/IIS, WCF, Self-hosting and any [OWIN](http://owin.org)
 * Ultra lightweight action declarations for GET, HEAD, PUT, POST, DELETE, OPTIONS and PATCH requests
 * View engine integration (Razor, Spark, dotLiquid, our own SuperSimpleViewEngine and many more)
 * Powerful request path matching that includes advanced parameter capabilities. The path matching strategy can be replaced with custom implementations to fit your exact needs


### PR DESCRIPTION
"Nancy is not built on any specific hosting framework can be run anywhere" is a bit ambiguous and incomplete so I added "meaning that" in order to fix the grammar mistake.

### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [ ] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->

<!-- Thanks for contributing to Nancy! -->
