### PR TITLE
Added Module extension RequiresRoles(string[] roles) and ...

### DIFF
--- a/src/Nancy/Security/ClaimsPrincipalExtensions.cs
+++ b/src/Nancy/Security/ClaimsPrincipalExtensions.cs
@@ -56,5 +56,27 @@
                 && user.Claims != null
                 && isValid(user.Claims);
         }
+
+        /// <summary>
+        /// Tests if the user is in all of the required roles.
+        /// </summary>
+        /// <param name="user">User to be verified</param>
+        /// <param name="requiredRoles">Roles the user needs to be in</param>
+        /// <returns>True if the user is in all of the required roles, false otherwise</returns>
+        public static bool IsInRoles(this ClaimsPrincipal user, params string[] requiredRoles)
+        {
+            return user != null && requiredRoles.All(user.IsInRole);
+        }
+
+        /// <summary>
+        /// Tests if the user is in at least one of the required roles.
+        /// </summary>
+        /// <param name="user">User to be verified</param>
+        /// <param name="requiredRoles">Roles the user needs to be in at least one of</param>
+        /// <returns>True if the user is in at least one of the required roles, false otherwise</returns>
+        public static bool IsInAnyRole(this ClaimsPrincipal user, params string[] requiredRoles)
+        {
+            return user != null && requiredRoles.Any(user.IsInRole);
+        }
     }
 }

--- a/src/Nancy/Security/ClaimsPrincipalExtensions.cs
+++ b/src/Nancy/Security/ClaimsPrincipalExtensions.cs
@@ -65,7 +65,7 @@
         /// <returns>True if the user is in all of the required roles, false otherwise</returns>
         public static bool IsInRoles(this ClaimsPrincipal user, params string[] requiredRoles)
         {
-            return user != null && requiredRoles.All(user.IsInRole);
+            return user != null && requiredRoles != null && requiredRoles.All(user.IsInRole);
         }
 
         /// <summary>
@@ -76,7 +76,7 @@
         /// <returns>True if the user is in at least one of the required roles, false otherwise</returns>
         public static bool IsInAnyRole(this ClaimsPrincipal user, params string[] requiredRoles)
         {
-            return user != null && requiredRoles.Any(user.IsInRole);
+            return user != null && requiredRoles != null && requiredRoles.Any(user.IsInRole);
         }
     }
 }

--- a/src/Nancy/Security/ModuleSecurity.cs
+++ b/src/Nancy/Security/ModuleSecurity.cs
@@ -64,7 +64,7 @@ namespace Nancy.Security
             module.AddBeforeHookOrExecute(SecurityHooks.RequiresAuthentication(), "Requires Authentication");
             module.AddBeforeHookOrExecute(SecurityHooks.RequiresAnyRole(requiredRoles), "Requires Any Role");
         }
-
+        
         /// <summary>
         /// This module requires https.
         /// </summary>

--- a/src/Nancy/Security/ModuleSecurity.cs
+++ b/src/Nancy/Security/ModuleSecurity.cs
@@ -51,7 +51,7 @@ namespace Nancy.Security
         public static void RequiresRoles(this INancyModule module, params string[] requiredRoles)
         {
             module.AddBeforeHookOrExecute(SecurityHooks.RequiresAuthentication(), "Requires Authentication");
-            module.AddBeforeHookOrExecute(SecurityHooks.RequiresRoles(requiredClaims), "Requires Roles");
+            module.AddBeforeHookOrExecute(SecurityHooks.RequiresRoles(requiredRoles), "Requires Roles");
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Nancy.Security
         public static void RequiresAnyRole(this INancyModule module, params string[] requiredRoles)
         {
             module.AddBeforeHookOrExecute(SecurityHooks.RequiresAuthentication(), "Requires Authentication");
-            module.AddBeforeHookOrExecute(SecurityHooks.RequiresAnyRole(requiredClaims), "Requires Any Role");
+            module.AddBeforeHookOrExecute(SecurityHooks.RequiresAnyRole(requiredRoles), "Requires Any Role");
         }
         
         /// <summary>

--- a/src/Nancy/Security/ModuleSecurity.cs
+++ b/src/Nancy/Security/ModuleSecurity.cs
@@ -42,6 +42,28 @@ namespace Nancy.Security
             module.AddBeforeHookOrExecute(SecurityHooks.RequiresAuthentication(), "Requires Authentication");
             module.AddBeforeHookOrExecute(SecurityHooks.RequiresAnyClaim(requiredClaims), "Requires Any Claim");
         }
