### PR TITLE
Add SameSite support for NancyCookies

### DIFF
--- a/src/Nancy/Cookies/INancyCookie.cs
+++ b/src/Nancy/Cookies/INancyCookie.cs
@@ -52,5 +52,10 @@ namespace Nancy.Cookies
         /// Whether the cookie is secure (i.e. HTTPS only)
         /// </summary>
         bool Secure { get; }
+
+        /// <summary>
+        /// Wheather the cookie is same site
+        /// </summary>
+        SameSite? SameSite { get; }
     }
 }

--- a/src/Nancy/Cookies/NancyCookie.cs
+++ b/src/Nancy/Cookies/NancyCookie.cs
@@ -30,7 +30,7 @@ namespace Nancy.Cookies
         /// <param name="value">The value of the cookie.</param>
         /// <param name="expires">The expiration date of the cookie. Can be <see langword="null" /> if it should expire at the end of the session.</param>
         public NancyCookie(string name, string value, DateTime expires)
-            : this(name, value, false, false, expires)
+            : this(name, value, false, false, expires, null)
         {
         }
 
@@ -42,7 +42,7 @@ namespace Nancy.Cookies
         /// <param name="value">The value of the cookie.</param>
         /// <param name="httpOnly">Whether the cookie is http only.</param>
         public NancyCookie(string name, string value, bool httpOnly)
-            : this(name, value, httpOnly, false, null)
+            : this(name, value, httpOnly, false, null, null)
         {
         }
 
@@ -55,7 +55,7 @@ namespace Nancy.Cookies
         /// <param name="httpOnly">Whether the cookie is http only.</param>
         /// <param name="secure">Whether the cookie is secure (i.e. HTTPS only).</param>
         public NancyCookie(string name, string value, bool httpOnly, bool secure)
-            : this(name, value, httpOnly, secure, null)
+            : this(name, value, httpOnly, secure, null, null)
         {
         }
 
@@ -68,13 +68,15 @@ namespace Nancy.Cookies
         /// <param name="httpOnly">Whether the cookie is http only.</param>
         /// <param name="secure">Whether the cookie is secure (i.e. HTTPS only).</param>
         /// <param name="expires">The expiration date of the cookie. Can be <see langword="null" /> if it should expire at the end of the session.</param>
-        public NancyCookie(string name, string value, bool httpOnly, bool secure, DateTime? expires)
+        /// <param name="sameSite">The same site attribute of the cookie. Can be <see langword="null" />.</param>
+        public NancyCookie(string name, string value, bool httpOnly, bool secure, DateTime? expires, SameSite? sameSite = null)
         {
             this.Name = name;
             this.Value = value;
             this.HttpOnly = httpOnly;
             this.Secure = secure;
             this.Expires = expires;
+            this.SameSite = sameSite;
         }
 
         /// <summary>
@@ -136,6 +138,11 @@ namespace Nancy.Cookies
         public bool Secure { get; private set; }
 
         /// <summary>
+        /// Wheather the cookie is same site
+        /// </summary>
+        public SameSite? SameSite { get; set; }
+
+        /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.
         /// </summary>
         /// <returns>
@@ -167,6 +174,11 @@ namespace Nancy.Cookies
             if (HttpOnly)
             {
                 sb.Append("; HttpOnly");
+            }
+
+            if(SameSite.HasValue)
+            {
+                sb.Append("; samesite=").Append(SameSite.ToString());
             }
 
             return sb.ToString();

--- a/src/Nancy/Cookies/SameSite.cs
+++ b/src/Nancy/Cookies/SameSite.cs
@@ -1,0 +1,29 @@
+﻿namespace Nancy.Cookies
+{
+    /// <summary>
+    /// Represents the SameSite for NancyCookie
+    /// </summary>
+    public enum SameSite
+    {
+        /// <summary>
+        /// If the value is invalid, the cookie will only be sent along with
+        /// "same-site" requests.  If the value is "Lax", the cookie will be
+        /// sent with "same-site" requests, and with "cross-site" top-level navigations
+        /// </summary>
+        Lax = 0,
+
+        /// <summary>
+        /// If you set SameSite to Strict, your cookie will only be sent in a
+        /// first-party context. In user terms, the cookie will only be sent
+        /// if the site for the cookie matches the site currently shown in
+        /// the browser's URL bar.
+        /// </summary>
+        Strict,
+
+        /// <summary>
+        /// Cookies with SameSite=None must also specify Secure,
+        /// meaning they require a secure context.
+        /// </summary>
+        None
+    }
+}

--- a/test/Nancy.Tests/Unit/NancyCookieFixture.cs
+++ b/test/Nancy.Tests/Unit/NancyCookieFixture.cs
@@ -162,6 +162,16 @@ namespace Nancy.Tests.Unit
             result.ShouldEqual("Value+with+spaces");
         }
 
+        [Fact]
+        public void Should_add_same_site_if_set()
+        {
+            // When
+            var cookie = new NancyCookie("leto", "worm") { SameSite = SameSite.Lax }.ToString();
+
+            // Then
+            cookie.ShouldEqual("leto=worm; path=/; samesite=Lax");
+        }
+
         public static string GetInvariantAbbreviatedMonthName(DateTime dateTime)
         {
             return CultureInfo.InvariantCulture.DateTimeFormat.AbbreviatedMonthNames[dateTime.Month - 1];


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/NancyFx/Nancy/pulls) open
- [x] I have verified that I am following the Nancy [code style guidelines](https://github.com/NancyFx/Nancy/blob/45238076ad0b7f6ecabd6bae8469e30458d02efe/CONTRIBUTING.md#style-guidelines)
- [x] I have provided test coverage for my change (where applicable)

### Description
Nancy Cookies doesn't support SameSite property. This PR adds SameSite property to cookies. The possible values for SameSite property are defined by an enum **SameSite.cs**:  `Lax`, `Strict` and `None`.

This change won't break anything, all cookies work as they suppose to work. All the tests are passed and two new tests added to cover the new functionality.

Fix #3002

<!-- Thanks for contributing to Nancy! -->
