### PR TITLE
Add netstandard2.1 target to Nancy.Validation.DataAnnotations

### DIFF
--- a/src/Nancy.Validation.DataAnnotations/Nancy.Validation.DataAnnotations.csproj
+++ b/src/Nancy.Validation.DataAnnotations/Nancy.Validation.DataAnnotations.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <Description>Adds Data Annotation validation support to Nancy.</Description>
     <PackageTags>$(PackageTags);Validation;DataAnnotations</PackageTags>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFrameworks>net452;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description

Make `Nancy.Validation.DataAnnotations` package available for net core 3.1 applications by adding `netstandard2.1` target

**NOTE:** `AssociatedMetadataTypeTypeDescriptionProvider` is not available for `netstandard2.0`