+
+        /// <summary>
+        /// This module requires authentication and certain roles to be present.
+        /// </summary>
+        /// <param name="module">Module to enable</param>
+        /// <param name="requiredRoles">Role(s) required</param>
+        public static void RequiresRoles(this INancyModule module, params string[] requiredRoles)
+        {
+            module.AddBeforeHookOrExecute(SecurityHooks.RequiresAuthentication(), "Requires Authentication");
+            module.AddBeforeHookOrExecute(SecurityHooks.RequiresRoles(requiredClaims), "Requires Roles");
+        }
+
+        /// <summary>
+        /// This module requires authentication and any one of certain roles to be present.
+        /// </summary>
+        /// <param name="module">Module to enable</param>
+        /// <param name="requiredRoles">Role(s) at least one of which is required</param>
+        public static void RequiresAnyRole(this INancyModule module, params string[] requiredRoles)
+        {
+            module.AddBeforeHookOrExecute(SecurityHooks.RequiresAuthentication(), "Requires Authentication");
+            module.AddBeforeHookOrExecute(SecurityHooks.RequiresAnyRole(requiredClaims), "Requires Any Role");
+        }
         
         /// <summary>
         /// This module requires https.

--- a/src/Nancy/Security/ModuleSecurity.cs
+++ b/src/Nancy/Security/ModuleSecurity.cs
@@ -64,7 +64,7 @@ namespace Nancy.Security
             module.AddBeforeHookOrExecute(SecurityHooks.RequiresAuthentication(), "Requires Authentication");
             module.AddBeforeHookOrExecute(SecurityHooks.RequiresAnyRole(requiredRoles), "Requires Any Role");
         }
-        
+
         /// <summary>
         /// This module requires https.
         /// </summary>

--- a/src/Nancy/Security/SecurityHooks.cs
+++ b/src/Nancy/Security/SecurityHooks.cs
@@ -3,7 +3,8 @@
     using System;
     using System.Collections.Generic;
     using System.Security.Claims;
-
+    using System.Linq;
+    
     using Nancy.Responses;
 
     /// <summary>
@@ -62,6 +63,36 @@
         {
             return ForbiddenIfNot(ctx => ctx.CurrentUser.HasValidClaims(isValid));
         }
+
+        /// <summary>
+        /// Creates a hook to be used in a pipeline before a route handler to ensure
+        /// that the request was made by an authenticated user being in all of
+        /// the required roles.
+        /// </summary>
+        /// <param name="roles">Roles the authenticated user needs to be in</param>
+        /// <returns>Hook that returns an Unauthorized response if the user is not
+        /// authenticated or is not in all of the required roles, null
+        /// otherwise</returns>
+        public static Func<NancyContext, Response> RequiresRoles(params string[] roles)
+        {
+            return ForbiddenIfNot(ctx => ctx.CurrentUser.IsInRoles(roles));
+        }
+
+        /// <summary>
+        /// Creates a hook to be used in a pipeline before a route handler to ensure
+        /// that the request was made by an authenticated user being in at least one of
+        /// the required roles.
+        /// </summary>
+        /// <param name="roles">Roles the authenticated user needs to be in at least one of</param>
+        /// <returns>Hook that returns an Unauthorized response if the user is not
+        /// authenticated or is not in at least one of the required roles, null
+        /// otherwise</returns>
+        public static Func<NancyContext, Response> RequiresAnyRole(params string[] roles)
+        {
+            return ForbiddenIfNot(ctx => ctx.CurrentUser.IsInAnyRole(roles));
+        }
+
+
 
         /// <summary>
         /// Creates a hook to be used in a pipeline before a route handler to ensure that

--- a/src/Nancy/Security/SecurityHooks.cs
+++ b/src/Nancy/Security/SecurityHooks.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Security.Claims;
-    
+
     using Nancy.Responses;
 
     /// <summary>

--- a/src/Nancy/Security/SecurityHooks.cs
+++ b/src/Nancy/Security/SecurityHooks.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.Security.Claims;
-    using System.Linq;
     
     using Nancy.Responses;
 

--- a/src/Nancy/Security/SecurityHooks.cs
+++ b/src/Nancy/Security/SecurityHooks.cs
@@ -91,8 +91,6 @@
             return ForbiddenIfNot(ctx => ctx.CurrentUser.IsInAnyRole(roles));
         }
 
-
-
         /// <summary>
         /// Creates a hook to be used in a pipeline before a route handler to ensure that
         /// the request satisfies a specific test.

--- a/src/Nancy/Security/SecurityHooks.cs
+++ b/src/Nancy/Security/SecurityHooks.cs
@@ -91,6 +91,8 @@
             return ForbiddenIfNot(ctx => ctx.CurrentUser.IsInAnyRole(roles));
         }
 
+
+
         /// <summary>
         /// Creates a hook to be used in a pipeline before a route handler to ensure that
         /// the request satisfies a specific test.

--- a/test/Nancy.Tests/Unit/Security/ClaimsPrincipalExtensionsFixture.cs
+++ b/test/Nancy.Tests/Unit/Security/ClaimsPrincipalExtensionsFixture.cs
@@ -281,20 +281,6 @@ namespace Nancy.Tests.Unit.Security
         }
 
         [Fact]
-        public void Should_return_false_for_valid_claim_if_the_user_is_null()
-        {
-            // Given
-            ClaimsPrincipal user = null;
-            Func<IEnumerable<Claim>, bool> isValid = claims => true;
-
-            // When
-            var result = user.HasValidClaims(isValid);
-
-            // Then
-            result.ShouldBeFalse();
-        }
-
-        [Fact]
         public void Should_return_false_for_required_role_if_the_roles_are_null()
         {
             // Given

--- a/test/Nancy.Tests/Unit/Security/ClaimsPrincipalExtensionsFixture.cs
+++ b/test/Nancy.Tests/Unit/Security/ClaimsPrincipalExtensionsFixture.cs
@@ -293,7 +293,7 @@ namespace Nancy.Tests.Unit.Security
             // Then
             result.ShouldBeFalse();
         }
-        
+
         [Fact]
         public void Should_return_false_for_required_role_if_the_user_does_not_have_role()
         {
@@ -349,7 +349,7 @@ namespace Nancy.Tests.Unit.Security
             // Then
             result.ShouldBeFalse();
         }
-        
+
         [Fact]
         public void Should_return_false_for_required_roles_if_the_user_does_not_have_all_roles()
         {
@@ -419,7 +419,7 @@ namespace Nancy.Tests.Unit.Security
             // Then
             result.ShouldBeFalse();
         }
-        
+
         [Fact]
         public void Should_return_false_for_any_required_role_if_the_user_does_not_have_any_role()
         {

--- a/test/Nancy.Tests/Unit/Security/ClaimsPrincipalExtensionsFixture.cs
+++ b/test/Nancy.Tests/Unit/Security/ClaimsPrincipalExtensionsFixture.cs
@@ -280,6 +280,194 @@ namespace Nancy.Tests.Unit.Security
             validatedClaims.ShouldEqualSequence(user.Claims);
         }
 
+        [Fact]
+        public void Should_return_false_for_valid_claim_if_the_user_is_null()
+        {
+            // Given
+            ClaimsPrincipal user = null;
+            Func<IEnumerable<Claim>, bool> isValid = claims => true;
+
+            // When
+            var result = user.HasValidClaims(isValid);
+
+            // Then
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_return_false_for_required_role_if_the_roles_are_null()
+        {
+            // Given
+            ClaimsPrincipal user = GetFakeUser("Fake");
+            var requiredRole = "not-present-role";
+
+            // When
+            var result = user.IsInRole(requiredRole);
+
+            // Then
+            result.ShouldBeFalse();
+        }
+        
+        [Fact]
+        public void Should_return_false_for_required_role_if_the_user_does_not_have_role()
+        {
+            // Given
+            ClaimsPrincipal user = GetFakeUser("Fake", new Claim(ClaimTypes.Role, string.Empty));
+            var requiredRole = "not-present-role";
+
+            // When
+            var result = user.IsInRole(requiredRole);
+
+            // Then
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_return_true_for_required_role_if_the_user_does_have_role()
+        {
+            // Given
+            ClaimsPrincipal user = GetFakeUser("Fake", new Claim(ClaimTypes.Role, "present-role"));
+            var requiredRole = "present-role";
+
+            // When
+            var result = user.IsInRole(requiredRole);
+
+            // Then
+            result.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Should_return_false_for_required_roles_if_the_user_is_null()
+        {
+            // Given
+            ClaimsPrincipal user = null;
+            var requiredRoles = new string[] { "not-present-role1", "not-present-role2" };
+
+            // When
+            var result = user.IsInRoles(requiredRoles);
+
+            // Then
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_return_false_for_required_roles_if_the_roles_are_null()
+        {
+            // Given
+            ClaimsPrincipal user = GetFakeUser("Fake");
+            var requiredRoles = null;
+
+            // When
+            var result = user.IsInRoles(requiredRoles);
+
+            // Then
+            result.ShouldBeFalse();
+        }
+        
+        [Fact]
+        public void Should_return_false_for_required_roles_if_the_user_does_not_have_all_roles()
+        {
+            // Given
+            ClaimsPrincipal user = GetFakeUser("Fake",
+                new Claim(ClaimTypes.Role, "present-role1"),
+                new Claim(ClaimTypes.Role, "present-role2"),
+                new Claim(ClaimTypes.Role, "present-role3"));
+            var requiredRoles = new string[]
+            {
+                "present-role1",
+                "not-present-role1"
+            };
+
+            // When
+            var result = user.IsInRoles(requiredRoles);
+
+            // Then
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_return_true_for_required_roles_if_the_user_does_have_all_roles()
+        {
+            // Given
+            ClaimsPrincipal user = GetFakeUser("Fake",
+                new Claim(ClaimTypes.Role, "present-role1"),
+                new Claim(ClaimTypes.Role, "present-role2"),
+                new Claim(ClaimTypes.Role, "present-role3"));
+            var requiredRoles = new string[]
+            {
+                "present-role1",
+                "present-role2"
+            };
+
+            // When
+            var result = user.IsInRoles(requiredRoles);
+
+            // Then
+            result.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Should_return_false_for_any_required_role_if_the_user_is_null()
+        {
+            // Given
+            ClaimsPrincipal user = null;
+            var requiredRoles = new string[] { "not-present-role1", "not-present-role2" };
+
+            // When
+            var result = user.IsInAnyRole(requiredRoles);
+
+            // Then
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_return_false_for_any_required_role_if_the_roles_are_null()
+        {
+            // Given
+            ClaimsPrincipal user = GetFakeUser("Fake");
+            var requiredRoles = null;
+
+            // When
+            var result = user.IsInAnyRole(requiredRoles);
+
+            // Then
+            result.ShouldBeFalse();
+        }
+        
+        [Fact]
+        public void Should_return_false_for_any_required_role_if_the_user_does_not_have_any_role()
+        {
+            // Given
+            ClaimsPrincipal user = GetFakeUser("Fake",
+                new Claim(ClaimTypes.Role, "present-role1"),
+                new Claim(ClaimTypes.Role, "present-role2"),
+                new Claim(ClaimTypes.Role, "present-role3"));
+            var requiredRoles = new string[] { "not-present-role1", "not-present-role2" };
+
+            // When
+            var result = user.IsInAnyRole(requiredRoles);
+
+            // Then
+            result.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void Should_return_true_for_any_required_role_if_the_user_does_have_any_of_role()
+        {
+            // Given
+            ClaimsPrincipal user = GetFakeUser("Fake",
+                new Claim(ClaimTypes.Role, "present-role1"),
+                new Claim(ClaimTypes.Role, "present-role2"),
+                new Claim(ClaimTypes.Role, "present-role3"));
+            var requiredRoles = new string[] { "present-role1", "not-present-role1" };
+
+            // When
+            var result = user.IsInAnyRole(requiredRoles);
+
+            // Then
+            result.ShouldBeTrue();
+        }
+
         private static ClaimsPrincipal GetFakeUser(string userName, params Claim[] claims)
         {
             var claimsList = (claims ?? Enumerable.Empty<Claim>()).ToList();

--- a/test/Nancy.Tests/Unit/Security/ClaimsPrincipalExtensionsFixture.cs
+++ b/test/Nancy.Tests/Unit/Security/ClaimsPrincipalExtensionsFixture.cs
@@ -341,7 +341,7 @@ namespace Nancy.Tests.Unit.Security
         {
             // Given
             ClaimsPrincipal user = GetFakeUser("Fake");
-            var requiredRoles = null;
+            string[] requiredRoles = null;
 
             // When
             var result = user.IsInRoles(requiredRoles);
@@ -411,7 +411,7 @@ namespace Nancy.Tests.Unit.Security
         {
             // Given
             ClaimsPrincipal user = GetFakeUser("Fake");
-            var requiredRoles = null;
+            string[] requiredRoles = null;
 
             // When
             var result = user.IsInAnyRole(requiredRoles);

--- a/test/Nancy.Tests/Unit/Security/ClaimsPrincipalExtensionsFixture.cs
+++ b/test/Nancy.Tests/Unit/Security/ClaimsPrincipalExtensionsFixture.cs
@@ -293,7 +293,7 @@ namespace Nancy.Tests.Unit.Security
             // Then
             result.ShouldBeFalse();
         }
-
+        
         [Fact]
         public void Should_return_false_for_required_role_if_the_user_does_not_have_role()
         {
@@ -349,7 +349,7 @@ namespace Nancy.Tests.Unit.Security
             // Then
             result.ShouldBeFalse();
         }
-
+        
         [Fact]
         public void Should_return_false_for_required_roles_if_the_user_does_not_have_all_roles()
         {
@@ -419,7 +419,7 @@ namespace Nancy.Tests.Unit.Security
             // Then
             result.ShouldBeFalse();
         }
-
+        
         [Fact]
         public void Should_return_false_for_any_required_role_if_the_user_does_not_have_any_role()
         {


### PR DESCRIPTION
... RequiresAnyRole(string[] roles)

This relates directly to #2981 and a bit also to #1190

### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
As the ClaimsPrincipal offers a function user.HasClaim, Nancy provides a hook to check if a claim is present (RequiresClaims, RequiresAnyClaim).
However, this did not exist for roles: While the ClaimsPrincipal offers user.IsInRole(), Nancy does not leverage that for modules.

This PR extends the Module hooks with the two documented functions RequiresAnyRole(string[] requiredRoles) and RequiresRoles(string[] requiredRoles).

This facilitates the check for roles when entering routes drastically. 

Tests are also included in this PR.